### PR TITLE
Add val & test set info from challenge

### DIFF
--- a/reference_data/README.md
+++ b/reference_data/README.md
@@ -1,7 +1,9 @@
-This folder should have the following data
- - `valid_A`: Validation set for Species A hybrid detection.
- - `test_A`: Test set for Species A hybrid detection.
- - `valid_mimic`: Validation set for Mimic hybrid detection.
- - `test_mimic`: Test set for Mimic hybrid detection.
+This folder contains the following data which was kept secret for the duration of the challenge
+ - `ref_val.csv`: Validation set used during the Development Phase. It includes both Species A & B, as well as subspecies hybrids of both, beyond just the Signal Hybrids.
+ - `ref_test.csv`: Test set used for final evaluation of submissions. It includes both Species A & B, as well as subspecies hybrids of both, beyond just the Signal Hybrids.
 
-I think this would just be the labels if we're looking at assessing their predictions. May be labels regardless: in the [Iris example](https://github.com/codalab/competition-examples/tree/master/codabench/iris/bundle/reference_data), this is the set of labels in folders "valid" and "test", while the [`input_data` folder](https://github.com/codalab/competition-examples/tree/master/codabench/iris/bundle/input_data) has the unlabeled data for each of validation and testing, as well as training data and training data labels.
+> [!NOTE]  
+> - Both of these CSVs contain a `split` column with both `test` and `test-2`; this was an artifact of our original pre-competition setup that distinguished multiple tests within each phase (one for Species A hybrid detection and one for Species B hybrid detection). 
+> - Actual subspecies epithets are provided in `subspecies_ref`, those with `ssp_indicator` mimic are _Heliconius melpomene_ and the rest are _Heliconius erato_.
+> - `X` is a unique identifier for all the images used in this challenge, as is `CAMID`.
+> - Images may be downloaded following the [training data download instructions](../pages/data.md#instructions-to-download-training-data).

--- a/reference_data/README.md
+++ b/reference_data/README.md
@@ -2,8 +2,7 @@ This folder contains the following data which was kept secret for the duration o
  - `ref_val.csv`: Validation set used during the Development Phase. It includes both Species A & B, as well as subspecies hybrids of both, beyond just the Signal Hybrids.
  - `ref_test.csv`: Test set used for final evaluation of submissions. It includes both Species A & B, as well as subspecies hybrids of both, beyond just the Signal Hybrids.
 
-> [!NOTE]  
-> - Both of these CSVs contain a `split` column with both `test` and `test-2`; this was an artifact of our original pre-competition setup that distinguished multiple tests within each phase (one for Species A hybrid detection and one for Species B hybrid detection). 
+> [!NOTE]
 > - Actual subspecies epithets are provided in `subspecies_ref`, those with `ssp_indicator` mimic are _Heliconius melpomene_ and the rest are _Heliconius erato_.
 > - `X` is a unique identifier for all the images used in this challenge, as is `CAMID`.
 > - Images may be downloaded following the [training data download instructions](../pages/data.md#instructions-to-download-training-data).

--- a/reference_data/ref_test.csv
+++ b/reference_data/ref_test.csv
@@ -1,2351 +1,2351 @@
-CAMID,file_url,hybrid_stat,split,X,subspecies_ref,filename,ssp_indicator
-F809,https://zenodo.org/record/2555086/files/F809_d.JPG,0,test,38048,demophoon,38048_F809_d.JPG,minor
-F866,https://zenodo.org/record/2555086/files/F866_d.JPG,0,test,38112,demophoon,38112_F866_d.JPG,minor
-F824,https://zenodo.org/record/2555086/files/F824_d.JPG,0,test,38052,demophoon,38052_F824_d.JPG,minor
-F844,https://zenodo.org/record/2555086/files/F844_d.JPG,0,test,38064,demophoon,38064_F844_d.JPG,minor
-F846,https://zenodo.org/record/2555086/files/F846_d.JPG,0,test,38068,demophoon,38068_F846_d.JPG,minor
-F848,https://zenodo.org/record/2555086/files/F848_d.JPG,0,test,38072,demophoon,38072_F848_d.JPG,minor
-F849,https://zenodo.org/record/2555086/files/F849_d.JPG,0,test,38076,demophoon,38076_F849_d.JPG,minor
-F837,https://zenodo.org/record/2555086/files/F837_d.JPG,0,test,38060,demophoon,38060_F837_d.JPG,minor
-F852,https://zenodo.org/record/2555086/files/F852_d.JPG,0,test,38084,demophoon,38084_F852_d.JPG,minor
-F853,https://zenodo.org/record/2555086/files/F853_d.JPG,0,test,38088,demophoon,38088_F853_d.JPG,minor
-F854,https://zenodo.org/record/2555086/files/F854_d.JPG,0,test,38092,demophoon,38092_F854_d.JPG,minor
-F858,https://zenodo.org/record/2555086/files/F858_d.JPG,0,test,38096,demophoon,38096_F858_d.JPG,minor
-F864,https://zenodo.org/record/2555086/files/F864_d.JPG,0,test,38104,demophoon,38104_F864_d.JPG,minor
-F862,https://zenodo.org/record/2555086/files/F862_d.JPG,0,test,38100,demophoon,38100_F862_d.JPG,minor
-F851,https://zenodo.org/record/2555086/files/F851_d.JPG,0,test,38080,demophoon,38080_F851_d.JPG,minor
-F8621,https://zenodo.org/record/2555086/files/F8621_d.JPG,0,test,38392,demophoon,38392_F8621_d.JPG,minor
-CAM000255,https://zenodo.org/record/2677821/files/CAM000255_d.JPG,0,test,6336,demophoon,6336_CAM000255_d.JPG,minor
-CAM000242,https://zenodo.org/record/2677821/files/CAM000242_d.JPG,0,test,6310,chestertonii,6310_CAM000242_d.JPG,minor
-CAM000241,https://zenodo.org/record/2677821/files/CAM000241_d.JPG,0,test,6308,chestertonii,6308_CAM000241_d.JPG,minor
-CAM000240,https://zenodo.org/record/2677821/files/CAM000240_d.JPG,0,test,6306,chestertonii,6306_CAM000240_d.JPG,minor
-CAM000239,https://zenodo.org/record/2677821/files/CAM000239_d.JPG,0,test,6304,chestertonii,6304_CAM000239_d.JPG,minor
-CAM000238,https://zenodo.org/record/2677821/files/CAM000238_d.JPG,0,test,6302,chestertonii,6302_CAM000238_d.JPG,minor
-CAM000237,https://zenodo.org/record/2677821/files/CAM000237_d.JPG,0,test,6300,chestertonii,6300_CAM000237_d.JPG,minor
-CAM000236,https://zenodo.org/record/2677821/files/CAM000236_d.JPG,0,test,6298,chestertonii,6298_CAM000236_d.JPG,minor
-CAM000235,https://zenodo.org/record/2677821/files/CAM000235_d.JPG,0,test,6296,chestertonii,6296_CAM000235_d.JPG,minor
-CAM000234,https://zenodo.org/record/2677821/files/CAM000234_d.JPG,0,test,6294,chestertonii,6294_CAM000234_d.JPG,minor
-CAM009553,https://zenodo.org/record/2686762/files/CAM009553_d.JPG,1,test,10848,hydara x petiverana,10848_CAM009553_d.JPG,minor
-CAM009568,https://zenodo.org/record/2686762/files/CAM009568_d.JPG,1,test,10878,hydara x petiverana,10878_CAM009568_d.JPG,minor
-CAM009574,https://zenodo.org/record/2686762/files/CAM009574_d.JPG,1,test,10890,hydara x petiverana,10890_CAM009574_d.JPG,minor
-CAM009510,https://zenodo.org/record/2686762/files/CAM009510_d.JPG,1,test,10762,hydara x petiverana,10762_CAM009510_d.JPG,minor
-CAM009513,https://zenodo.org/record/2686762/files/CAM009513_d.JPG,1,test,10768,hydara x petiverana,10768_CAM009513_d.JPG,minor
-CAM009518,https://zenodo.org/record/2686762/files/CAM009518_d.JPG,1,test,10778,hydara x petiverana,10778_CAM009518_d.JPG,minor
-CAM009520,https://zenodo.org/record/2686762/files/CAM009520_d.JPG,1,test,10782,hydara x petiverana,10782_CAM009520_d.JPG,minor
-CAM009523,https://zenodo.org/record/2686762/files/CAM009523_d.JPG,1,test,10788,hydara x petiverana,10788_CAM009523_d.JPG,minor
-CAM009526,https://zenodo.org/record/2686762/files/CAM009526_d.JPG,1,test,10794,hydara x petiverana,10794_CAM009526_d.JPG,minor
-CAM009534,https://zenodo.org/record/2686762/files/CAM009534_d.JPG,0,test,10810,petiverana,10810_CAM009534_d.JPG,minor
-CAM009503,https://zenodo.org/record/2686762/files/CAM009503_d.JPG,0,test,10748,petiverana,10748_CAM009503_d.JPG,minor
-CAM009304,https://zenodo.org/record/2686762/files/CAM009304_d.JPG,0,test,10460,hydara,10460_CAM009304_d.JPG,minor
-CAM009305,https://zenodo.org/record/2686762/files/CAM009305_d.JPG,0,test,10462,hydara,10462_CAM009305_d.JPG,minor
-CAM009306,https://zenodo.org/record/2686762/files/CAM009306_d.JPG,0,test,10464,hydara,10464_CAM009306_d.JPG,minor
-CAM009307,https://zenodo.org/record/2686762/files/CAM009307_d.JPG,0,test,10466,hydara,10466_CAM009307_d.JPG,minor
-CAM009328,https://zenodo.org/record/2686762/files/CAM009328_d.JPG,0,test,10508,hydara,10508_CAM009328_d.JPG,minor
-CAM009327,https://zenodo.org/record/2686762/files/CAM009327_d.JPG,0,test,10506,hydara,10506_CAM009327_d.JPG,minor
-CAM009326,https://zenodo.org/record/2686762/files/CAM009326_d.JPG,0,test,10504,hydara,10504_CAM009326_d.JPG,minor
-CAM009322,https://zenodo.org/record/2686762/files/CAM009322_d.JPG,0,test,10496,hydara,10496_CAM009322_d.JPG,minor
-CAM009321,https://zenodo.org/record/2686762/files/CAM009321_d.JPG,0,test,10494,hydara,10494_CAM009321_d.JPG,minor
-CAM009320,https://zenodo.org/record/2686762/files/CAM009320_d.JPG,0,test,10492,hydara,10492_CAM009320_d.JPG,minor
-CAM009313,https://zenodo.org/record/2686762/files/CAM009313_d.JPG,0,test,10478,hydara,10478_CAM009313_d.JPG,minor
-CAM009312,https://zenodo.org/record/2686762/files/CAM009312_d.JPG,0,test,10476,hydara,10476_CAM009312_d.JPG,minor
-CAM009311,https://zenodo.org/record/2686762/files/CAM009311_d.JPG,0,test,10474,hydara,10474_CAM009311_d.JPG,minor
-CAM009310,https://zenodo.org/record/2686762/files/CAM009310_d.JPG,0,test,10472,hydara,10472_CAM009310_d.JPG,minor
-CAM009309,https://zenodo.org/record/2686762/files/CAM009309_d.JPG,0,test,10470,hydara,10470_CAM009309_d.JPG,minor
-CAM009308,https://zenodo.org/record/2686762/files/CAM009308_d.JPG,0,test,10468,hydara,10468_CAM009308_d.JPG,minor
-CAM009014,https://zenodo.org/record/2686762/files/CAM009014_d.JPG,0,test,10133,hydara,10133_CAM009014_d.JPG,minor
-CAM009018,https://zenodo.org/record/2686762/files/CAM009018_d.JPG,0,test,10141,hydara,10141_CAM009018_d.JPG,minor
-CAM009017,https://zenodo.org/record/2686762/files/CAM009017_d.JPG,0,test,10139,hydara,10139_CAM009017_d.JPG,minor
-CAM021240,https://zenodo.org/record/2702457/files/CAM021240_d.JPG,0,test,11690,hydara,11690_CAM021240_d.JPG,minor
-CAM021239,https://zenodo.org/record/2702457/files/CAM021239_d.JPG,0,test,11688,hydara,11688_CAM021239_d.JPG,minor
-CAM021053,https://zenodo.org/record/2702457/files/CAM021053_d.JPG,0,test,11538,erato,11538_CAM021053_d.JPG,minor
-CAM021033,https://zenodo.org/record/2702457/files/CAM021033_d.JPG,1,test,11500,hydara x amalfreda,11500_CAM021033_d.JPG,minor
-CAM021034,https://zenodo.org/record/2702457/files/CAM021034_d.JPG,1,test,11502,hydara x amalfreda,11502_CAM021034_d.JPG,minor
-CAM021035,https://zenodo.org/record/2702457/files/CAM021035_d.JPG,1,test,11504,hydara x amalfreda,11504_CAM021035_d.JPG,minor
-CAM021038,https://zenodo.org/record/2702457/files/CAM021038_d.JPG,0,test,11508,amalfreda,11508_CAM021038_d.JPG,minor
-CAM021039,https://zenodo.org/record/2702457/files/CAM021039_d.JPG,0,test,11510,amalfreda,11510_CAM021039_d.JPG,minor
-CAM021040,https://zenodo.org/record/2702457/files/CAM021040_d.JPG,0,test,11512,amalfreda,11512_CAM021040_d.JPG,minor
-CAM021041,https://zenodo.org/record/2702457/files/CAM021041_d.JPG,0,test,11514,amalfreda,11514_CAM021041_d.JPG,minor
-CAM021042,https://zenodo.org/record/2702457/files/CAM021042_d.JPG,0,test,11516,amalfreda,11516_CAM021042_d.JPG,minor
-CAM021032,https://zenodo.org/record/2702457/files/CAM021032_d.JPG,1,test,11498,hydara x amalfreda,11498_CAM021032_d.JPG,minor
-CAM021067,https://zenodo.org/record/2702457/files/CAM021067_d.JPG,0,test,11563,erato,11563_CAM021067_d.JPG,minor
-CAM021063,https://zenodo.org/record/2702457/files/CAM021063_d.JPG,0,test,11555,erato,11555_CAM021063_d.JPG,minor
-CAM040078,https://zenodo.org/record/2707828/files/CAM040078_d.JPG,0,test,11820,dignus,11820_CAM040078_d.JPG,minor
-CAM040077,https://zenodo.org/record/2707828/files/CAM040077_d.JPG,0,test,11818,dignus,11818_CAM040077_d.JPG,minor
-CAM040066,https://zenodo.org/record/2707828/files/CAM040066_d.JPG,0,test,11812,dignus,11812_CAM040066_d.JPG,minor
-CAM040039,https://zenodo.org/record/2707828/files/CAM040039_d.JPG,0,test,11758,dignus,11758_CAM040039_d.JPG,minor
-CS004059,https://zenodo.org/record/2813153/files/CS004059_d.JPG,0,test,14384,reductimacula,14384_CS004059_d.JPG,minor
-CAM016323,https://zenodo.org/record/3082688/files/CAM016323_d.JPG,0,test-2,3420,plesseni,3420_CAM016323_d.JPG,mimic
-CAM016324,https://zenodo.org/record/3082688/files/CAM016324_d.JPG,0,test-2,3422,plesseni,3422_CAM016324_d.JPG,mimic
-CAM016341,https://zenodo.org/record/3082688/files/CAM016341_d.JPG,1,test-2,3430,plesseni x malleti,3430_CAM016341_d.JPG,mimic
-CAM016092,https://zenodo.org/record/3082688/files/CAM016092_d.JPG,1,test-2,3092,plesseni x malleti,3092_CAM016092_d.JPG,mimic
-CAM016141,https://zenodo.org/record/3082688/files/CAM016141_d.JPG,1,test-2,3190,plesseni x malleti,3190_CAM016141_d.JPG,mimic
-CAM016142,https://zenodo.org/record/3082688/files/CAM016142_d.JPG,1,test-2,3192,plesseni x malleti,3192_CAM016142_d.JPG,mimic
-CAM016143,https://zenodo.org/record/3082688/files/CAM016143_d.JPG,1,test-2,3194,plesseni x malleti,3194_CAM016143_d.JPG,mimic
-CAM016235,https://zenodo.org/record/3082688/files/CAM016235_d.JPG,1,test-2,3346,plesseni x malleti,3346_CAM016235_d.JPG,mimic
-CAM016230,https://zenodo.org/record/3082688/files/CAM016230_d.JPG,1,test-2,3342,plesseni x malleti,3342_CAM016230_d.JPG,mimic
-CAM016228,https://zenodo.org/record/3082688/files/CAM016228_d.JPG,1,test-2,3340,plesseni x malleti,3340_CAM016228_d.JPG,mimic
-CAM016227,https://zenodo.org/record/3082688/files/CAM016227_d.JPG,1,test-2,3338,plesseni x malleti,3338_CAM016227_d.JPG,mimic
-CAM016225,https://zenodo.org/record/3082688/files/CAM016225_d.JPG,1,test-2,3336,plesseni x malleti,3336_CAM016225_d.JPG,mimic
-CAM016196,https://zenodo.org/record/3082688/files/CAM016196_d.JPG,1,test-2,3300,plesseni x malleti,3300_CAM016196_d.JPG,mimic
-CAM016195,https://zenodo.org/record/3082688/files/CAM016195_d.JPG,1,test-2,3298,plesseni x malleti,3298_CAM016195_d.JPG,mimic
-CAM016191,https://zenodo.org/record/3082688/files/CAM016191_d.JPG,1,test-2,3290,plesseni x malleti,3290_CAM016191_d.JPG,mimic
-CAM016237,https://zenodo.org/record/3082688/files/CAM016237_d.JPG,1,test-2,3348,plesseni x malleti,3348_CAM016237_d.JPG,mimic
-CAM016239,https://zenodo.org/record/3082688/files/CAM016239_d.JPG,1,test-2,3350,plesseni x malleti,3350_CAM016239_d.JPG,mimic
-CAM016242,https://zenodo.org/record/3082688/files/CAM016242_d.JPG,1,test-2,3352,plesseni x malleti,3352_CAM016242_d.JPG,mimic
-CAM016244,https://zenodo.org/record/3082688/files/CAM016244_d.JPG,1,test-2,3354,plesseni x malleti,3354_CAM016244_d.JPG,mimic
-CAM016285,https://zenodo.org/record/3082688/files/CAM016285_d.JPG,0,test-2,3398,plesseni,3398_CAM016285_d.JPG,mimic
-CAM016287,https://zenodo.org/record/3082688/files/CAM016287_d.JPG,0,test-2,3400,plesseni,3400_CAM016287_d.JPG,mimic
-CAM016290,https://zenodo.org/record/3082688/files/CAM016290_d.JPG,0,test-2,3402,plesseni,3402_CAM016290_d.JPG,mimic
-CAM016294,https://zenodo.org/record/3082688/files/CAM016294_d.JPG,0,test-2,3404,plesseni,3404_CAM016294_d.JPG,mimic
-CAM016295,https://zenodo.org/record/3082688/files/CAM016295_d.JPG,0,test-2,3406,plesseni,3406_CAM016295_d.JPG,mimic
-CAM016272,https://zenodo.org/record/3082688/files/CAM016272_d.JPG,1,test-2,3388,plesseni x malleti,3388_CAM016272_d.JPG,mimic
-CAM016189,https://zenodo.org/record/3082688/files/CAM016189_d.JPG,1,test-2,3286,plesseni x malleti,3286_CAM016189_d.JPG,mimic
-CAM016270,https://zenodo.org/record/3082688/files/CAM016270_d.JPG,1,test-2,3386,plesseni x malleti,3386_CAM016270_d.JPG,mimic
-CAM016254,https://zenodo.org/record/3082688/files/CAM016254_d.JPG,1,test-2,3368,plesseni x malleti,3368_CAM016254_d.JPG,mimic
-CAM016253,https://zenodo.org/record/3082688/files/CAM016253_d.JPG,1,test-2,3366,plesseni x malleti,3366_CAM016253_d.JPG,mimic
-CAM016251,https://zenodo.org/record/3082688/files/CAM016251_d.JPG,1,test-2,3362,plesseni x malleti,3362_CAM016251_d.JPG,mimic
-CAM016250,https://zenodo.org/record/3082688/files/CAM016250_d.JPG,1,test-2,3360,plesseni x malleti,3360_CAM016250_d.JPG,mimic
-CAM016249,https://zenodo.org/record/3082688/files/CAM016249_d.JPG,1,test-2,3358,plesseni x malleti,3358_CAM016249_d.JPG,mimic
-CAM016247,https://zenodo.org/record/3082688/files/CAM016247_d.JPG,0,test-2,3356,plesseni,3356_CAM016247_d.JPG,mimic
-CAM016161,https://zenodo.org/record/3082688/files/CAM016161_d.JPG,1,test-2,3230,plesseni x malleti,3230_CAM016161_d.JPG,mimic
-CAM016160,https://zenodo.org/record/3082688/files/CAM016160_d.JPG,1,test-2,3228,plesseni x malleti,3228_CAM016160_d.JPG,mimic
-CAM016159,https://zenodo.org/record/3082688/files/CAM016159_d.JPG,1,test-2,3226,plesseni x malleti,3226_CAM016159_d.JPG,mimic
-CAM016158,https://zenodo.org/record/3082688/files/CAM016158_d.JPG,1,test-2,3224,plesseni x malleti,3224_CAM016158_d.JPG,mimic
-CAM016374,https://zenodo.org/record/3082688/files/CAM016374_d.JPG,0,test-2,3462,plesseni,3462_CAM016374_d.JPG,mimic
-CAM016165,https://zenodo.org/record/3082688/files/CAM016165_d.JPG,1,test-2,3238,plesseni x malleti,3238_CAM016165_d.JPG,mimic
-CAM016166,https://zenodo.org/record/3082688/files/CAM016166_d.JPG,1,test-2,3240,plesseni x malleti,3240_CAM016166_d.JPG,mimic
-CAM016073,https://zenodo.org/record/3082688/files/CAM016073_d.JPG,0,test-2,3054,plesseni,3054_CAM016073_d.JPG,mimic
-CAM016602,https://zenodo.org/record/3082688/files/CAM016602_d.JPG,1,test-2,3791,plesseni x malleti,3791_CAM016602_d.JPG,mimic
-CAM016608,https://zenodo.org/record/3082688/files/CAM016608_d.JPG,1,test-2,3801,plesseni x malleti,3801_CAM016608_d.JPG,mimic
-CAM016404,https://zenodo.org/record/3082688/files/CAM016404_d.JPG,0,test-2,3519,plesseni,3519_CAM016404_d.JPG,mimic
-CAM016406,https://zenodo.org/record/3082688/files/CAM016406_d.JPG,1,test-2,3523,plesseni x malleti,3523_CAM016406_d.JPG,mimic
-CAM016407,https://zenodo.org/record/3082688/files/CAM016407_d.JPG,1,test-2,3525,plesseni x malleti,3525_CAM016407_d.JPG,mimic
-CAM016408,https://zenodo.org/record/3082688/files/CAM016408_d.JPG,1,test-2,3527,plesseni x malleti,3527_CAM016408_d.JPG,mimic
-CAM016409,https://zenodo.org/record/3082688/files/CAM016409_d.JPG,1,test-2,3529,plesseni x malleti,3529_CAM016409_d.JPG,mimic
-CAM016378,https://zenodo.org/record/3082688/files/CAM016378_d.JPG,0,test-2,3470,plesseni,3470_CAM016378_d.JPG,mimic
-CAM016393,https://zenodo.org/record/3082688/files/CAM016393_d.JPG,1,test-2,3499,plesseni x malleti,3499_CAM016393_d.JPG,mimic
-CAM016394,https://zenodo.org/record/3082688/files/CAM016394_d.JPG,1,test-2,3501,plesseni x malleti,3501_CAM016394_d.JPG,mimic
-CAM016500,https://zenodo.org/record/3082688/files/CAM016500_d.JPG,1,test-2,3633,plesseni x malleti,3633_CAM016500_d.JPG,mimic
-CAM016503,https://zenodo.org/record/3082688/files/CAM016503_d.JPG,1,test-2,3639,plesseni x malleti,3639_CAM016503_d.JPG,mimic
-CAM016504,https://zenodo.org/record/3082688/files/CAM016504_d.JPG,1,test-2,3641,plesseni x malleti,3641_CAM016504_d.JPG,mimic
-CAM016508,https://zenodo.org/record/3082688/files/CAM016508_d.JPG,1,test-2,3649,plesseni x malleti,3649_CAM016508_d.JPG,mimic
-CAM016509,https://zenodo.org/record/3082688/files/CAM016509_d.JPG,1,test-2,3651,plesseni x malleti,3651_CAM016509_d.JPG,mimic
-CAM016510,https://zenodo.org/record/3082688/files/CAM016510_d.JPG,1,test-2,3653,plesseni x malleti,3653_CAM016510_d.JPG,mimic
-CAM016511,https://zenodo.org/record/3082688/files/CAM016511_d.JPG,1,test-2,3655,plesseni x malleti,3655_CAM016511_d.JPG,mimic
-CAM016505,https://zenodo.org/record/3082688/files/CAM016505_d.JPG,1,test-2,3643,plesseni x malleti,3643_CAM016505_d.JPG,mimic
-CAM016422,https://zenodo.org/record/3082688/files/CAM016422_d.JPG,1,test-2,3555,plesseni x malleti,3555_CAM016422_d.JPG,mimic
-CAM016424,https://zenodo.org/record/3082688/files/CAM016424_d.JPG,1,test-2,3559,plesseni x malleti,3559_CAM016424_d.JPG,mimic
-CAM016428,https://zenodo.org/record/3082688/files/CAM016428_d.JPG,1,test-2,3567,plesseni x malleti,3567_CAM016428_d.JPG,mimic
-CAM016082,https://zenodo.org/record/3082688/files/CAM016082_d.JPG,0,test-2,3072,plesseni,3072_CAM016082_d.JPG,mimic
-CAM017668,https://zenodo.org/record/3082688/files/CAM017668_d.JPG,1,test-2,5414,malleti x plesseni,5414_CAM017668_d.JPG,mimic
-CAM017351,https://zenodo.org/record/3082688/files/CAM017351_d.JPG,1,test-2,4980,plesseni x malleti,4980_CAM017351_d.JPG,mimic
-CAM017345,https://zenodo.org/record/3082688/files/CAM017345_d.JPG,1,test-2,4968,plesseni x malleti,4968_CAM017345_d.JPG,mimic
-CAM017614,https://zenodo.org/record/3082688/files/CAM017614_d.JPG,0,test-2,5388,plesseni,5388_CAM017614_d.JPG,mimic
-CAM017612,https://zenodo.org/record/3082688/files/CAM017612_d.JPG,1,test-2,5386,plesseni x malleti,5386_CAM017612_d.JPG,mimic
-CAM017611,https://zenodo.org/record/3082688/files/CAM017611_d.JPG,1,test-2,5384,plesseni x malleti,5384_CAM017611_d.JPG,mimic
-CAM017609,https://zenodo.org/record/3082688/files/CAM017609_d.JPG,1,test,5380,notabilis x lativitta,5380_CAM017609_d.JPG,major
-CAM017608,https://zenodo.org/record/3082688/files/CAM017608_d.JPG,1,test,5378,notabilis x lativitta,5378_CAM017608_d.JPG,major
-CAM017607,https://zenodo.org/record/3082688/files/CAM017607_d.JPG,1,test,5376,notabilis x lativitta,5376_CAM017607_d.JPG,major
-CAM017606,https://zenodo.org/record/3082688/files/CAM017606_d.JPG,1,test,5374,notabilis x lativitta,5374_CAM017606_d.JPG,major
-CAM017605,https://zenodo.org/record/3082688/files/CAM017605_d.JPG,1,test-2,5372,plesseni x malleti,5372_CAM017605_d.JPG,mimic
-CAM017604,https://zenodo.org/record/3082688/files/CAM017604_d.JPG,1,test,5370,notabilis x lativitta,5370_CAM017604_d.JPG,major
-CAM017603,https://zenodo.org/record/3082688/files/CAM017603_d.JPG,1,test,5368,notabilis x lativitta,5368_CAM017603_d.JPG,major
-CAM017602,https://zenodo.org/record/3082688/files/CAM017602_d.JPG,1,test,5366,notabilis x lativitta,5366_CAM017602_d.JPG,major
-CAM017601,https://zenodo.org/record/3082688/files/CAM017601_d.JPG,1,test,5364,notabilis x lativitta,5364_CAM017601_d.JPG,major
-CAM016009,https://zenodo.org/record/3082688/files/CAM016009_d.JPG,0,test-2,2927,plesseni,2927_CAM016009_d.JPG,mimic
-CAM016012,https://zenodo.org/record/3082688/files/CAM016012_d.JPG,1,test-2,2933,plesseni x malleti,2933_CAM016012_d.JPG,mimic
-CAM016019,https://zenodo.org/record/3082688/files/CAM016019_d.JPG,1,test,2947,notabilis x lativitta,2947_CAM016019_d.JPG,major
-CAM017658,https://zenodo.org/record/3082688/files/CAM017658_d.JPG,1,test-2,5396,malleti x plesseni,5396_CAM017658_d.JPG,mimic
-CAM016016,https://zenodo.org/record/3082688/files/CAM016016_d.JPG,1,test,2941,notabilis x lativitta,2941_CAM016016_d.JPG,major
-CAM016015,https://zenodo.org/record/3082688/files/CAM016015_d.JPG,1,test-2,2939,plesseni x malleti,2939_CAM016015_d.JPG,mimic
-CAM016017,https://zenodo.org/record/3082688/files/CAM016017_d.JPG,1,test,2943,notabilis x lativitta,2943_CAM016017_d.JPG,major
-CAM017340,https://zenodo.org/record/3082688/files/CAM017340_d.JPG,1,test,4958,notabilis x lativitta,4958_CAM017340_d.JPG,major
-CAM017339,https://zenodo.org/record/3082688/files/CAM017339_d.JPG,1,test,4956,notabilis x lativitta,4956_CAM017339_d.JPG,major
-CAM017298,https://zenodo.org/record/3082688/files/CAM017298_d.JPG,1,test,4888,notabilis x lativitta,4888_CAM017298_d.JPG,major
-CAM017300,https://zenodo.org/record/3082688/files/CAM017300_d.JPG,1,test,4890,notabilis x lativitta,4890_CAM017300_d.JPG,major
-CAM017301,https://zenodo.org/record/3082688/files/CAM017301_d.JPG,1,test,4892,notabilis x lativitta,4892_CAM017301_d.JPG,major
-CAM017302,https://zenodo.org/record/3082688/files/CAM017302_d.JPG,1,test,4894,notabilis x lativitta,4894_CAM017302_d.JPG,major
-CAM017303,https://zenodo.org/record/3082688/files/CAM017303_d.JPG,1,test,4896,notabilis x lativitta,4896_CAM017303_d.JPG,major
-CAM017306,https://zenodo.org/record/3082688/files/CAM017306_d.JPG,1,test,4898,notabilis x lativitta,4898_CAM017306_d.JPG,major
-CAM017307,https://zenodo.org/record/3082688/files/CAM017307_d.JPG,1,test,4900,notabilis x lativitta,4900_CAM017307_d.JPG,major
-CAM017308,https://zenodo.org/record/3082688/files/CAM017308_d.JPG,1,test,4902,notabilis x lativitta,4902_CAM017308_d.JPG,major
-CAM017297,https://zenodo.org/record/3082688/files/CAM017297_d.JPG,1,test,4886,notabilis x lativitta,4886_CAM017297_d.JPG,major
-CAM017296,https://zenodo.org/record/3082688/files/CAM017296_d.JPG,1,test,4884,notabilis x lativitta,4884_CAM017296_d.JPG,major
-CAM017287,https://zenodo.org/record/3082688/files/CAM017287_d.JPG,1,test,4882,notabilis x lativitta,4882_CAM017287_d.JPG,major
-CAM017274,https://zenodo.org/record/3082688/files/CAM017274_d.JPG,1,test,4860,notabilis x lativitta,4860_CAM017274_d.JPG,major
-CAM017275,https://zenodo.org/record/3082688/files/CAM017275_d.JPG,1,test,4862,notabilis x lativitta,4862_CAM017275_d.JPG,major
-CAM017276,https://zenodo.org/record/3082688/files/CAM017276_d.JPG,1,test,4864,notabilis x lativitta,4864_CAM017276_d.JPG,major
-CAM017309,https://zenodo.org/record/3082688/files/CAM017309_d.JPG,1,test,4904,notabilis x lativitta,4904_CAM017309_d.JPG,major
-CAM017277,https://zenodo.org/record/3082688/files/CAM017277_d.JPG,1,test,4866,notabilis x lativitta,4866_CAM017277_d.JPG,major
-CAM017280,https://zenodo.org/record/3082688/files/CAM017280_d.JPG,1,test,4872,notabilis x lativitta,4872_CAM017280_d.JPG,major
-CAM017732,https://zenodo.org/record/3082688/files/CAM017732_d.JPG,1,test-2,5494,plesseni x malleti,5494_CAM017732_d.JPG,mimic
-CAM017281,https://zenodo.org/record/3082688/files/CAM017281_d.JPG,1,test,4874,notabilis x lativitta,4874_CAM017281_d.JPG,major
-CAM017282,https://zenodo.org/record/3082688/files/CAM017282_d.JPG,1,test-2,4876,plesseni x malleti,4876_CAM017282_d.JPG,mimic
-CAM017050,https://zenodo.org/record/3082688/files/CAM017050_d.JPG,1,test,4449,notabilis x lativitta,4449_CAM017050_d.JPG,major
-CAM016028,https://zenodo.org/record/3082688/files/CAM016028_d.JPG,1,test,2965,notabilis x lativitta,2965_CAM016028_d.JPG,major
-CAM017328,https://zenodo.org/record/3082688/files/CAM017328_d.JPG,1,test,4934,notabilis x lativitta,4934_CAM017328_d.JPG,major
-CAM017329,https://zenodo.org/record/3082688/files/CAM017329_d.JPG,1,test-2,4936,plesseni x malleti,4936_CAM017329_d.JPG,mimic
-CAM017330,https://zenodo.org/record/3082688/files/CAM017330_d.JPG,1,test,4938,notabilis x lativitta,4938_CAM017330_d.JPG,major
-CAM017331,https://zenodo.org/record/3082688/files/CAM017331_d.JPG,1,test,4940,notabilis x lativitta,4940_CAM017331_d.JPG,major
-CAM017332,https://zenodo.org/record/3082688/files/CAM017332_d.JPG,1,test,4942,notabilis x lativitta,4942_CAM017332_d.JPG,major
-CAM017333,https://zenodo.org/record/3082688/files/CAM017333_d.JPG,1,test,4944,notabilis x lativitta,4944_CAM017333_d.JPG,major
-CAM017334,https://zenodo.org/record/3082688/files/CAM017334_d.JPG,1,test,4946,notabilis x lativitta,4946_CAM017334_d.JPG,major
-CAM017692,https://zenodo.org/record/3082688/files/CAM017692_d.JPG,1,test-2,5448,malleti x plesseni,5448_CAM017692_d.JPG,mimic
-CAM017335,https://zenodo.org/record/3082688/files/CAM017335_d.JPG,1,test-2,4948,plesseni x malleti,4948_CAM017335_d.JPG,mimic
-CAM017336,https://zenodo.org/record/3082688/files/CAM017336_d.JPG,1,test-2,4950,plesseni x malleti,4950_CAM017336_d.JPG,mimic
-CAM017337,https://zenodo.org/record/3082688/files/CAM017337_d.JPG,1,test,4952,notabilis x lativitta,4952_CAM017337_d.JPG,major
-CAM017338,https://zenodo.org/record/3082688/files/CAM017338_d.JPG,1,test,4954,notabilis x lativitta,4954_CAM017338_d.JPG,major
-CAM016029,https://zenodo.org/record/3082688/files/CAM016029_d.JPG,1,test,2967,notabilis x lativitta,2967_CAM016029_d.JPG,major
-CAM017311,https://zenodo.org/record/3082688/files/CAM017311_d.JPG,1,test,4908,notabilis x lativitta,4908_CAM017311_d.JPG,major
-CAM017312,https://zenodo.org/record/3082688/files/CAM017312_d.JPG,1,test,4910,notabilis x lativitta,4910_CAM017312_d.JPG,major
-CAM017713,https://zenodo.org/record/3082688/files/CAM017713_d.JPG,1,test,5466,lativitta x notabilis,5466_CAM017713_d.JPG,major
-CAM016030,https://zenodo.org/record/3082688/files/CAM016030_d.JPG,1,test,2969,notabilis x lativitta,2969_CAM016030_d.JPG,major
-CAM017314,https://zenodo.org/record/3082688/files/CAM017314_d.JPG,1,test,4912,notabilis x lativitta,4912_CAM017314_d.JPG,major
-CAM017315,https://zenodo.org/record/3082688/files/CAM017315_d.JPG,1,test,4914,notabilis x lativitta,4914_CAM017315_d.JPG,major
-CAM017316,https://zenodo.org/record/3082688/files/CAM017316_d.JPG,1,test,4916,notabilis x lativitta,4916_CAM017316_d.JPG,major
-CAM017310,https://zenodo.org/record/3082688/files/CAM017310_d.JPG,1,test,4906,notabilis x lativitta,4906_CAM017310_d.JPG,major
-CAM017317,https://zenodo.org/record/3082688/files/CAM017317_d.JPG,1,test,4918,notabilis x lativitta,4918_CAM017317_d.JPG,major
-CAM017318,https://zenodo.org/record/3082688/files/CAM017318_d.JPG,1,test,4920,notabilis x lativitta,4920_CAM017318_d.JPG,major
-CAM017319,https://zenodo.org/record/3082688/files/CAM017319_d.JPG,1,test,4922,notabilis x lativitta,4922_CAM017319_d.JPG,major
-CAM017703,https://zenodo.org/record/3082688/files/CAM017703_d.JPG,1,test,5458,lativitta x notabilis,5458_CAM017703_d.JPG,major
-CAM017456,https://zenodo.org/record/3082688/files/CAM017456_d.JPG,1,test-2,5140,malleti x plesseni,5140_CAM017456_d.JPG,mimic
-CAM017459,https://zenodo.org/record/3082688/files/CAM017459_d.JPG,1,test-2,5142,malleti x plesseni,5142_CAM017459_d.JPG,mimic
-CAM017440,https://zenodo.org/record/3082688/files/CAM017440_d.JPG,1,test-2,5115,plesseni x malleti,5115_CAM017440_d.JPG,mimic
-CAM017441,https://zenodo.org/record/3082688/files/CAM017441_d.JPG,1,test,5117,notabilis x lativitta,5117_CAM017441_d.JPG,major
-CAM017442,https://zenodo.org/record/3082688/files/CAM017442_d.JPG,1,test,5119,notabilis x lativitta,5119_CAM017442_d.JPG,major
-CAM017443,https://zenodo.org/record/3082688/files/CAM017443_d.JPG,1,test,5121,notabilis x lativitta,5121_CAM017443_d.JPG,major
-CAM017444,https://zenodo.org/record/3082688/files/CAM017444_d.JPG,1,test,5122,notabilis x lativitta,5122_CAM017444_d.JPG,major
-CAM017445,https://zenodo.org/record/3082688/files/CAM017445_d.JPG,1,test,5124,notabilis x lativitta,5124_CAM017445_d.JPG,major
-CAM017446,https://zenodo.org/record/3082688/files/CAM017446_d.JPG,1,test,5126,notabilis x lativitta,5126_CAM017446_d.JPG,major
-CAM017447,https://zenodo.org/record/3082688/files/CAM017447_d.JPG,1,test,5128,notabilis x lativitta,5128_CAM017447_d.JPG,major
-CAM017450,https://zenodo.org/record/3082688/files/CAM017450_d.JPG,1,test-2,5132,malleti x plesseni,5132_CAM017450_d.JPG,mimic
-CAM017451,https://zenodo.org/record/3082688/files/CAM017451_d.JPG,1,test-2,5134,malleti x plesseni,5134_CAM017451_d.JPG,mimic
-CAM017452,https://zenodo.org/record/3082688/files/CAM017452_d.JPG,1,test-2,5136,malleti x plesseni,5136_CAM017452_d.JPG,mimic
-CAM017454,https://zenodo.org/record/3082688/files/CAM017454_d.JPG,1,test-2,5138,plesseni x malleti,5138_CAM017454_d.JPG,mimic
-CAM017508,https://zenodo.org/record/3082688/files/CAM017508_d.JPG,1,test-2,5218,plesseni x malleti,5218_CAM017508_d.JPG,mimic
-CAM017507,https://zenodo.org/record/3082688/files/CAM017507_d.JPG,1,test-2,5216,malleti x plesseni,5216_CAM017507_d.JPG,mimic
-CAM017439,https://zenodo.org/record/3082688/files/CAM017439_d.JPG,1,test,5113,notabilis x lativitta,5113_CAM017439_d.JPG,major
-CAM017438,https://zenodo.org/record/3082688/files/CAM017438_d.JPG,1,test,5111,notabilis x lativitta,5111_CAM017438_d.JPG,major
-CAM017398,https://zenodo.org/record/3082688/files/CAM017398_d.JPG,1,test,5039,notabilis x lativitta,5039_CAM017398_d.JPG,major
-CAM017578,https://zenodo.org/record/3082688/files/CAM017578_d.JPG,1,test-2,5330,plesseni x malleti,5330_CAM017578_d.JPG,mimic
-CAM017407,https://zenodo.org/record/3082688/files/CAM017407_d.JPG,1,test,5055,notabilis x lativitta,5055_CAM017407_d.JPG,major
-CAM017408,https://zenodo.org/record/3082688/files/CAM017408_d.JPG,1,test,5057,notabilis x lativitta,5057_CAM017408_d.JPG,major
-CAM017574,https://zenodo.org/record/3082688/files/CAM017574_d.JPG,1,test-2,5322,malleti x plesseni,5322_CAM017574_d.JPG,mimic
-CAM017384,https://zenodo.org/record/3082688/files/CAM017384_d.JPG,1,test-2,5018,plesseni x malleti,5018_CAM017384_d.JPG,mimic
-CAM017393,https://zenodo.org/record/3082688/files/CAM017393_d.JPG,1,test,5035,notabilis x lativitta,5035_CAM017393_d.JPG,major
-CAM017410,https://zenodo.org/record/3082688/files/CAM017410_d.JPG,1,test,5059,notabilis x lativitta,5059_CAM017410_d.JPG,major
-CAM017426,https://zenodo.org/record/3082688/files/CAM017426_d.JPG,1,test,5089,notabilis x lativitta,5089_CAM017426_d.JPG,major
-CAM017427,https://zenodo.org/record/3082688/files/CAM017427_d.JPG,1,test,5091,notabilis x lativitta,5091_CAM017427_d.JPG,major
-CAM017429,https://zenodo.org/record/3082688/files/CAM017429_d.JPG,1,test,5095,notabilis x lativitta,5095_CAM017429_d.JPG,major
-CAM017431,https://zenodo.org/record/3082688/files/CAM017431_d.JPG,1,test-2,5099,plesseni x malleti,5099_CAM017431_d.JPG,mimic
-CAM017432,https://zenodo.org/record/3082688/files/CAM017432_d.JPG,1,test,5101,notabilis x lativitta,5101_CAM017432_d.JPG,major
-CAM017552,https://zenodo.org/record/3082688/files/CAM017552_d.JPG,1,test-2,5294,malleti x plesseni,5294_CAM017552_d.JPG,mimic
-CAM017433,https://zenodo.org/record/3082688/files/CAM017433_d.JPG,1,test,5103,notabilis x lativitta,5103_CAM017433_d.JPG,major
-CAM017551,https://zenodo.org/record/3082688/files/CAM017551_d.JPG,1,test-2,5292,malleti x plesseni,5292_CAM017551_d.JPG,mimic
-CAM017435,https://zenodo.org/record/3082688/files/CAM017435_d.JPG,1,test,5105,notabilis x lativitta,5105_CAM017435_d.JPG,major
-CAM017550,https://zenodo.org/record/3082688/files/CAM017550_d.JPG,1,test-2,5290,malleti x plesseni,5290_CAM017550_d.JPG,mimic
-CAM017436,https://zenodo.org/record/3082688/files/CAM017436_d.JPG,1,test,5107,notabilis x lativitta,5107_CAM017436_d.JPG,major
-CAM017549,https://zenodo.org/record/3082688/files/CAM017549_d.JPG,1,test-2,5288,malleti x plesseni,5288_CAM017549_d.JPG,mimic
-CAM017437,https://zenodo.org/record/3082688/files/CAM017437_d.JPG,1,test-2,5109,plesseni x malleti,5109_CAM017437_d.JPG,mimic
-CAM017425,https://zenodo.org/record/3082688/files/CAM017425_d.JPG,1,test,5087,notabilis x lativitta,5087_CAM017425_d.JPG,major
-CAM017424,https://zenodo.org/record/3082688/files/CAM017424_d.JPG,1,test,5085,notabilis x lativitta,5085_CAM017424_d.JPG,major
-CAM017417,https://zenodo.org/record/3082688/files/CAM017417_d.JPG,1,test-2,5071,plesseni x malleti,5071_CAM017417_d.JPG,mimic
-CAM017564,https://zenodo.org/record/3082688/files/CAM017564_d.JPG,1,test-2,5308,malleti x plesseni,5308_CAM017564_d.JPG,mimic
-CAM017419,https://zenodo.org/record/3082688/files/CAM017419_d.JPG,1,test,5075,notabilis x lativitta,5075_CAM017419_d.JPG,major
-CAM017420,https://zenodo.org/record/3082688/files/CAM017420_d.JPG,1,test,5077,notabilis x lativitta,5077_CAM017420_d.JPG,major
-CAM017421,https://zenodo.org/record/3082688/files/CAM017421_d.JPG,1,test,5079,notabilis x lativitta,5079_CAM017421_d.JPG,major
-CAM017422,https://zenodo.org/record/3082688/files/CAM017422_d.JPG,1,test,5081,notabilis x lativitta,5081_CAM017422_d.JPG,major
-CAM017423,https://zenodo.org/record/3082688/files/CAM017423_d.JPG,1,test-2,5083,plesseni x malleti,5083_CAM017423_d.JPG,mimic
-CAM017418,https://zenodo.org/record/3082688/files/CAM017418_d.JPG,1,test,5073,notabilis x lativitta,5073_CAM017418_d.JPG,major
-CAM017125,https://zenodo.org/record/3082688/files/CAM017125_d.JPG,1,test-2,4579,plesseni x malleti,4579_CAM017125_d.JPG,mimic
-CAM017127,https://zenodo.org/record/3082688/files/CAM017127_d.JPG,1,test,4583,notabilis x lativitta,4583_CAM017127_d.JPG,major
-CAM017128,https://zenodo.org/record/3082688/files/CAM017128_d.JPG,1,test-2,4585,plesseni x malleti,4585_CAM017128_d.JPG,mimic
-CAM017129,https://zenodo.org/record/3082688/files/CAM017129_d.JPG,1,test,4587,notabilis x lativitta,4587_CAM017129_d.JPG,major
-CAM017130,https://zenodo.org/record/3082688/files/CAM017130_d.JPG,1,test,4589,notabilis x lativitta,4589_CAM017130_d.JPG,major
-CAM017131,https://zenodo.org/record/3082688/files/CAM017131_d.JPG,1,test-2,4591,plesseni x malleti,4591_CAM017131_d.JPG,mimic
-CAM017132,https://zenodo.org/record/3082688/files/CAM017132_d.JPG,1,test,4593,notabilis x lativitta,4593_CAM017132_d.JPG,major
-CAM017133,https://zenodo.org/record/3082688/files/CAM017133_d.JPG,1,test,4595,notabilis x lativitta,4595_CAM017133_d.JPG,major
-CAM017123,https://zenodo.org/record/3082688/files/CAM017123_d.JPG,1,test-2,4575,plesseni x malleti,4575_CAM017123_d.JPG,mimic
-CAM017114,https://zenodo.org/record/3082688/files/CAM017114_d.JPG,1,test,4557,notabilis x lativitta,4557_CAM017114_d.JPG,major
-CAM017116,https://zenodo.org/record/3082688/files/CAM017116_d.JPG,1,test,4561,notabilis x lativitta,4561_CAM017116_d.JPG,major
-CAM017118,https://zenodo.org/record/3082688/files/CAM017118_d.JPG,1,test,4565,notabilis x lativitta,4565_CAM017118_d.JPG,major
-CAM017119,https://zenodo.org/record/3082688/files/CAM017119_d.JPG,1,test,4567,notabilis x lativitta,4567_CAM017119_d.JPG,major
-CAM017122,https://zenodo.org/record/3082688/files/CAM017122_d.JPG,1,test,4573,notabilis x lativitta,4573_CAM017122_d.JPG,major
-CAM017150,https://zenodo.org/record/3082688/files/CAM017150_d.JPG,1,test,4625,notabilis x lativitta,4625_CAM017150_d.JPG,major
-CAM017151,https://zenodo.org/record/3082688/files/CAM017151_d.JPG,1,test,4627,notabilis x lativitta,4627_CAM017151_d.JPG,major
-CAM017152,https://zenodo.org/record/3082688/files/CAM017152_d.JPG,1,test-2,4629,plesseni x malleti,4629_CAM017152_d.JPG,mimic
-CAM017153,https://zenodo.org/record/3082688/files/CAM017153_d.JPG,1,test-2,4631,plesseni x malleti,4631_CAM017153_d.JPG,mimic
-CAM017270,https://zenodo.org/record/3082688/files/CAM017270_d.JPG,1,test,4852,notabilis x lativitta,4852_CAM017270_d.JPG,major
-CAM017155,https://zenodo.org/record/3082688/files/CAM017155_d.JPG,1,test-2,4635,plesseni x malleti,4635_CAM017155_d.JPG,mimic
-CAM017157,https://zenodo.org/record/3082688/files/CAM017157_d.JPG,1,test,4639,notabilis x lativitta,4639_CAM017157_d.JPG,major
-CAM017158,https://zenodo.org/record/3082688/files/CAM017158_d.JPG,1,test,4641,notabilis x lativitta,4641_CAM017158_d.JPG,major
-CAM017159,https://zenodo.org/record/3082688/files/CAM017159_d.JPG,1,test,4643,notabilis x lativitta,4643_CAM017159_d.JPG,major
-CAM017149,https://zenodo.org/record/3082688/files/CAM017149_d.JPG,1,test,4623,notabilis x lativitta,4623_CAM017149_d.JPG,major
-CAM017148,https://zenodo.org/record/3082688/files/CAM017148_d.JPG,1,test,4621,notabilis x lativitta,4621_CAM017148_d.JPG,major
-CAM017141,https://zenodo.org/record/3082688/files/CAM017141_d.JPG,1,test,4607,notabilis x lativitta,4607_CAM017141_d.JPG,major
-CAM017142,https://zenodo.org/record/3082688/files/CAM017142_d.JPG,1,test,4609,notabilis x lativitta,4609_CAM017142_d.JPG,major
-CAM017144,https://zenodo.org/record/3082688/files/CAM017144_d.JPG,1,test,4613,notabilis x lativitta,4613_CAM017144_d.JPG,major
-CAM017145,https://zenodo.org/record/3082688/files/CAM017145_d.JPG,1,test,4615,notabilis x lativitta,4615_CAM017145_d.JPG,major
-CAM017146,https://zenodo.org/record/3082688/files/CAM017146_d.JPG,1,test,4617,notabilis x lativitta,4617_CAM017146_d.JPG,major
-CAM017867,https://zenodo.org/record/3082688/files/CAM017867_d.JPG,1,test-2,5661,malleti x plesseni,5661_CAM017867_d.JPG,mimic
-CAM017147,https://zenodo.org/record/3082688/files/CAM017147_d.JPG,1,test,4619,notabilis x lativitta,4619_CAM017147_d.JPG,major
-CAM017143,https://zenodo.org/record/3082688/files/CAM017143_d.JPG,1,test,4611,notabilis x lativitta,4611_CAM017143_d.JPG,major
-CAM017066,https://zenodo.org/record/3082688/files/CAM017066_d.JPG,1,test-2,4481,plesseni x malleti,4481_CAM017066_d.JPG,mimic
-CAM017067,https://zenodo.org/record/3082688/files/CAM017067_d.JPG,1,test-2,4483,plesseni x malleti,4483_CAM017067_d.JPG,mimic
-CAM017068,https://zenodo.org/record/3082688/files/CAM017068_d.JPG,1,test-2,4485,plesseni x malleti,4485_CAM017068_d.JPG,mimic
-CAM017072,https://zenodo.org/record/3082688/files/CAM017072_d.JPG,1,test-2,4493,plesseni x malleti,4493_CAM017072_d.JPG,mimic
-CAM017074,https://zenodo.org/record/3082688/files/CAM017074_d.JPG,1,test,4497,notabilis x lativitta,4497_CAM017074_d.JPG,major
-CAM017065,https://zenodo.org/record/3082688/files/CAM017065_d.JPG,1,test,4479,notabilis x lativitta,4479_CAM017065_d.JPG,major
-CAM017063,https://zenodo.org/record/3082688/files/CAM017063_d.JPG,1,test,4475,notabilis x lativitta,4475_CAM017063_d.JPG,major
-CAM017052,https://zenodo.org/record/3082688/files/CAM017052_d.JPG,1,test,4453,notabilis x lativitta,4453_CAM017052_d.JPG,major
-CAM017053,https://zenodo.org/record/3082688/files/CAM017053_d.JPG,1,test-2,4455,plesseni x malleti,4455_CAM017053_d.JPG,mimic
-CAM017054,https://zenodo.org/record/3082688/files/CAM017054_d.JPG,1,test,4457,notabilis x lativitta,4457_CAM017054_d.JPG,major
-CAM017055,https://zenodo.org/record/3082688/files/CAM017055_d.JPG,1,test,4459,notabilis x lativitta,4459_CAM017055_d.JPG,major
-CAM017056,https://zenodo.org/record/3082688/files/CAM017056_d.JPG,1,test,4461,notabilis x lativitta,4461_CAM017056_d.JPG,major
-CAM017057,https://zenodo.org/record/3082688/files/CAM017057_d.JPG,1,test,4463,notabilis x lativitta,4463_CAM017057_d.JPG,major
-CAM017059,https://zenodo.org/record/3082688/files/CAM017059_d.JPG,1,test,4467,notabilis x lativitta,4467_CAM017059_d.JPG,major
-CAM017062,https://zenodo.org/record/3082688/files/CAM017062_d.JPG,1,test,4473,notabilis x lativitta,4473_CAM017062_d.JPG,major
-CAM017058,https://zenodo.org/record/3082688/files/CAM017058_d.JPG,1,test,4465,notabilis x lativitta,4465_CAM017058_d.JPG,major
-CAM017094,https://zenodo.org/record/3082688/files/CAM017094_d.JPG,1,test-2,4529,plesseni x malleti,4529_CAM017094_d.JPG,mimic
-CAM017095,https://zenodo.org/record/3082688/files/CAM017095_d.JPG,1,test-2,4531,plesseni x malleti,4531_CAM017095_d.JPG,mimic
-CAM017096,https://zenodo.org/record/3082688/files/CAM017096_d.JPG,1,test-2,4533,plesseni x malleti,4533_CAM017096_d.JPG,mimic
-CAM017102,https://zenodo.org/record/3082688/files/CAM017102_d.JPG,1,test-2,4541,plesseni x malleti,4541_CAM017102_d.JPG,mimic
-CAM017109,https://zenodo.org/record/3082688/files/CAM017109_d.JPG,1,test,4547,notabilis x lativitta,4547_CAM017109_d.JPG,major
-CAM017110,https://zenodo.org/record/3082688/files/CAM017110_d.JPG,1,test,4549,notabilis x lativitta,4549_CAM017110_d.JPG,major
-CAM017080,https://zenodo.org/record/3082688/files/CAM017080_d.JPG,1,test-2,4501,plesseni x malleti,4501_CAM017080_d.JPG,mimic
-CAM017084,https://zenodo.org/record/3082688/files/CAM017084_d.JPG,1,test-2,4509,plesseni x malleti,4509_CAM017084_d.JPG,mimic
-CAM017085,https://zenodo.org/record/3082688/files/CAM017085_d.JPG,1,test,4511,notabilis x lativitta,4511_CAM017085_d.JPG,major
-CAM017087,https://zenodo.org/record/3082688/files/CAM017087_d.JPG,1,test,4515,notabilis x lativitta,4515_CAM017087_d.JPG,major
-CAM017088,https://zenodo.org/record/3082688/files/CAM017088_d.JPG,1,test,4517,notabilis x lativitta,4517_CAM017088_d.JPG,major
-CAM017090,https://zenodo.org/record/3082688/files/CAM017090_d.JPG,1,test-2,4521,plesseni x malleti,4521_CAM017090_d.JPG,mimic
-CAM017160,https://zenodo.org/record/3082688/files/CAM017160_d.JPG,1,test,4645,notabilis x lativitta,4645_CAM017160_d.JPG,major
-CAM017230,https://zenodo.org/record/3082688/files/CAM017230_d.JPG,1,test,4777,notabilis x lativitta,4777_CAM017230_d.JPG,major
-CAM017231,https://zenodo.org/record/3082688/files/CAM017231_d.JPG,1,test-2,4779,plesseni x malleti,4779_CAM017231_d.JPG,mimic
-CAM017232,https://zenodo.org/record/3082688/files/CAM017232_d.JPG,1,test-2,4781,plesseni x malleti,4781_CAM017232_d.JPG,mimic
-CAM017233,https://zenodo.org/record/3082688/files/CAM017233_d.JPG,1,test-2,4783,plesseni x malleti,4783_CAM017233_d.JPG,mimic
-CAM017234,https://zenodo.org/record/3082688/files/CAM017234_d.JPG,1,test,4785,notabilis x lativitta,4785_CAM017234_d.JPG,major
-CAM017778,https://zenodo.org/record/3082688/files/CAM017778_d.JPG,1,test-2,5544,plesseni x malleti,5544_CAM017778_d.JPG,mimic
-CAM017776,https://zenodo.org/record/3082688/files/CAM017776_d.JPG,1,test-2,5540,malleti x plesseni,5540_CAM017776_d.JPG,mimic
-CAM017235,https://zenodo.org/record/3082688/files/CAM017235_d.JPG,1,test,4787,notabilis x lativitta,4787_CAM017235_d.JPG,major
-CAM017773,https://zenodo.org/record/3082688/files/CAM017773_d.JPG,1,test,5534,lativitta x notabilis,5534_CAM017773_d.JPG,major
-CAM017229,https://zenodo.org/record/3082688/files/CAM017229_d.JPG,1,test,4775,notabilis x lativitta,4775_CAM017229_d.JPG,major
-CAM017218,https://zenodo.org/record/3082688/files/CAM017218_d.JPG,1,test,4753,notabilis x lativitta,4753_CAM017218_d.JPG,major
-CAM017161,https://zenodo.org/record/3082688/files/CAM017161_d.JPG,1,test,4647,notabilis x lativitta,4647_CAM017161_d.JPG,major
-CAM017224,https://zenodo.org/record/3082688/files/CAM017224_d.JPG,1,test,4765,notabilis x lativitta,4765_CAM017224_d.JPG,major
-CAM017225,https://zenodo.org/record/3082688/files/CAM017225_d.JPG,1,test,4767,notabilis x lativitta,4767_CAM017225_d.JPG,major
-CAM017226,https://zenodo.org/record/3082688/files/CAM017226_d.JPG,1,test,4769,notabilis x lativitta,4769_CAM017226_d.JPG,major
-CAM017222,https://zenodo.org/record/3082688/files/CAM017222_d.JPG,1,test,4761,notabilis x lativitta,4761_CAM017222_d.JPG,major
-CAM017215,https://zenodo.org/record/3082688/files/CAM017215_d.JPG,1,test,4747,notabilis x lativitta,4747_CAM017215_d.JPG,major
-CAM017257,https://zenodo.org/record/3082688/files/CAM017257_d.JPG,1,test-2,4828,plesseni x malleti,4828_CAM017257_d.JPG,mimic
-CAM016031,https://zenodo.org/record/3082688/files/CAM016031_d.JPG,1,test,2971,notabilis x lativitta,2971_CAM016031_d.JPG,major
-CAM017754,https://zenodo.org/record/3082688/files/CAM017754_d.JPG,1,test,5514,lativitta x notabilis,5514_CAM017754_d.JPG,major
-CAM017753,https://zenodo.org/record/3082688/files/CAM017753_d.JPG,1,test-2,5512,plesseni x malleti,5512_CAM017753_d.JPG,mimic
-CAM017752,https://zenodo.org/record/3082688/files/CAM017752_d.JPG,1,test-2,5510,plesseni x malleti,5510_CAM017752_d.JPG,mimic
-CAM016032,https://zenodo.org/record/3082688/files/CAM016032_d.JPG,1,test,2973,notabilis x lativitta,2973_CAM016032_d.JPG,major
-CAM017264,https://zenodo.org/record/3082688/files/CAM017264_d.JPG,1,test-2,4840,plesseni x malleti,4840_CAM017264_d.JPG,mimic
-CAM017748,https://zenodo.org/record/3082688/files/CAM017748_d.JPG,1,test,5506,lativitta x notabilis,5506_CAM017748_d.JPG,major
-CAM017265,https://zenodo.org/record/3082688/files/CAM017265_d.JPG,1,test,4842,notabilis x lativitta,4842_CAM017265_d.JPG,major
-CAM017266,https://zenodo.org/record/3082688/files/CAM017266_d.JPG,1,test,4844,notabilis x lativitta,4844_CAM017266_d.JPG,major
-CAM017747,https://zenodo.org/record/3082688/files/CAM017747_d.JPG,1,test-2,5504,malleti x plesseni,5504_CAM017747_d.JPG,mimic
-CAM017267,https://zenodo.org/record/3082688/files/CAM017267_d.JPG,1,test-2,4846,plesseni x malleti,4846_CAM017267_d.JPG,mimic
-CAM017758,https://zenodo.org/record/3082688/files/CAM017758_d.JPG,1,test-2,5516,plesseni x malleti,5516_CAM017758_d.JPG,mimic
-CAM017760,https://zenodo.org/record/3082688/files/CAM017760_d.JPG,1,test-2,5520,plesseni x malleti,5520_CAM017760_d.JPG,mimic
-CAM017759,https://zenodo.org/record/3082688/files/CAM017759_d.JPG,1,test,5518,lativitta x notabilis,5518_CAM017759_d.JPG,major
-CAM017220,https://zenodo.org/record/3082688/files/CAM017220_d.JPG,1,test,4757,notabilis x lativitta,4757_CAM017220_d.JPG,major
-CAM017835,https://zenodo.org/record/3082688/files/CAM017835_d.JPG,1,test-2,5615,plesseni x malleti,5615_CAM017835_d.JPG,mimic
-CAM017179,https://zenodo.org/record/3082688/files/CAM017179_d.JPG,0,test,4678,notabilis,4678_CAM017179_d.JPG,major
-CAM017175,https://zenodo.org/record/3082688/files/CAM017175_d.JPG,0,test,4670,notabilis,4670_CAM017175_d.JPG,major
-CAM017213,https://zenodo.org/record/3082688/files/CAM017213_d.JPG,0,test,4743,notabilis,4743_CAM017213_d.JPG,major
-CAM017181,https://zenodo.org/record/3082688/files/CAM017181_d.JPG,0,test,4682,notabilis,4682_CAM017181_d.JPG,major
-CAM017182,https://zenodo.org/record/3082688/files/CAM017182_d.JPG,0,test,4684,notabilis,4684_CAM017182_d.JPG,major
-CAM017183,https://zenodo.org/record/3082688/files/CAM017183_d.JPG,0,test,4686,notabilis,4686_CAM017183_d.JPG,major
-CAM017180,https://zenodo.org/record/3082688/files/CAM017180_d.JPG,0,test,4680,notabilis,4680_CAM017180_d.JPG,major
-CAM017174,https://zenodo.org/record/3082688/files/CAM017174_d.JPG,0,test,4669,notabilis,4669_CAM017174_d.JPG,major
-CAM017163,https://zenodo.org/record/3082688/files/CAM017163_d.JPG,1,test,4649,notabilis x lativitta,4649_CAM017163_d.JPG,major
-CAM017165,https://zenodo.org/record/3082688/files/CAM017165_d.JPG,1,test,4651,notabilis x lativitta,4651_CAM017165_d.JPG,major
-CAM017172,https://zenodo.org/record/3082688/files/CAM017172_d.JPG,0,test,4665,notabilis,4665_CAM017172_d.JPG,major
-CAM017173,https://zenodo.org/record/3082688/files/CAM017173_d.JPG,0,test,4667,notabilis,4667_CAM017173_d.JPG,major
-CAM017826,https://zenodo.org/record/3082688/files/CAM017826_d.JPG,1,test,5599,lativitta x notabilis,5599_CAM017826_d.JPG,major
-CAM017184,https://zenodo.org/record/3082688/files/CAM017184_d.JPG,1,test-2,4688,plesseni x malleti,4688_CAM017184_d.JPG,mimic
-CAM017185,https://zenodo.org/record/3082688/files/CAM017185_d.JPG,0,test-2,4690,plesseni,4690_CAM017185_d.JPG,mimic
-CAM017198,https://zenodo.org/record/3082688/files/CAM017198_d.JPG,0,test,4715,notabilis,4715_CAM017198_d.JPG,major
-CAM017199,https://zenodo.org/record/3082688/files/CAM017199_d.JPG,0,test,4717,notabilis,4717_CAM017199_d.JPG,major
-CAM017200,https://zenodo.org/record/3082688/files/CAM017200_d.JPG,0,test,4719,notabilis,4719_CAM017200_d.JPG,major
-CAM017201,https://zenodo.org/record/3082688/files/CAM017201_d.JPG,1,test,4721,notabilis x lativitta,4721_CAM017201_d.JPG,major
-CAM017202,https://zenodo.org/record/3082688/files/CAM017202_d.JPG,0,test,4723,notabilis,4723_CAM017202_d.JPG,major
-CAM017196,https://zenodo.org/record/3082688/files/CAM017196_d.JPG,0,test,4711,notabilis,4711_CAM017196_d.JPG,major
-CAM017203,https://zenodo.org/record/3082688/files/CAM017203_d.JPG,0,test,4725,notabilis,4725_CAM017203_d.JPG,major
-CAM017206,https://zenodo.org/record/3082688/files/CAM017206_d.JPG,1,test,4729,notabilis x lativitta,4729_CAM017206_d.JPG,major
-CAM017207,https://zenodo.org/record/3082688/files/CAM017207_d.JPG,0,test,4731,notabilis,4731_CAM017207_d.JPG,major
-CAM017208,https://zenodo.org/record/3082688/files/CAM017208_d.JPG,1,test-2,4733,plesseni x malleti,4733_CAM017208_d.JPG,mimic
-CAM017209,https://zenodo.org/record/3082688/files/CAM017209_d.JPG,1,test-2,4735,plesseni x malleti,4735_CAM017209_d.JPG,mimic
-CAM017211,https://zenodo.org/record/3082688/files/CAM017211_d.JPG,0,test,4739,notabilis,4739_CAM017211_d.JPG,major
-CAM017204,https://zenodo.org/record/3082688/files/CAM017204_d.JPG,0,test,4727,notabilis,4727_CAM017204_d.JPG,major
-CAM017197,https://zenodo.org/record/3082688/files/CAM017197_d.JPG,0,test,4713,notabilis,4713_CAM017197_d.JPG,major
-CAM017195,https://zenodo.org/record/3082688/files/CAM017195_d.JPG,0,test,4710,notabilis,4710_CAM017195_d.JPG,major
-CAM017186,https://zenodo.org/record/3082688/files/CAM017186_d.JPG,0,test-2,4692,plesseni,4692_CAM017186_d.JPG,mimic
-CAM017187,https://zenodo.org/record/3082688/files/CAM017187_d.JPG,0,test-2,4694,plesseni,4694_CAM017187_d.JPG,mimic
-CAM017188,https://zenodo.org/record/3082688/files/CAM017188_d.JPG,0,test,4696,notabilis,4696_CAM017188_d.JPG,major
-CAM017189,https://zenodo.org/record/3082688/files/CAM017189_d.JPG,0,test,4698,notabilis,4698_CAM017189_d.JPG,major
-CAM017190,https://zenodo.org/record/3082688/files/CAM017190_d.JPG,0,test,4700,notabilis,4700_CAM017190_d.JPG,major
-CAM017191,https://zenodo.org/record/3082688/files/CAM017191_d.JPG,1,test,4702,notabilis x lativitta,4702_CAM017191_d.JPG,major
-CAM017192,https://zenodo.org/record/3082688/files/CAM017192_d.JPG,1,test,4704,notabilis x lativitta,4704_CAM017192_d.JPG,major
-CAM017193,https://zenodo.org/record/3082688/files/CAM017193_d.JPG,0,test,4706,notabilis,4706_CAM017193_d.JPG,major
-CAM016280,https://zenodo.org/record/3082688/files/CAM016280_d.JPG,0,test-2,3394,plesseni,3394_CAM016280_d.JPG,mimic
-CAM017194,https://zenodo.org/record/3082688/files/CAM017194_d.JPG,0,test,4708,notabilis,4708_CAM017194_d.JPG,major
-CAM016208,https://zenodo.org/record/4153502/files/CAM016208_D.JPG,1,test,19072,notabilis x lativitta,19072_CAM016208_D.JPG,major
-CAM016004,https://zenodo.org/record/4153502/files/CAM016004_d.JPG,0,test-2,18849,plesseni,18849_CAM016004_d.JPG,mimic
-CAM016229,https://zenodo.org/record/4153502/files/CAM016229_D.JPG,1,test,19082,notabilis x lativitta,19082_CAM016229_D.JPG,major
-CAM016002,https://zenodo.org/record/4153502/files/CAM016002_d.JPG,0,test-2,18845,plesseni,18845_CAM016002_d.JPG,mimic
-CAM016231,https://zenodo.org/record/4153502/files/CAM016231_D.JPG,1,test,19084,notabilis x lativitta,19084_CAM016231_D.JPG,major
-CAM016232,https://zenodo.org/record/4153502/files/CAM016232_D.JPG,1,test,19086,notabilis x lativitta,19086_CAM016232_D.JPG,major
-CAM016000,https://zenodo.org/record/4153502/files/CAM016000_d.JPG,0,test-2,18841,plesseni,18841_CAM016000_d.JPG,mimic
-CAM016233,https://zenodo.org/record/4153502/files/CAM016233_D.JPG,1,test,19088,notabilis x lativitta,19088_CAM016233_D.JPG,major
-CAM016271,https://zenodo.org/record/4153502/files/CAM016271_D.JPG,1,test,19104,notabilis x lativitta,19104_CAM016271_D.JPG,major
-CAM016221,https://zenodo.org/record/4153502/files/CAM016221_D.JPG,1,test,19080,notabilis x lativitta,19080_CAM016221_D.JPG,major
-CAM016236,https://zenodo.org/record/4153502/files/CAM016236_D.JPG,1,test,19090,notabilis x lativitta,19090_CAM016236_D.JPG,major
-CAM016003,https://zenodo.org/record/4153502/files/CAM016003_d.JPG,0,test-2,18847,plesseni,18847_CAM016003_d.JPG,mimic
-CAM016265,https://zenodo.org/record/4153502/files/CAM016265_D.JPG,1,test,19102,notabilis x lativitta,19102_CAM016265_D.JPG,major
-CAM016262,https://zenodo.org/record/4153502/files/CAM016262_D.JPG,1,test,19100,notabilis x lativitta,19100_CAM016262_D.JPG,major
-CAM016261,https://zenodo.org/record/4153502/files/CAM016261_D.JPG,1,test,19098,notabilis x lativitta,19098_CAM016261_D.JPG,major
-CAM016258,https://zenodo.org/record/4153502/files/CAM016258_D.JPG,1,test,19094,notabilis x lativitta,19094_CAM016258_D.JPG,major
-CAM016001,https://zenodo.org/record/4153502/files/CAM016001_d.JPG,0,test-2,18843,plesseni,18843_CAM016001_d.JPG,mimic
-CAM016213,https://zenodo.org/record/4153502/files/CAM016213_D.JPG,1,test,19076,notabilis x lativitta,19076_CAM016213_D.JPG,major
-CAM016005,https://zenodo.org/record/4153502/files/CAM016005_d.JPG,0,test-2,18851,plesseni,18851_CAM016005_d.JPG,mimic
-CAM016212,https://zenodo.org/record/4153502/files/CAM016212_D.JPG,1,test,19074,notabilis x lativitta,19074_CAM016212_D.JPG,major
-CAM016215,https://zenodo.org/record/4153502/files/CAM016215_D.JPG,1,test,19078,notabilis x lativitta,19078_CAM016215_D.JPG,major
-CAM016256,https://zenodo.org/record/4153502/files/CAM016256_D.JPG,1,test,19092,notabilis x lativitta,19092_CAM016256_D.JPG,major
-CAM016698,https://zenodo.org/record/4153502/files/CAM016698_d.JPG,0,test-2,18940,plesseni,18940_CAM016698_d.JPG,mimic
-CAM016690,https://zenodo.org/record/4153502/files/CAM016690_d.JPG,0,test-2,18924,plesseni,18924_CAM016690_d.JPG,mimic
-CAM016303,https://zenodo.org/record/4153502/files/CAM016303_D.JPG,1,test,19108,notabilis x lativitta,19108_CAM016303_D.JPG,major
-CAM016305,https://zenodo.org/record/4153502/files/CAM016305_d.JPG,0,test,18864,notabilis,18864_CAM016305_d.JPG,major
-CAM016307,https://zenodo.org/record/4153502/files/CAM016307_d.JPG,1,test,18866,notabilis x lativitta,18866_CAM016307_d.JPG,major
-CAM016308,https://zenodo.org/record/4153502/files/CAM016308_D.JPG,1,test,19110,notabilis x lativitta,19110_CAM016308_D.JPG,major
-CAM016310,https://zenodo.org/record/4153502/files/CAM016310_D.JPG,1,test,19112,notabilis x lativitta,19112_CAM016310_D.JPG,major
-CAM016311,https://zenodo.org/record/4153502/files/CAM016311_D.JPG,1,test,19114,notabilis x lativitta,19114_CAM016311_D.JPG,major
-CAM016314,https://zenodo.org/record/4153502/files/CAM016314_d.JPG,1,test,18868,notabilis x lativitta,18868_CAM016314_d.JPG,major
-CAM016315,https://zenodo.org/record/4153502/files/CAM016315_D.JPG,0,test,19116,notabilis,19116_CAM016315_D.JPG,major
-CAM016316,https://zenodo.org/record/4153502/files/CAM016316_D.JPG,1,test,19118,notabilis x lativitta,19118_CAM016316_D.JPG,major
-CAM016317,https://zenodo.org/record/4153502/files/CAM016317_D.JPG,1,test,19120,notabilis x lativitta,19120_CAM016317_D.JPG,major
-CAM016322,https://zenodo.org/record/4153502/files/CAM016322_d.JPG,0,test,18870,notabilis,18870_CAM016322_d.JPG,major
-CAM016352,https://zenodo.org/record/4153502/files/CAM016352_D.JPG,0,test,19122,notabilis,19122_CAM016352_D.JPG,major
-CAM016353,https://zenodo.org/record/4153502/files/CAM016353_D.JPG,0,test,19124,notabilis,19124_CAM016353_D.JPG,major
-CAM016356,https://zenodo.org/record/4153502/files/CAM016356_D.JPG,0,test,19126,notabilis,19126_CAM016356_D.JPG,major
-CAM016361,https://zenodo.org/record/4153502/files/CAM016361_D.JPG,0,test,19128,notabilis,19128_CAM016361_D.JPG,major
-CAM016362,https://zenodo.org/record/4153502/files/CAM016362_D.JPG,0,test,19130,notabilis,19130_CAM016362_D.JPG,major
-CAM016363,https://zenodo.org/record/4153502/files/CAM016363_D.JPG,0,test,19132,notabilis,19132_CAM016363_D.JPG,major
-CAM016451,https://zenodo.org/record/4153502/files/CAM016451_d.JPG,1,test,18878,notabilis x lativitta,18878_CAM016451_d.JPG,major
-CAM016457,https://zenodo.org/record/4153502/files/CAM016457_d.JPG,1,test,18882,notabilis x lativitta,18882_CAM016457_d.JPG,major
-CAM016302,https://zenodo.org/record/4153502/files/CAM016302_d.JPG,1,test,18862,notabilis x lativitta,18862_CAM016302_d.JPG,major
-CAM016460,https://zenodo.org/record/4153502/files/CAM016460_d.JPG,1,test,18884,notabilis x lativitta,18884_CAM016460_d.JPG,major
-CAM016301,https://zenodo.org/record/4153502/files/CAM016301_d.JPG,0,test,18860,notabilis,18860_CAM016301_d.JPG,major
-CAM017357,https://zenodo.org/record/4153502/files/CAM017357_d.JPG,0,test-2,19020,plesseni,19020_CAM017357_d.JPG,mimic
-CAM017376,https://zenodo.org/record/4153502/files/CAM017376_d.JPG,0,test-2,19038,plesseni,19038_CAM017376_d.JPG,mimic
-CAM017613,https://zenodo.org/record/4153502/files/CAM017613_d.JPG,0,test-2,19054,plesseni,19054_CAM017613_d.JPG,mimic
-CAM017615,https://zenodo.org/record/4153502/files/CAM017615_d.JPG,0,test-2,19056,plesseni,19056_CAM017615_d.JPG,mimic
-CAM017616,https://zenodo.org/record/4153502/files/CAM017616_d.JPG,0,test-2,19058,plesseni,19058_CAM017616_d.JPG,mimic
-CAM017617,https://zenodo.org/record/4153502/files/CAM017617_d.JPG,0,test-2,19060,plesseni,19060_CAM017617_d.JPG,mimic
-CAM017618,https://zenodo.org/record/4153502/files/CAM017618_d.JPG,0,test-2,19062,plesseni,19062_CAM017618_d.JPG,mimic
-CAM017619,https://zenodo.org/record/4153502/files/CAM017619_d.JPG,0,test-2,19064,plesseni,19064_CAM017619_d.JPG,mimic
-CAM017620,https://zenodo.org/record/4153502/files/CAM017620_d.JPG,0,test-2,19066,plesseni,19066_CAM017620_d.JPG,mimic
-CAM017621,https://zenodo.org/record/4153502/files/CAM017621_d.JPG,0,test-2,19068,plesseni,19068_CAM017621_d.JPG,mimic
-CAM017622,https://zenodo.org/record/4153502/files/CAM017622_d.JPG,0,test-2,19070,plesseni,19070_CAM017622_d.JPG,mimic
-CAM017373,https://zenodo.org/record/4153502/files/CAM017373_d.JPG,0,test-2,19036,plesseni,19036_CAM017373_d.JPG,mimic
-CAM017372,https://zenodo.org/record/4153502/files/CAM017372_d.JPG,0,test-2,19034,plesseni,19034_CAM017372_d.JPG,mimic
-CAM017371,https://zenodo.org/record/4153502/files/CAM017371_d.JPG,0,test-2,19032,plesseni,19032_CAM017371_d.JPG,mimic
-CAM017368,https://zenodo.org/record/4153502/files/CAM017368_d.JPG,0,test-2,19030,plesseni,19030_CAM017368_d.JPG,mimic
-CAM017367,https://zenodo.org/record/4153502/files/CAM017367_d.JPG,0,test-2,19028,plesseni,19028_CAM017367_d.JPG,mimic
-CAM017365,https://zenodo.org/record/4153502/files/CAM017365_d.JPG,0,test-2,19026,plesseni,19026_CAM017365_d.JPG,mimic
-CAM017364,https://zenodo.org/record/4153502/files/CAM017364_d.JPG,0,test-2,19024,plesseni,19024_CAM017364_d.JPG,mimic
-CAM017363,https://zenodo.org/record/4153502/files/CAM017363_d.JPG,0,test-2,19022,plesseni,19022_CAM017363_d.JPG,mimic
-CAM016297,https://zenodo.org/record/4153502/files/CAM016297_D.JPG,0,test,19106,notabilis,19106_CAM016297_D.JPG,major
-CAM016705,https://zenodo.org/record/4153502/files/CAM016705_d.JPG,0,test,18954,notabilis,18954_CAM016705_d.JPG,major
-CAM016707,https://zenodo.org/record/4153502/files/CAM016707_d.JPG,0,test,18956,notabilis,18956_CAM016707_d.JPG,major
-CAM016709,https://zenodo.org/record/4153502/files/CAM016709_d.JPG,0,test,18958,notabilis,18958_CAM016709_d.JPG,major
-CAM016712,https://zenodo.org/record/4153502/files/CAM016712_d.JPG,0,test,18960,notabilis,18960_CAM016712_d.JPG,major
-CAM016734,https://zenodo.org/record/4153502/files/CAM016734_d.JPG,0,test-2,18962,plesseni,18962_CAM016734_d.JPG,mimic
-CAM016737,https://zenodo.org/record/4153502/files/CAM016737_d.JPG,0,test-2,18964,plesseni,18964_CAM016737_d.JPG,mimic
-CAM016738,https://zenodo.org/record/4153502/files/CAM016738_d.JPG,0,test-2,18966,plesseni,18966_CAM016738_d.JPG,mimic
-CAM016739,https://zenodo.org/record/4153502/files/CAM016739_d.JPG,0,test-2,18968,plesseni,18968_CAM016739_d.JPG,mimic
-CAM016905,https://zenodo.org/record/4153502/files/CAM016905_d.JPG,0,test-2,18974,plesseni,18974_CAM016905_d.JPG,mimic
-CAM016906,https://zenodo.org/record/4153502/files/CAM016906_d.JPG,0,test-2,18976,plesseni,18976_CAM016906_d.JPG,mimic
-CAM016907,https://zenodo.org/record/4153502/files/CAM016907_d.JPG,0,test-2,18978,plesseni,18978_CAM016907_d.JPG,mimic
-CAM016908,https://zenodo.org/record/4153502/files/CAM016908_d.JPG,0,test-2,18980,plesseni,18980_CAM016908_d.JPG,mimic
-CAM016909,https://zenodo.org/record/4153502/files/CAM016909_d.JPG,0,test-2,18982,plesseni,18982_CAM016909_d.JPG,mimic
-CAM016910,https://zenodo.org/record/4153502/files/CAM016910_d.JPG,0,test-2,18984,plesseni,18984_CAM016910_d.JPG,mimic
-CAM016911,https://zenodo.org/record/4153502/files/CAM016911_d.JPG,0,test-2,18986,plesseni,18986_CAM016911_d.JPG,mimic
-CAM016913,https://zenodo.org/record/4153502/files/CAM016913_d.JPG,0,test-2,18988,plesseni,18988_CAM016913_d.JPG,mimic
-CAM017256,https://zenodo.org/record/4153502/files/CAM017256_d.JPG,0,test-2,19002,plesseni,19002_CAM017256_d.JPG,mimic
-CAM017258,https://zenodo.org/record/4153502/files/CAM017258_d.JPG,0,test-2,19004,plesseni,19004_CAM017258_d.JPG,mimic
-CAM017313,https://zenodo.org/record/4153502/files/CAM017313_d.JPG,1,test-2,19006,plesseni x malleti,19006_CAM017313_d.JPG,mimic
-CAM017325,https://zenodo.org/record/4153502/files/CAM017325_d.JPG,0,test-2,19008,plesseni,19008_CAM017325_d.JPG,mimic
-CAM017327,https://zenodo.org/record/4153502/files/CAM017327_d.JPG,0,test-2,19010,plesseni,19010_CAM017327_d.JPG,mimic
-CAM016704,https://zenodo.org/record/4153502/files/CAM016704_d.JPG,0,test,18952,notabilis,18952_CAM016704_d.JPG,major
-CAM016703,https://zenodo.org/record/4153502/files/CAM016703_d.JPG,0,test,18950,notabilis,18950_CAM016703_d.JPG,major
-CAM016702,https://zenodo.org/record/4153502/files/CAM016702_d.JPG,0,test,18948,notabilis,18948_CAM016702_d.JPG,major
-CAM016701,https://zenodo.org/record/4153502/files/CAM016701_d.JPG,0,test-2,18946,plesseni,18946_CAM016701_d.JPG,mimic
-CAM016634,https://zenodo.org/record/4153502/files/CAM016634_d.JPG,1,test,18902,notabilis x lativitta,18902_CAM016634_d.JPG,major
-CAM016638,https://zenodo.org/record/4153502/files/CAM016638_d.JPG,1,test,18904,notabilis x lativitta,18904_CAM016638_d.JPG,major
-CAM016640,https://zenodo.org/record/4153502/files/CAM016640_d.JPG,1,test,18906,notabilis x lativitta,18906_CAM016640_d.JPG,major
-CAM016642,https://zenodo.org/record/4153502/files/CAM016642_d.JPG,1,test,18908,notabilis x lativitta,18908_CAM016642_d.JPG,major
-CAM016683,https://zenodo.org/record/4153502/files/CAM016683_d.JPG,0,test-2,18910,plesseni,18910_CAM016683_d.JPG,mimic
-CAM016684,https://zenodo.org/record/4153502/files/CAM016684_d.JPG,0,test-2,18912,plesseni,18912_CAM016684_d.JPG,mimic
-CAM016685,https://zenodo.org/record/4153502/files/CAM016685_d.JPG,0,test-2,18914,plesseni,18914_CAM016685_d.JPG,mimic
-CAM016686,https://zenodo.org/record/4153502/files/CAM016686_d.JPG,0,test-2,18916,plesseni,18916_CAM016686_d.JPG,mimic
-CAM016687,https://zenodo.org/record/4153502/files/CAM016687_d.JPG,0,test-2,18918,plesseni,18918_CAM016687_d.JPG,mimic
-CAM016688,https://zenodo.org/record/4153502/files/CAM016688_d.JPG,0,test-2,18920,plesseni,18920_CAM016688_d.JPG,mimic
-CAM016689,https://zenodo.org/record/4153502/files/CAM016689_d.JPG,0,test-2,18922,plesseni,18922_CAM016689_d.JPG,mimic
-CAM016691,https://zenodo.org/record/4153502/files/CAM016691_d.JPG,0,test-2,18926,plesseni,18926_CAM016691_d.JPG,mimic
-CAM016692,https://zenodo.org/record/4153502/files/CAM016692_d.JPG,0,test-2,18928,plesseni,18928_CAM016692_d.JPG,mimic
-CAM016693,https://zenodo.org/record/4153502/files/CAM016693_d.JPG,0,test-2,18930,plesseni,18930_CAM016693_d.JPG,mimic
-CAM016694,https://zenodo.org/record/4153502/files/CAM016694_d.JPG,0,test-2,18932,plesseni,18932_CAM016694_d.JPG,mimic
-CAM016695,https://zenodo.org/record/4153502/files/CAM016695_d.JPG,0,test-2,18934,plesseni,18934_CAM016695_d.JPG,mimic
-CAM016696,https://zenodo.org/record/4153502/files/CAM016696_d.JPG,0,test-2,18936,plesseni,18936_CAM016696_d.JPG,mimic
-CAM016697,https://zenodo.org/record/4153502/files/CAM016697_d.JPG,0,test-2,18938,plesseni,18938_CAM016697_d.JPG,mimic
-CAM017355,https://zenodo.org/record/4153502/files/CAM017355_d.JPG,0,test-2,19016,plesseni,19016_CAM017355_d.JPG,mimic
-CAM016699,https://zenodo.org/record/4153502/files/CAM016699_d.JPG,0,test-2,18942,plesseni,18942_CAM016699_d.JPG,mimic
-CAM016700,https://zenodo.org/record/4153502/files/CAM016700_d.JPG,0,test-2,18944,plesseni,18944_CAM016700_d.JPG,mimic
-CAM017356,https://zenodo.org/record/4153502/files/CAM017356_d.JPG,0,test-2,19018,plesseni,19018_CAM017356_d.JPG,mimic
-CAM017352,https://zenodo.org/record/4153502/files/CAM017352_d.JPG,0,test-2,19012,plesseni,19012_CAM017352_d.JPG,mimic
-CAM017353,https://zenodo.org/record/4153502/files/CAM017353_d.JPG,0,test-2,19014,plesseni,19014_CAM017353_d.JPG,mimic
-19N0332,https://zenodo.org/record/4288311/files/19N0332_d.JPG,0,test,19774,erato,19774_19N0332_d.JPG,minor
-19N1223,https://zenodo.org/record/4288311/files/19N1223_d.JPG,0,test-2,20235,malleti,20235_19N1223_d.JPG,mimic
-19N1212,https://zenodo.org/record/4288311/files/19N1212_d.JPG,0,test-2,20231,malleti,20231_19N1212_d.JPG,mimic
-19N1196,https://zenodo.org/record/4288311/files/19N1196_d.JPG,0,test-2,20225,malleti,20225_19N1196_d.JPG,mimic
-19N1195,https://zenodo.org/record/4288311/files/19N1195_d.JPG,0,test-2,20223,malleti,20223_19N1195_d.JPG,mimic
-19N1194,https://zenodo.org/record/4288311/files/19N1194_d.JPG,0,test-2,20221,malleti,20221_19N1194_d.JPG,mimic
-19N1158,https://zenodo.org/record/4288311/files/19N1158_d.JPG,0,test-2,20204,malleti,20204_19N1158_d.JPG,mimic
-19N1124,https://zenodo.org/record/4288311/files/19N1124_d.JPG,0,test-2,20198,malleti,20198_19N1124_d.JPG,mimic
-19N1112,https://zenodo.org/record/4288311/files/19N1112_d.JPG,0,test-2,20190,malleti,20190_19N1112_d.JPG,mimic
-19N1111,https://zenodo.org/record/4288311/files/19N1111_d.JPG,0,test-2,20188,malleti,20188_19N1111_d.JPG,mimic
-19N1110,https://zenodo.org/record/4288311/files/19N1110_d.JPG,0,test-2,20186,malleti,20186_19N1110_d.JPG,mimic
-19N1109,https://zenodo.org/record/4288311/files/19N1109_d.JPG,0,test-2,20184,malleti,20184_19N1109_d.JPG,mimic
-19N1179,https://zenodo.org/record/4288311/files/19N1179_d.JPG,0,test-2,20213,malleti,20213_19N1179_d.JPG,mimic
-19N0901,https://zenodo.org/record/4288311/files/19N0901_d.JPG,0,test-2,20098,malleti,20098_19N0901_d.JPG,mimic
-19N0746,https://zenodo.org/record/4288311/files/19N0746_d.JPG,0,test-2,20022,malleti,20022_19N0746_d.JPG,mimic
-19N0745,https://zenodo.org/record/4288311/files/19N0745_d.JPG,0,test-2,20020,malleti,20020_19N0745_d.JPG,mimic
-19N0738,https://zenodo.org/record/4288311/files/19N0738_d.JPG,0,test-2,20016,malleti,20016_19N0738_d.JPG,mimic
-19N0727,https://zenodo.org/record/4288311/files/19N0727_d.JPG,0,test-2,20012,malleti,20012_19N0727_d.JPG,mimic
-19N0715,https://zenodo.org/record/4288311/files/19N0715_d.JPG,0,test-2,20008,malleti,20008_19N0715_d.JPG,mimic
-19N0713,https://zenodo.org/record/4288311/files/19N0713_d.JPG,0,test-2,20004,malleti,20004_19N0713_d.JPG,mimic
-19N0712,https://zenodo.org/record/4288311/files/19N0712_d.JPG,0,test-2,20002,malleti,20002_19N0712_d.JPG,mimic
-19N0708,https://zenodo.org/record/4288311/files/19N0708_d.JPG,0,test-2,20000,malleti,20000_19N0708_d.JPG,mimic
-19N0700,https://zenodo.org/record/4288311/files/19N0700_d.JPG,0,test-2,19996,malleti,19996_19N0700_d.JPG,mimic
-19N0698,https://zenodo.org/record/4288311/files/19N0698_d.JPG,0,test-2,19992,malleti,19992_19N0698_d.JPG,mimic
-19N0759,https://zenodo.org/record/4288311/files/19N0759_d.JPG,0,test-2,20024,malleti,20024_19N0759_d.JPG,mimic
-19N0691,https://zenodo.org/record/4288311/files/19N0691_d.JPG,0,test-2,19984,malleti,19984_19N0691_d.JPG,mimic
-19N0690,https://zenodo.org/record/4288311/files/19N0690_d.JPG,0,test-2,19982,malleti,19982_19N0690_d.JPG,mimic
-19N0683,https://zenodo.org/record/4288311/files/19N0683_d.JPG,0,test-2,19976,malleti,19976_19N0683_d.JPG,mimic
-19N0682,https://zenodo.org/record/4288311/files/19N0682_d.JPG,0,test-2,19974,malleti,19974_19N0682_d.JPG,mimic
-19N0680,https://zenodo.org/record/4288311/files/19N0680_d.JPG,0,test-2,19972,malleti,19972_19N0680_d.JPG,mimic
-19N0674,https://zenodo.org/record/4288311/files/19N0674_d.JPG,0,test-2,19970,malleti,19970_19N0674_d.JPG,mimic
-19N0673,https://zenodo.org/record/4288311/files/19N0673_d.JPG,0,test-2,19968,malleti,19968_19N0673_d.JPG,mimic
-19N0672,https://zenodo.org/record/4288311/files/19N0672_d.JPG,0,test-2,19966,malleti,19966_19N0672_d.JPG,mimic
-19N0671,https://zenodo.org/record/4288311/files/19N0671_d.JPG,0,test-2,19964,malleti,19964_19N0671_d.JPG,mimic
-19N0667,https://zenodo.org/record/4288311/files/19N0667_d.JPG,0,test-2,19958,malleti,19958_19N0667_d.JPG,mimic
-19N0666,https://zenodo.org/record/4288311/files/19N0666_d.JPG,0,test-2,19956,malleti,19956_19N0666_d.JPG,mimic
-19N0899,https://zenodo.org/record/4288311/files/19N0899_d.JPG,0,test-2,20094,malleti,20094_19N0899_d.JPG,mimic
-19N0897,https://zenodo.org/record/4288311/files/19N0897_d.JPG,0,test-2,20090,malleti,20090_19N0897_d.JPG,mimic
-19N0868,https://zenodo.org/record/4288311/files/19N0868_d.JPG,0,test-2,20076,malleti,20076_19N0868_d.JPG,mimic
-19N0867,https://zenodo.org/record/4288311/files/19N0867_d.JPG,0,test-2,20074,malleti,20074_19N0867_d.JPG,mimic
-19N0866,https://zenodo.org/record/4288311/files/19N0866_d.JPG,0,test-2,20072,malleti,20072_19N0866_d.JPG,mimic
-19N0864,https://zenodo.org/record/4288311/files/19N0864_d.JPG,0,test-2,20068,malleti,20068_19N0864_d.JPG,mimic
-19N0863,https://zenodo.org/record/4288311/files/19N0863_d.JPG,0,test-2,20066,malleti,20066_19N0863_d.JPG,mimic
-19N0809,https://zenodo.org/record/4288311/files/19N0809_d.JPG,0,test-2,20034,malleti,20034_19N0809_d.JPG,mimic
-19N0812,https://zenodo.org/record/4288311/files/19N0812_d.JPG,0,test-2,20040,malleti,20040_19N0812_d.JPG,mimic
-19N0813,https://zenodo.org/record/4288311/files/19N0813_d.JPG,0,test-2,20042,malleti,20042_19N0813_d.JPG,mimic
-19N0833,https://zenodo.org/record/4288311/files/19N0833_d.JPG,0,test-2,20048,malleti,20048_19N0833_d.JPG,mimic
-19N0281,https://zenodo.org/record/4288311/files/19N0281_d.JPG,0,test-2,19708,malleti,19708_19N0281_d.JPG,mimic
-19N0056,https://zenodo.org/record/4288311/files/19N0056_d.JPG,0,test-2,19254,malleti,19254_19N0056_d.JPG,mimic
-19N0058,https://zenodo.org/record/4288311/files/19N0058_d.JPG,0,test-2,19260,malleti,19260_19N0058_d.JPG,mimic
-19N0061,https://zenodo.org/record/4288311/files/19N0061_d.JPG,0,test-2,19267,malleti,19267_19N0061_d.JPG,mimic
-19N0063,https://zenodo.org/record/4288311/files/19N0063_d.JPG,0,test-2,19271,malleti,19271_19N0063_d.JPG,mimic
-19N0068,https://zenodo.org/record/4288311/files/19N0068_d.JPG,0,test-2,19281,malleti,19281_19N0068_d.JPG,mimic
-19N0073,https://zenodo.org/record/4288311/files/19N0073_d.JPG,0,test-2,19291,malleti,19291_19N0073_d.JPG,mimic
-19N0074,https://zenodo.org/record/4288311/files/19N0074_d.JPG,0,test-2,19293,malleti,19293_19N0074_d.JPG,mimic
-19N0075,https://zenodo.org/record/4288311/files/19N0075_d.JPG,0,test-2,19295,malleti,19295_19N0075_d.JPG,mimic
-19N0076,https://zenodo.org/record/4288311/files/19N0076_d.JPG,0,test-2,19297,malleti,19297_19N0076_d.JPG,mimic
-19N0013,https://zenodo.org/record/4288311/files/19N0013_d.JPG,0,test-2,19165,malleti,19165_19N0013_d.JPG,mimic
-19N0014,https://zenodo.org/record/4288311/files/19N0014_d.JPG,0,test-2,19167,malleti,19167_19N0014_d.JPG,mimic
-19N0015,https://zenodo.org/record/4288311/files/19N0015_d.JPG,0,test-2,19169,malleti,19169_19N0015_d.JPG,mimic
-19N0026,https://zenodo.org/record/4288311/files/19N0026_d.JPG,0,test-2,19191,malleti,19191_19N0026_d.JPG,mimic
-19N0027,https://zenodo.org/record/4288311/files/19N0027_d.JPG,0,test-2,19194,malleti,19194_19N0027_d.JPG,mimic
-19N0029,https://zenodo.org/record/4288311/files/19N0029_d.JPG,0,test-2,19198,malleti,19198_19N0029_d.JPG,mimic
-19N0031,https://zenodo.org/record/4288311/files/19N0031_d.JPG,0,test-2,19202,malleti,19202_19N0031_d.JPG,mimic
-19N0033,https://zenodo.org/record/4288311/files/19N0033_d.JPG,0,test-2,19206,malleti,19206_19N0033_d.JPG,mimic
-19N0034,https://zenodo.org/record/4288311/files/19N0034_d.JPG,0,test-2,19208,malleti,19208_19N0034_d.JPG,mimic
-19N0035,https://zenodo.org/record/4288311/files/19N0035_d.JPG,0,test-2,19210,malleti,19210_19N0035_d.JPG,mimic
-19N0012,https://zenodo.org/record/4288311/files/19N0012_d.JPG,0,test-2,19163,malleti,19163_19N0012_d.JPG,mimic
-19N0114,https://zenodo.org/record/4288311/files/19N0114_d.JPG,0,test-2,19373,malleti,19373_19N0114_d.JPG,mimic
-19N0115,https://zenodo.org/record/4288311/files/19N0115_d.JPG,0,test-2,19375,malleti,19375_19N0115_d.JPG,mimic
-19N0116,https://zenodo.org/record/4288311/files/19N0116_d.JPG,0,test-2,19377,malleti,19377_19N0116_d.JPG,mimic
-19N0118,https://zenodo.org/record/4288311/files/19N0118_d.JPG,0,test-2,19381,malleti,19381_19N0118_d.JPG,mimic
-19N0123,https://zenodo.org/record/4288311/files/19N0123_d.JPG,0,test-2,19391,malleti,19391_19N0123_d.JPG,mimic
-19N0126,https://zenodo.org/record/4288311/files/19N0126_d.JPG,0,test-2,19397,malleti,19397_19N0126_d.JPG,mimic
-19N0127,https://zenodo.org/record/4288311/files/19N0127_d.JPG,0,test-2,19399,malleti,19399_19N0127_d.JPG,mimic
-19N0128,https://zenodo.org/record/4288311/files/19N0128_d.JPG,0,test-2,19401,malleti,19401_19N0128_d.JPG,mimic
-19N0130,https://zenodo.org/record/4288311/files/19N0130_d.JPG,0,test-2,19405,malleti,19405_19N0130_d.JPG,mimic
-19N0131,https://zenodo.org/record/4288311/files/19N0131_d.JPG,0,test-2,19407,malleti,19407_19N0131_d.JPG,mimic
-19N0133,https://zenodo.org/record/4288311/files/19N0133_d.JPG,0,test-2,19411,malleti,19411_19N0133_d.JPG,mimic
-19N0134,https://zenodo.org/record/4288311/files/19N0134_d.JPG,0,test-2,19413,malleti,19413_19N0134_d.JPG,mimic
-19N0135,https://zenodo.org/record/4288311/files/19N0135_d.JPG,0,test-2,19415,malleti,19415_19N0135_d.JPG,mimic
-19N0136,https://zenodo.org/record/4288311/files/19N0136_d.JPG,0,test-2,19417,malleti,19417_19N0136_d.JPG,mimic
-19N0137,https://zenodo.org/record/4288311/files/19N0137_d.JPG,0,test-2,19419,malleti,19419_19N0137_d.JPG,mimic
-19N0140,https://zenodo.org/record/4288311/files/19N0140_d.JPG,0,test-2,19425,malleti,19425_19N0140_d.JPG,mimic
-19N0141,https://zenodo.org/record/4288311/files/19N0141_d.JPG,0,test-2,19427,malleti,19427_19N0141_d.JPG,mimic
-19N0112,https://zenodo.org/record/4288311/files/19N0112_d.JPG,0,test-2,19369,malleti,19369_19N0112_d.JPG,mimic
-19N0110,https://zenodo.org/record/4288311/files/19N0110_d.JPG,0,test-2,19365,malleti,19365_19N0110_d.JPG,mimic
-19N0084,https://zenodo.org/record/4288311/files/19N0084_d.JPG,0,test-2,19313,malleti,19313_19N0084_d.JPG,mimic
-19N0086,https://zenodo.org/record/4288311/files/19N0086_d.JPG,0,test-2,19317,malleti,19317_19N0086_d.JPG,mimic
-19N0088,https://zenodo.org/record/4288311/files/19N0088_d.JPG,0,test-2,19321,malleti,19321_19N0088_d.JPG,mimic
-19N0089,https://zenodo.org/record/4288311/files/19N0089_d.JPG,0,test-2,19323,malleti,19323_19N0089_d.JPG,mimic
-19N0091,https://zenodo.org/record/4288311/files/19N0091_d.JPG,0,test-2,19327,malleti,19327_19N0091_d.JPG,mimic
-19N0094,https://zenodo.org/record/4288311/files/19N0094_d.JPG,0,test-2,19333,malleti,19333_19N0094_d.JPG,mimic
-19N0095,https://zenodo.org/record/4288311/files/19N0095_d.JPG,0,test-2,19335,malleti,19335_19N0095_d.JPG,mimic
-19N0097,https://zenodo.org/record/4288311/files/19N0097_d.JPG,0,test-2,19339,malleti,19339_19N0097_d.JPG,mimic
-19N0098,https://zenodo.org/record/4288311/files/19N0098_d.JPG,0,test-2,19341,malleti,19341_19N0098_d.JPG,mimic
-19N0100,https://zenodo.org/record/4288311/files/19N0100_d.JPG,0,test-2,19345,malleti,19345_19N0100_d.JPG,mimic
-19N0101,https://zenodo.org/record/4288311/files/19N0101_d.JPG,0,test-2,19347,malleti,19347_19N0101_d.JPG,mimic
-19N0102,https://zenodo.org/record/4288311/files/19N0102_d.JPG,0,test-2,19349,malleti,19349_19N0102_d.JPG,mimic
-19N0103,https://zenodo.org/record/4288311/files/19N0103_d.JPG,0,test-2,19351,malleti,19351_19N0103_d.JPG,mimic
-19N0105,https://zenodo.org/record/4288311/files/19N0105_d.JPG,0,test-2,19355,malleti,19355_19N0105_d.JPG,mimic
-19N0106,https://zenodo.org/record/4288311/files/19N0106_d.JPG,0,test-2,19357,malleti,19357_19N0106_d.JPG,mimic
-19N0107,https://zenodo.org/record/4288311/files/19N0107_d.JPG,0,test-2,19359,malleti,19359_19N0107_d.JPG,mimic
-19N0111,https://zenodo.org/record/4288311/files/19N0111_d.JPG,0,test-2,19367,malleti,19367_19N0111_d.JPG,mimic
-19N0226,https://zenodo.org/record/4288311/files/19N0226_d.JPG,0,test-2,19597,malleti,19597_19N0226_d.JPG,mimic
-19N0225,https://zenodo.org/record/4288311/files/19N0225_d.JPG,0,test-2,19595,malleti,19595_19N0225_d.JPG,mimic
-19N0212,https://zenodo.org/record/4288311/files/19N0212_d.JPG,0,test-2,19569,malleti,19569_19N0212_d.JPG,mimic
-19N0205,https://zenodo.org/record/4288311/files/19N0205_d.JPG,0,test-2,19555,malleti,19555_19N0205_d.JPG,mimic
-19N0242,https://zenodo.org/record/4288311/files/19N0242_d.JPG,0,test-2,19629,malleti,19629_19N0242_d.JPG,mimic
-19N0246,https://zenodo.org/record/4288311/files/19N0246_d.JPG,0,test-2,19637,malleti,19637_19N0246_d.JPG,mimic
-19N0280,https://zenodo.org/record/4288311/files/19N0280_d.JPG,0,test-2,19706,malleti,19706_19N0280_d.JPG,mimic
-19N0279,https://zenodo.org/record/4288311/files/19N0279_d.JPG,0,test-2,19704,malleti,19704_19N0279_d.JPG,mimic
-19N0278,https://zenodo.org/record/4288311/files/19N0278_d.JPG,0,test-2,19702,malleti,19702_19N0278_d.JPG,mimic
-19N0275,https://zenodo.org/record/4288311/files/19N0275_d.JPG,0,test-2,19696,malleti,19696_19N0275_d.JPG,mimic
-19N0267,https://zenodo.org/record/4288311/files/19N0267_d.JPG,0,test-2,19679,malleti,19679_19N0267_d.JPG,mimic
-19N0261,https://zenodo.org/record/4288311/files/19N0261_d.JPG,0,test-2,19667,malleti,19667_19N0261_d.JPG,mimic
-19N0257,https://zenodo.org/record/4288311/files/19N0257_d.JPG,0,test-2,19659,malleti,19659_19N0257_d.JPG,mimic
-19N0255,https://zenodo.org/record/4288311/files/19N0255_d.JPG,0,test-2,19655,malleti,19655_19N0255_d.JPG,mimic
-19N0010,https://zenodo.org/record/4288311/files/19N0010_d.JPG,0,test-2,19159,malleti,19159_19N0010_d.JPG,mimic
-19N0162,https://zenodo.org/record/4288311/files/19N0162_d.JPG,0,test-2,19469,malleti,19469_19N0162_d.JPG,mimic
-19N0160,https://zenodo.org/record/4288311/files/19N0160_d.JPG,0,test-2,19465,malleti,19465_19N0160_d.JPG,mimic
-19N0158,https://zenodo.org/record/4288311/files/19N0158_d.JPG,0,test-2,19461,malleti,19461_19N0158_d.JPG,mimic
-19N0153,https://zenodo.org/record/4288311/files/19N0153_d.JPG,0,test-2,19451,malleti,19451_19N0153_d.JPG,mimic
-19N0152,https://zenodo.org/record/4288311/files/19N0152_d.JPG,0,test-2,19449,malleti,19449_19N0152_d.JPG,mimic
-19N0150,https://zenodo.org/record/4288311/files/19N0150_d.JPG,0,test-2,19445,malleti,19445_19N0150_d.JPG,mimic
-19N0148,https://zenodo.org/record/4288311/files/19N0148_d.JPG,0,test-2,19441,malleti,19441_19N0148_d.JPG,mimic
-19N0147,https://zenodo.org/record/4288311/files/19N0147_d.JPG,0,test-2,19439,malleti,19439_19N0147_d.JPG,mimic
-19N1238,https://zenodo.org/record/4288311/files/19N1238_d.JPG,0,test,20249,erato,20249_19N1238_d.JPG,minor
-19N0000,https://zenodo.org/record/4288311/files/19N0000_d.JPG,0,test-2,19139,malleti,19139_19N0000_d.JPG,mimic
-19N0163,https://zenodo.org/record/4288311/files/19N0163_d.JPG,0,test-2,19471,malleti,19471_19N0163_d.JPG,mimic
-19N0196,https://zenodo.org/record/4288311/files/19N0196_d.JPG,0,test-2,19537,malleti,19537_19N0196_d.JPG,mimic
-19N0164,https://zenodo.org/record/4288311/files/19N0164_d.JPG,0,test-2,19473,malleti,19473_19N0164_d.JPG,mimic
-19N0190,https://zenodo.org/record/4288311/files/19N0190_d.JPG,0,test-2,19525,malleti,19525_19N0190_d.JPG,mimic
-19N0187,https://zenodo.org/record/4288311/files/19N0187_d.JPG,0,test-2,19519,malleti,19519_19N0187_d.JPG,mimic
-19N0186,https://zenodo.org/record/4288311/files/19N0186_d.JPG,0,test-2,19517,malleti,19517_19N0186_d.JPG,mimic
-19N0185,https://zenodo.org/record/4288311/files/19N0185_d.JPG,0,test-2,19515,malleti,19515_19N0185_d.JPG,mimic
-19N0184,https://zenodo.org/record/4288311/files/19N0184_d.JPG,0,test-2,19513,malleti,19513_19N0184_d.JPG,mimic
-19N0183,https://zenodo.org/record/4288311/files/19N0183_d.JPG,0,test-2,19511,malleti,19511_19N0183_d.JPG,mimic
-19N0182,https://zenodo.org/record/4288311/files/19N0182_d.JPG,0,test-2,19509,malleti,19509_19N0182_d.JPG,mimic
-19N0181,https://zenodo.org/record/4288311/files/19N0181_d.JPG,0,test-2,19507,malleti,19507_19N0181_d.JPG,mimic
-19N0180,https://zenodo.org/record/4288311/files/19N0180_d.JPG,0,test-2,19505,malleti,19505_19N0180_d.JPG,mimic
-19N0179,https://zenodo.org/record/4288311/files/19N0179_d.JPG,0,test-2,19503,malleti,19503_19N0179_d.JPG,mimic
-19N0178,https://zenodo.org/record/4288311/files/19N0178_d.JPG,0,test-2,19501,malleti,19501_19N0178_d.JPG,mimic
-19N0177,https://zenodo.org/record/4288311/files/19N0177_d.JPG,0,test-2,19499,malleti,19499_19N0177_d.JPG,mimic
-19N0175,https://zenodo.org/record/4288311/files/19N0175_d.JPG,0,test-2,19495,malleti,19495_19N0175_d.JPG,mimic
-19N0174,https://zenodo.org/record/4288311/files/19N0174_d.JPG,0,test-2,19493,malleti,19493_19N0174_d.JPG,mimic
-19N0173,https://zenodo.org/record/4288311/files/19N0173_d.JPG,0,test-2,19491,malleti,19491_19N0173_d.JPG,mimic
-19N0172,https://zenodo.org/record/4288311/files/19N0172_d.JPG,0,test-2,19489,malleti,19489_19N0172_d.JPG,mimic
-19N0171,https://zenodo.org/record/4288311/files/19N0171_d.JPG,0,test-2,19487,malleti,19487_19N0171_d.JPG,mimic
-19N0170,https://zenodo.org/record/4288311/files/19N0170_d.JPG,0,test-2,19485,malleti,19485_19N0170_d.JPG,mimic
-19N0169,https://zenodo.org/record/4288311/files/19N0169_d.JPG,0,test-2,19483,malleti,19483_19N0169_d.JPG,mimic
-19N2260,https://zenodo.org/record/4288311/files/19N2260_d.JPG,0,test-2,21967,malleti,21967_19N2260_d.JPG,mimic
-19N1260,https://zenodo.org/record/4288311/files/19N1260_d.JPG,0,test-2,20255,malleti,20255_19N1260_d.JPG,mimic
-19N2257,https://zenodo.org/record/4288311/files/19N2257_d.JPG,0,test-2,21955,malleti,21955_19N2257_d.JPG,mimic
-19N2259,https://zenodo.org/record/4288311/files/19N2259_d.JPG,0,test-2,21963,malleti,21963_19N2259_d.JPG,mimic
-19N2270,https://zenodo.org/record/4288311/files/19N2270_d.JPG,0,test-2,22007,malleti,22007_19N2270_d.JPG,mimic
-19N2272,https://zenodo.org/record/4288311/files/19N2272_d.JPG,0,test-2,22015,malleti,22015_19N2272_d.JPG,mimic
-19N2273,https://zenodo.org/record/4288311/files/19N2273_d.JPG,0,test-2,22019,malleti,22019_19N2273_d.JPG,mimic
-19N2254,https://zenodo.org/record/4288311/files/19N2254_d.JPG,0,test-2,21943,malleti,21943_19N2254_d.JPG,mimic
-19N2253,https://zenodo.org/record/4288311/files/19N2253_d.JPG,0,test-2,21939,malleti,21939_19N2253_d.JPG,mimic
-19N2235,https://zenodo.org/record/4288311/files/19N2235_d.JPG,0,test-2,21867,malleti,21867_19N2235_d.JPG,mimic
-19N2236,https://zenodo.org/record/4288311/files/19N2236_d.JPG,0,test-2,21871,malleti,21871_19N2236_d.JPG,mimic
-19N2237,https://zenodo.org/record/4288311/files/19N2237_d.JPG,0,test-2,21875,malleti,21875_19N2237_d.JPG,mimic
-19N2242,https://zenodo.org/record/4288311/files/19N2242_d.JPG,0,test-2,21895,malleti,21895_19N2242_d.JPG,mimic
-19N2244,https://zenodo.org/record/4288311/files/19N2244_d.JPG,0,test-2,21903,malleti,21903_19N2244_d.JPG,mimic
-19N2246,https://zenodo.org/record/4288311/files/19N2246_d.JPG,0,test-2,21911,malleti,21911_19N2246_d.JPG,mimic
-19N2249,https://zenodo.org/record/4288311/files/19N2249_d.JPG,0,test-2,21923,malleti,21923_19N2249_d.JPG,mimic
-19N2250,https://zenodo.org/record/4288311/files/19N2250_d.JPG,0,test-2,21927,malleti,21927_19N2250_d.JPG,mimic
-19N2251,https://zenodo.org/record/4288311/files/19N2251_d.JPG,0,test-2,21931,malleti,21931_19N2251_d.JPG,mimic
-19N2252,https://zenodo.org/record/4288311/files/19N2252_d.JPG,0,test-2,21935,malleti,21935_19N2252_d.JPG,mimic
-19N2277,https://zenodo.org/record/4288311/files/19N2277_d.JPG,0,test-2,22035,malleti,22035_19N2277_d.JPG,mimic
-19N2279,https://zenodo.org/record/4288311/files/19N2279_d.JPG,0,test-2,22043,malleti,22043_19N2279_d.JPG,mimic
-19N1997,https://zenodo.org/record/4288311/files/19N1997_d.JPG,0,test-2,21387,malleti,21387_19N1997_d.JPG,mimic
-19N1996,https://zenodo.org/record/4288311/files/19N1996_d.JPG,0,test-2,21383,malleti,21383_19N1996_d.JPG,mimic
-19N1983,https://zenodo.org/record/4288311/files/19N1983_d.JPG,0,test-2,21347,malleti,21347_19N1983_d.JPG,mimic
-19N1981,https://zenodo.org/record/4288311/files/19N1981_d.JPG,0,test-2,21339,malleti,21339_19N1981_d.JPG,mimic
-19N1977,https://zenodo.org/record/4288311/files/19N1977_d.JPG,0,test-2,21335,malleti,21335_19N1977_d.JPG,mimic
-19N1989,https://zenodo.org/record/4288311/files/19N1989_d.JPG,0,test-2,21367,malleti,21367_19N1989_d.JPG,mimic
-19N2011,https://zenodo.org/record/4288311/files/19N2011_d.JPG,0,test-2,21415,malleti,21415_19N2011_d.JPG,mimic
-19N2280,https://zenodo.org/record/4288311/files/19N2280_d.JPG,0,test-2,22047,malleti,22047_19N2280_d.JPG,mimic
-19N2283,https://zenodo.org/record/4288311/files/19N2283_d.JPG,0,test-2,22059,malleti,22059_19N2283_d.JPG,mimic
-19N2284,https://zenodo.org/record/4288311/files/19N2284_d.JPG,0,test-2,22063,malleti,22063_19N2284_d.JPG,mimic
-19N2040,https://zenodo.org/record/4288311/files/19N2040_d.JPG,0,test-2,21487,malleti,21487_19N2040_d.JPG,mimic
-19N2036,https://zenodo.org/record/4288311/files/19N2036_d.JPG,0,test-2,21475,malleti,21475_19N2036_d.JPG,mimic
-19N2034,https://zenodo.org/record/4288311/files/19N2034_d.JPG,0,test-2,21467,malleti,21467_19N2034_d.JPG,mimic
-19N2033,https://zenodo.org/record/4288311/files/19N2033_d.JPG,0,test-2,21463,malleti,21463_19N2033_d.JPG,mimic
-19N2027,https://zenodo.org/record/4288311/files/19N2027_d.JPG,0,test-2,21459,malleti,21459_19N2027_d.JPG,mimic
-19N2026,https://zenodo.org/record/4288311/files/19N2026_d.JPG,0,test-2,21455,malleti,21455_19N2026_d.JPG,mimic
-19N2025,https://zenodo.org/record/4288311/files/19N2025_d.JPG,0,test-2,21451,malleti,21451_19N2025_d.JPG,mimic
-19N2020,https://zenodo.org/record/4288311/files/19N2020_d.JPG,0,test-2,21435,malleti,21435_19N2020_d.JPG,mimic
-19N2230,https://zenodo.org/record/4288311/files/19N2230_d.JPG,0,test-2,21847,malleti,21847_19N2230_d.JPG,mimic
-19N2088,https://zenodo.org/record/4288311/files/19N2088_d.JPG,0,test-2,21595,malleti,21595_19N2088_d.JPG,mimic
-19N2115,https://zenodo.org/record/4288311/files/19N2115_d.JPG,0,test-2,21611,malleti,21611_19N2115_d.JPG,mimic
-19N2116,https://zenodo.org/record/4288311/files/19N2116_d.JPG,0,test-2,21615,malleti,21615_19N2116_d.JPG,mimic
-19N2082,https://zenodo.org/record/4288311/files/19N2082_d.JPG,0,test-2,21579,malleti,21579_19N2082_d.JPG,mimic
-19N2118,https://zenodo.org/record/4288311/files/19N2118_d.JPG,0,test-2,21623,malleti,21623_19N2118_d.JPG,mimic
-19N2122,https://zenodo.org/record/4288311/files/19N2122_d.JPG,0,test-2,21635,malleti,21635_19N2122_d.JPG,mimic
-19N2126,https://zenodo.org/record/4288311/files/19N2126_d.JPG,0,test-2,21643,malleti,21643_19N2126_d.JPG,mimic
-19N2127,https://zenodo.org/record/4288311/files/19N2127_d.JPG,0,test-2,21647,malleti,21647_19N2127_d.JPG,mimic
-19N2119,https://zenodo.org/record/4288311/files/19N2119_d.JPG,0,test-2,21627,malleti,21627_19N2119_d.JPG,mimic
-19N2081,https://zenodo.org/record/4288311/files/19N2081_d.JPG,0,test-2,21575,malleti,21575_19N2081_d.JPG,mimic
-19N2079,https://zenodo.org/record/4288311/files/19N2079_d.JPG,0,test-2,21571,malleti,21571_19N2079_d.JPG,mimic
-19N2078,https://zenodo.org/record/4288311/files/19N2078_d.JPG,0,test-2,21567,malleti,21567_19N2078_d.JPG,mimic
-19N2041,https://zenodo.org/record/4288311/files/19N2041_d.JPG,0,test-2,21491,malleti,21491_19N2041_d.JPG,mimic
-19N2042,https://zenodo.org/record/4288311/files/19N2042_d.JPG,0,test-2,21495,malleti,21495_19N2042_d.JPG,mimic
-19N2043,https://zenodo.org/record/4288311/files/19N2043_d.JPG,0,test-2,21499,malleti,21499_19N2043_d.JPG,mimic
-19N2056,https://zenodo.org/record/4288311/files/19N2056_d.JPG,0,test-2,21511,malleti,21511_19N2056_d.JPG,mimic
-19N2059,https://zenodo.org/record/4288311/files/19N2059_d.JPG,0,test-2,21523,malleti,21523_19N2059_d.JPG,mimic
-19N2060,https://zenodo.org/record/4288311/files/19N2060_d.JPG,0,test-2,21527,malleti,21527_19N2060_d.JPG,mimic
-19N2061,https://zenodo.org/record/4288311/files/19N2061_d.JPG,0,test-2,21531,malleti,21531_19N2061_d.JPG,mimic
-19N2063,https://zenodo.org/record/4288311/files/19N2063_d.JPG,0,test-2,21539,malleti,21539_19N2063_d.JPG,mimic
-19N2068,https://zenodo.org/record/4288311/files/19N2068_d.JPG,0,test-2,21547,malleti,21547_19N2068_d.JPG,mimic
-19N2070,https://zenodo.org/record/4288311/files/19N2070_d.JPG,0,test-2,21555,malleti,21555_19N2070_d.JPG,mimic
-19N2231,https://zenodo.org/record/4288311/files/19N2231_d.JPG,0,test-2,21851,malleti,21851_19N2231_d.JPG,mimic
-19N2141,https://zenodo.org/record/4288311/files/19N2141_d.JPG,0,test-2,21667,malleti,21667_19N2141_d.JPG,mimic
-19N2143,https://zenodo.org/record/4288311/files/19N2143_d.JPG,0,test-2,21675,malleti,21675_19N2143_d.JPG,mimic
-19N2216,https://zenodo.org/record/4288311/files/19N2216_d.JPG,0,test-2,21791,malleti,21791_19N2216_d.JPG,mimic
-19N2219,https://zenodo.org/record/4288311/files/19N2219_d.JPG,0,test-2,21803,malleti,21803_19N2219_d.JPG,mimic
-19N2220,https://zenodo.org/record/4288311/files/19N2220_d.JPG,0,test-2,21807,malleti,21807_19N2220_d.JPG,mimic
-19N2224,https://zenodo.org/record/4288311/files/19N2224_d.JPG,0,test-2,21823,malleti,21823_19N2224_d.JPG,mimic
-19N2225,https://zenodo.org/record/4288311/files/19N2225_d.JPG,0,test-2,21827,malleti,21827_19N2225_d.JPG,mimic
-19N2227,https://zenodo.org/record/4288311/files/19N2227_d.JPG,0,test-2,21835,malleti,21835_19N2227_d.JPG,mimic
-19N2228,https://zenodo.org/record/4288311/files/19N2228_d.JPG,0,test-2,21839,malleti,21839_19N2228_d.JPG,mimic
-19N2229,https://zenodo.org/record/4288311/files/19N2229_d.JPG,0,test-2,21843,malleti,21843_19N2229_d.JPG,mimic
-19N2221,https://zenodo.org/record/4288311/files/19N2221_d.JPG,0,test-2,21811,malleti,21811_19N2221_d.JPG,mimic
-19N2144,https://zenodo.org/record/4288311/files/19N2144_d.JPG,0,test-2,21679,malleti,21679_19N2144_d.JPG,mimic
-19N2158,https://zenodo.org/record/4288311/files/19N2158_d.JPG,0,test-2,21687,malleti,21687_19N2158_d.JPG,mimic
-19N2165,https://zenodo.org/record/4288311/files/19N2165_d.JPG,0,test-2,21695,malleti,21695_19N2165_d.JPG,mimic
-19N2166,https://zenodo.org/record/4288311/files/19N2166_d.JPG,0,test-2,21699,malleti,21699_19N2166_d.JPG,mimic
-19N2188,https://zenodo.org/record/4288311/files/19N2188_d.JPG,0,test-2,21719,malleti,21719_19N2188_d.JPG,mimic
-19N2189,https://zenodo.org/record/4288311/files/19N2189_d.JPG,0,test-2,21723,malleti,21723_19N2189_d.JPG,mimic
-19N2142,https://zenodo.org/record/4288311/files/19N2142_d.JPG,0,test-2,21671,malleti,21671_19N2142_d.JPG,mimic
-19N1974,https://zenodo.org/record/4288311/files/19N1974_d.JPG,0,test-2,21323,malleti,21323_19N1974_d.JPG,mimic
-19N2038,https://zenodo.org/record/4288311/files/19N2038_d.JPG,0,test-2,21479,malleti,21479_19N2038_d.JPG,mimic
-19N1735,https://zenodo.org/record/4288311/files/19N1735_d.JPG,0,test-2,20935,malleti,20935_19N1735_d.JPG,mimic
-19N1714,https://zenodo.org/record/4288311/files/19N1714_d.JPG,0,test-2,20899,malleti,20899_19N1714_d.JPG,mimic
-19N1699,https://zenodo.org/record/4288311/files/19N1699_d.JPG,0,test-2,20891,malleti,20891_19N1699_d.JPG,mimic
-19N1646,https://zenodo.org/record/4288311/files/19N1646_d.JPG,0,test-2,20835,malleti,20835_19N1646_d.JPG,mimic
-19N1743,https://zenodo.org/record/4288311/files/19N1743_d.JPG,0,test-2,20943,malleti,20943_19N1743_d.JPG,mimic
-19N1744,https://zenodo.org/record/4288311/files/19N1744_d.JPG,0,test-2,20947,malleti,20947_19N1744_d.JPG,mimic
-19N1745,https://zenodo.org/record/4288311/files/19N1745_d.JPG,0,test-2,20951,malleti,20951_19N1745_d.JPG,mimic
-19N1821,https://zenodo.org/record/4288311/files/19N1821_d.JPG,0,test-2,21071,malleti,21071_19N1821_d.JPG,mimic
-19N1820,https://zenodo.org/record/4288311/files/19N1820_d.JPG,0,test-2,21067,malleti,21067_19N1820_d.JPG,mimic
-19N1813,https://zenodo.org/record/4288311/files/19N1813_d.JPG,0,test-2,21059,malleti,21059_19N1813_d.JPG,mimic
-19N1810,https://zenodo.org/record/4288311/files/19N1810_d.JPG,0,test-2,21047,malleti,21047_19N1810_d.JPG,mimic
-19N1806,https://zenodo.org/record/4288311/files/19N1806_d.JPG,0,test-2,21039,malleti,21039_19N1806_d.JPG,mimic
-19N1771,https://zenodo.org/record/4288311/files/19N1771_d.JPG,0,test-2,20999,malleti,20999_19N1771_d.JPG,mimic
-19N1769,https://zenodo.org/record/4288311/files/19N1769_d.JPG,0,test-2,20991,malleti,20991_19N1769_d.JPG,mimic
-19N1763,https://zenodo.org/record/4288311/files/19N1763_d.JPG,0,test-2,20979,malleti,20979_19N1763_d.JPG,mimic
-19N1762,https://zenodo.org/record/4288311/files/19N1762_d.JPG,0,test-2,20975,malleti,20975_19N1762_d.JPG,mimic
-19N1761,https://zenodo.org/record/4288311/files/19N1761_d.JPG,0,test-2,20971,malleti,20971_19N1761_d.JPG,mimic
-19N1754,https://zenodo.org/record/4288311/files/19N1754_d.JPG,0,test-2,20967,malleti,20967_19N1754_d.JPG,mimic
-19N1379,https://zenodo.org/record/4288311/files/19N1379_d.JPG,0,test-2,20313,malleti,20313_19N1379_d.JPG,mimic
-19N1377,https://zenodo.org/record/4288311/files/19N1377_d.JPG,0,test-2,20309,malleti,20309_19N1377_d.JPG,mimic
-19N1373,https://zenodo.org/record/4288311/files/19N1373_d.JPG,0,test-2,20305,malleti,20305_19N1373_d.JPG,mimic
-19N1367,https://zenodo.org/record/4288311/files/19N1367_d.JPG,0,test-2,20301,malleti,20301_19N1367_d.JPG,mimic
-19N1363,https://zenodo.org/record/4288311/files/19N1363_d.JPG,0,test-2,20299,malleti,20299_19N1363_d.JPG,mimic
-19N1349,https://zenodo.org/record/4288311/files/19N1349_d.JPG,0,test-2,20289,malleti,20289_19N1349_d.JPG,mimic
-19N1348,https://zenodo.org/record/4288311/files/19N1348_d.JPG,0,test-2,20287,malleti,20287_19N1348_d.JPG,mimic
-19N1334,https://zenodo.org/record/4288311/files/19N1334_d.JPG,0,test-2,20283,malleti,20283_19N1334_d.JPG,mimic
-19N1333,https://zenodo.org/record/4288311/files/19N1333_d.JPG,0,test-2,20281,malleti,20281_19N1333_d.JPG,mimic
-19N1332,https://zenodo.org/record/4288311/files/19N1332_d.JPG,0,test-2,20279,malleti,20279_19N1332_d.JPG,mimic
-19N1318,https://zenodo.org/record/4288311/files/19N1318_d.JPG,0,test-2,20275,malleti,20275_19N1318_d.JPG,mimic
-19N1316,https://zenodo.org/record/4288311/files/19N1316_d.JPG,0,test-2,20271,malleti,20271_19N1316_d.JPG,mimic
-19N1312,https://zenodo.org/record/4288311/files/19N1312_d.JPG,0,test-2,20269,malleti,20269_19N1312_d.JPG,mimic
-19N1299,https://zenodo.org/record/4288311/files/19N1299_d.JPG,0,test-2,20267,malleti,20267_19N1299_d.JPG,mimic
-19N1298,https://zenodo.org/record/4288311/files/19N1298_d.JPG,0,test-2,20265,malleti,20265_19N1298_d.JPG,mimic
-19N1380,https://zenodo.org/record/4288311/files/19N1380_d.JPG,0,test-2,20315,malleti,20315_19N1380_d.JPG,mimic
-19N1381,https://zenodo.org/record/4288311/files/19N1381_d.JPG,0,test-2,20317,malleti,20317_19N1381_d.JPG,mimic
-19N1382,https://zenodo.org/record/4288311/files/19N1382_d.JPG,0,test-2,20319,malleti,20319_19N1382_d.JPG,mimic
-19N1471,https://zenodo.org/record/4288311/files/19N1471_d.JPG,0,test-2,20381,malleti,20381_19N1471_d.JPG,mimic
-19N1467,https://zenodo.org/record/4288311/files/19N1467_d.JPG,0,test-2,20379,malleti,20379_19N1467_d.JPG,mimic
-19N1446,https://zenodo.org/record/4288311/files/19N1446_d.JPG,0,test-2,20371,malleti,20371_19N1446_d.JPG,mimic
-19N1432,https://zenodo.org/record/4288311/files/19N1432_d.JPG,0,test-2,20363,malleti,20363_19N1432_d.JPG,mimic
-19N1426,https://zenodo.org/record/4288311/files/19N1426_d.JPG,0,test-2,20357,malleti,20357_19N1426_d.JPG,mimic
-19N1422,https://zenodo.org/record/4288311/files/19N1422_d.JPG,0,test-2,20353,malleti,20353_19N1422_d.JPG,mimic
-19N1421,https://zenodo.org/record/4288311/files/19N1421_d.JPG,0,test-2,20351,malleti,20351_19N1421_d.JPG,mimic
-19N1419,https://zenodo.org/record/4288311/files/19N1419_d.JPG,0,test-2,20347,malleti,20347_19N1419_d.JPG,mimic
-19N1398,https://zenodo.org/record/4288311/files/19N1398_d.JPG,0,test-2,20339,malleti,20339_19N1398_d.JPG,mimic
-19N1394,https://zenodo.org/record/4288311/files/19N1394_d.JPG,0,test-2,20333,malleti,20333_19N1394_d.JPG,mimic
-19N1393,https://zenodo.org/record/4288311/files/19N1393_d.JPG,0,test-2,20331,malleti,20331_19N1393_d.JPG,mimic
-19N1392,https://zenodo.org/record/4288311/files/19N1392_d.JPG,0,test-2,20329,malleti,20329_19N1392_d.JPG,mimic
-19N1389,https://zenodo.org/record/4288311/files/19N1389_d.JPG,0,test-2,20327,malleti,20327_19N1389_d.JPG,mimic
-19N1388,https://zenodo.org/record/4288311/files/19N1388_d.JPG,0,test-2,20325,malleti,20325_19N1388_d.JPG,mimic
-19N1387,https://zenodo.org/record/4288311/files/19N1387_d.JPG,0,test-2,20323,malleti,20323_19N1387_d.JPG,mimic
-19N1827,https://zenodo.org/record/4288311/files/19N1827_d.JPG,0,test-2,21087,malleti,21087_19N1827_d.JPG,mimic
-19N1912,https://zenodo.org/record/4288311/files/19N1912_d.JPG,0,test-2,21219,malleti,21219_19N1912_d.JPG,mimic
-19N1909,https://zenodo.org/record/4288311/files/19N1909_d.JPG,0,test-2,21215,malleti,21215_19N1909_d.JPG,mimic
-19N1908,https://zenodo.org/record/4288311/files/19N1908_d.JPG,0,test-2,21211,malleti,21211_19N1908_d.JPG,mimic
-19N1907,https://zenodo.org/record/4288311/files/19N1907_d.JPG,0,test-2,21207,malleti,21207_19N1907_d.JPG,mimic
-19N1896,https://zenodo.org/record/4288311/files/19N1896_d.JPG,0,test-2,21191,malleti,21191_19N1896_d.JPG,mimic
-19N1892,https://zenodo.org/record/4288311/files/19N1892_d.JPG,0,test-2,21183,malleti,21183_19N1892_d.JPG,mimic
-19N1890,https://zenodo.org/record/4288311/files/19N1890_d.JPG,0,test-2,21179,malleti,21179_19N1890_d.JPG,mimic
-19N1888,https://zenodo.org/record/4288311/files/19N1888_d.JPG,0,test-2,21171,malleti,21171_19N1888_d.JPG,mimic
-19N1877,https://zenodo.org/record/4288311/files/19N1877_d.JPG,0,test-2,21159,malleti,21159_19N1877_d.JPG,mimic
-19N1957,https://zenodo.org/record/4288311/files/19N1957_d.JPG,0,test-2,21299,malleti,21299_19N1957_d.JPG,mimic
-19N1876,https://zenodo.org/record/4288311/files/19N1876_d.JPG,0,test-2,21155,malleti,21155_19N1876_d.JPG,mimic
-19N1945,https://zenodo.org/record/4288311/files/19N1945_d.JPG,0,test-2,21275,malleti,21275_19N1945_d.JPG,mimic
-19N1932,https://zenodo.org/record/4288311/files/19N1932_d.JPG,0,test-2,21251,malleti,21251_19N1932_d.JPG,mimic
-19N1251,https://zenodo.org/record/4288311/files/19N1251_d.JPG,0,test-2,20253,malleti,20253_19N1251_d.JPG,mimic
-19N1867,https://zenodo.org/record/4288311/files/19N1867_d.JPG,0,test-2,21143,malleti,21143_19N1867_d.JPG,mimic
-19N1875,https://zenodo.org/record/4288311/files/19N1875_d.JPG,0,test-2,21151,malleti,21151_19N1875_d.JPG,mimic
-19N1864,https://zenodo.org/record/4288311/files/19N1864_d.JPG,0,test-2,21131,malleti,21131_19N1864_d.JPG,mimic
-19N1861,https://zenodo.org/record/4288311/files/19N1861_d.JPG,0,test-2,21123,malleti,21123_19N1861_d.JPG,mimic
-19N1857,https://zenodo.org/record/4288311/files/19N1857_d.JPG,0,test-2,21115,malleti,21115_19N1857_d.JPG,mimic
-19N1856,https://zenodo.org/record/4288311/files/19N1856_d.JPG,0,test-2,21111,malleti,21111_19N1856_d.JPG,mimic
-19N1855,https://zenodo.org/record/4288311/files/19N1855_d.JPG,0,test-2,21107,malleti,21107_19N1855_d.JPG,mimic
-19N1850,https://zenodo.org/record/4288311/files/19N1850_d.JPG,0,test-2,21103,malleti,21103_19N1850_d.JPG,mimic
-19N1845,https://zenodo.org/record/4288311/files/19N1845_d.JPG,0,test-2,21099,malleti,21099_19N1845_d.JPG,mimic
-19N1841,https://zenodo.org/record/4288311/files/19N1841_d.JPG,0,test-2,21095,malleti,21095_19N1841_d.JPG,mimic
-19N1860,https://zenodo.org/record/4288311/files/19N1860_d.JPG,0,test-2,21119,malleti,21119_19N1860_d.JPG,mimic
-15N261,https://zenodo.org/record/4289223/files/15N261_d.JPG,0,test,15220,venus,15220_15N261_d.JPG,minor
-15N145,https://zenodo.org/record/4289223/files/15N145_d.JPG,0,test,14957,venus,14957_15N145_d.JPG,minor
-15N146,https://zenodo.org/record/4289223/files/15N146_d.JPG,0,test,14959,venus,14959_15N146_d.JPG,minor
-15N149,https://zenodo.org/record/4289223/files/15N149_d.JPG,0,test,14961,venus,14961_15N149_d.JPG,minor
-15N192,https://zenodo.org/record/4289223/files/15N192_d.JPG,0,test,15202,venus,15202_15N192_d.JPG,minor
-15N193,https://zenodo.org/record/4289223/files/15N193_d.JPG,0,test,15204,venus,15204_15N193_d.JPG,minor
-15N194,https://zenodo.org/record/4289223/files/15N194_d.JPG,0,test,15206,venus,15206_15N194_d.JPG,minor
-15N195,https://zenodo.org/record/4289223/files/15N195_d.JPG,0,test,15208,venus,15208_15N195_d.JPG,minor
-15N238,https://zenodo.org/record/4289223/files/15N238_d.JPG,0,test,15210,venus,15210_15N238_d.JPG,minor
-15N239,https://zenodo.org/record/4289223/files/15N239_d.JPG,0,test,15212,venus,15212_15N239_d.JPG,minor
-15N241,https://zenodo.org/record/4289223/files/15N241_d.JPG,0,test,15216,venus,15216_15N241_d.JPG,minor
-15N136,https://zenodo.org/record/4289223/files/15N136_d.JPG,0,test,15184,chestertonii,15184_15N136_d.JPG,minor
-15N135,https://zenodo.org/record/4289223/files/15N135_d.JPG,0,test,15182,chestertonii,15182_15N135_d.JPG,minor
-15N101,https://zenodo.org/record/4289223/files/15N101_d.JPG,0,test,14953,venus,14953_15N101_d.JPG,minor
-15N111,https://zenodo.org/record/4289223/files/15N111_d.JPG,0,test,15169,venus,15169_15N111_d.JPG,minor
-15N112,https://zenodo.org/record/4289223/files/15N112_d.JPG,0,test,15171,venus,15171_15N112_d.JPG,minor
-15N113,https://zenodo.org/record/4289223/files/15N113_d.JPG,0,test,15173,venus,15173_15N113_d.JPG,minor
-15N115,https://zenodo.org/record/4289223/files/15N115_d.JPG,0,test,14955,venus,14955_15N115_d.JPG,minor
-15N120,https://zenodo.org/record/4289223/files/15N120_d.JPG,0,test,15174,venus,15174_15N120_d.JPG,minor
-15N121,https://zenodo.org/record/4289223/files/15N121_d.JPG,0,test,15176,venus,15176_15N121_d.JPG,minor
-CAM041525,https://zenodo.org/record/4291095/files/CAM041525_d.JPG,0,test-2,39072,malleti,39072_CAM041525_d.JPG,mimic
-CAM041524,https://zenodo.org/record/4291095/files/CAM041524_d.JPG,0,test-2,39068,malleti,39068_CAM041524_d.JPG,mimic
-CAM041517,https://zenodo.org/record/4291095/files/CAM041517_d.JPG,0,test-2,39040,malleti,39040_CAM041517_d.JPG,mimic
-CAM041526,https://zenodo.org/record/4291095/files/CAM041526_d.JPG,0,test-2,39076,malleti,39076_CAM041526_d.JPG,mimic
-CAM041500,https://zenodo.org/record/4291095/files/CAM041500_d.JPG,0,test-2,38972,malleti,38972_CAM041500_d.JPG,mimic
-CAM041499,https://zenodo.org/record/4291095/files/CAM041499_d.JPG,0,test-2,38968,malleti,38968_CAM041499_d.JPG,mimic
-CAM041498,https://zenodo.org/record/4291095/files/CAM041498_d.JPG,0,test-2,38964,malleti,38964_CAM041498_d.JPG,mimic
-CAM041497,https://zenodo.org/record/4291095/files/CAM041497_d.JPG,0,test-2,38960,malleti,38960_CAM041497_d.JPG,mimic
-CAM041496,https://zenodo.org/record/4291095/files/CAM041496_d.JPG,0,test-2,38956,malleti,38956_CAM041496_d.JPG,mimic
-CAM041582,https://zenodo.org/record/4291095/files/CAM041582_d.JPG,0,test-2,39296,malleti,39296_CAM041582_d.JPG,mimic
-CAM041581,https://zenodo.org/record/4291095/files/CAM041581_d.JPG,0,test-2,39292,malleti,39292_CAM041581_d.JPG,mimic
-CAM041580,https://zenodo.org/record/4291095/files/CAM041580_d.JPG,0,test-2,39288,malleti,39288_CAM041580_d.JPG,mimic
-CAM041579,https://zenodo.org/record/4291095/files/CAM041579_d.JPG,0,test-2,39284,malleti,39284_CAM041579_d.JPG,mimic
-CAM041578,https://zenodo.org/record/4291095/files/CAM041578_d.JPG,0,test-2,39280,malleti,39280_CAM041578_d.JPG,mimic
-CAM041577,https://zenodo.org/record/4291095/files/CAM041577_d.JPG,0,test-2,39276,malleti,39276_CAM041577_d.JPG,mimic
-CAM041576,https://zenodo.org/record/4291095/files/CAM041576_d.JPG,0,test-2,39272,malleti,39272_CAM041576_d.JPG,mimic
-CAM041557,https://zenodo.org/record/4291095/files/CAM041557_d.JPG,0,test-2,39196,malleti,39196_CAM041557_d.JPG,mimic
-CAM041547,https://zenodo.org/record/4291095/files/CAM041547_d.JPG,0,test-2,39160,malleti,39160_CAM041547_d.JPG,mimic
-CAM041546,https://zenodo.org/record/4291095/files/CAM041546_d.JPG,0,test-2,39156,malleti,39156_CAM041546_d.JPG,mimic
-CAM041542,https://zenodo.org/record/4291095/files/CAM041542_d.JPG,0,test-2,39140,malleti,39140_CAM041542_d.JPG,mimic
-CAM041372,https://zenodo.org/record/4291095/files/CAM041372_d.JPG,0,test-2,38468,malleti,38468_CAM041372_d.JPG,mimic
-CAM041371,https://zenodo.org/record/4291095/files/CAM041371_d.JPG,0,test-2,38464,malleti,38464_CAM041371_d.JPG,mimic
-CAM041369,https://zenodo.org/record/4291095/files/CAM041369_d.JPG,0,test-2,38456,malleti,38456_CAM041369_d.JPG,mimic
-CAM041368,https://zenodo.org/record/4291095/files/CAM041368_d.JPG,0,test-2,38452,malleti,38452_CAM041368_d.JPG,mimic
-CAM041367,https://zenodo.org/record/4291095/files/CAM041367_d.JPG,0,test-2,38448,malleti,38448_CAM041367_d.JPG,mimic
-CAM041475,https://zenodo.org/record/4291095/files/CAM041475_d.JPG,0,test-2,38868,malleti,38868_CAM041475_d.JPG,mimic
-CAM041458,https://zenodo.org/record/4291095/files/CAM041458_d.JPG,0,test-2,38804,malleti,38804_CAM041458_d.JPG,mimic
-CAM041456,https://zenodo.org/record/4291095/files/CAM041456_d.JPG,0,test-2,38796,malleti,38796_CAM041456_d.JPG,mimic
-CAM041403,https://zenodo.org/record/4291095/files/CAM041403_d.JPG,0,test-2,38584,malleti,38584_CAM041403_d.JPG,mimic
-CAM041400,https://zenodo.org/record/4291095/files/CAM041400_d.JPG,0,test-2,38572,malleti,38572_CAM041400_d.JPG,mimic
-CAM041587,https://zenodo.org/record/4291095/files/CAM041587_d.JPG,0,test-2,39315,malleti,39315_CAM041587_d.JPG,mimic
-CAM041588,https://zenodo.org/record/4291095/files/CAM041588_d.JPG,0,test-2,39319,malleti,39319_CAM041588_d.JPG,mimic
-CAM041803,https://zenodo.org/record/4291095/files/CAM041803_d.JPG,0,test,40179,lativitta,40179_CAM041803_d.JPG,major
-CAM041802,https://zenodo.org/record/4291095/files/CAM041802_d.JPG,0,test,40175,lativitta,40175_CAM041802_d.JPG,major
-CAM041801,https://zenodo.org/record/4291095/files/CAM041801_d.JPG,0,test,40171,lativitta,40171_CAM041801_d.JPG,major
-CAM041800,https://zenodo.org/record/4291095/files/CAM041800_d.JPG,0,test,40167,lativitta,40167_CAM041800_d.JPG,major
-CAM041799,https://zenodo.org/record/4291095/files/CAM041799_d.JPG,0,test,40163,lativitta,40163_CAM041799_d.JPG,major
-CAM041798,https://zenodo.org/record/4291095/files/CAM041798_d.JPG,0,test,40159,lativitta,40159_CAM041798_d.JPG,major
-CAM041797,https://zenodo.org/record/4291095/files/CAM041797_d.JPG,0,test,40155,lativitta,40155_CAM041797_d.JPG,major
-CAM041796,https://zenodo.org/record/4291095/files/CAM041796_d.JPG,0,test,40151,lativitta,40151_CAM041796_d.JPG,major
-CAM041795,https://zenodo.org/record/4291095/files/CAM041795_d.JPG,0,test,40147,lativitta,40147_CAM041795_d.JPG,major
-CAM041794,https://zenodo.org/record/4291095/files/CAM041794_d.JPG,0,test,40143,lativitta,40143_CAM041794_d.JPG,major
-CAM041793,https://zenodo.org/record/4291095/files/CAM041793_d.JPG,0,test,40139,lativitta,40139_CAM041793_d.JPG,major
-CAM041792,https://zenodo.org/record/4291095/files/CAM041792_d.JPG,0,test,40135,lativitta,40135_CAM041792_d.JPG,major
-CAM041791,https://zenodo.org/record/4291095/files/CAM041791_d.JPG,0,test,40131,lativitta,40131_CAM041791_d.JPG,major
-CAM041790,https://zenodo.org/record/4291095/files/CAM041790_d.JPG,0,test,40127,lativitta,40127_CAM041790_d.JPG,major
-CAM041789,https://zenodo.org/record/4291095/files/CAM041789_d.JPG,0,test,40123,lativitta,40123_CAM041789_d.JPG,major
-CAM041788,https://zenodo.org/record/4291095/files/CAM041788_d.JPG,0,test,40119,lativitta,40119_CAM041788_d.JPG,major
-CAM041787,https://zenodo.org/record/4291095/files/CAM041787_d.JPG,0,test,40115,lativitta,40115_CAM041787_d.JPG,major
-CAM041786,https://zenodo.org/record/4291095/files/CAM041786_d.JPG,0,test,40111,lativitta,40111_CAM041786_d.JPG,major
-CAM041785,https://zenodo.org/record/4291095/files/CAM041785_d.JPG,0,test,40107,lativitta,40107_CAM041785_d.JPG,major
-CAM041784,https://zenodo.org/record/4291095/files/CAM041784_d.JPG,0,test,40103,lativitta,40103_CAM041784_d.JPG,major
-CAM041783,https://zenodo.org/record/4291095/files/CAM041783_d.JPG,0,test,40099,lativitta,40099_CAM041783_d.JPG,major
-CAM041782,https://zenodo.org/record/4291095/files/CAM041782_d.JPG,0,test,40095,lativitta,40095_CAM041782_d.JPG,major
-CAM041780,https://zenodo.org/record/4291095/files/CAM041780_d.JPG,0,test,40087,lativitta,40087_CAM041780_d.JPG,major
-CAM041805,https://zenodo.org/record/4291095/files/CAM041805_d.JPG,0,test,40187,lativitta,40187_CAM041805_d.JPG,major
-CAM041753,https://zenodo.org/record/4291095/files/CAM041753_d.JPG,0,test,39979,lativitta,39979_CAM041753_d.JPG,major
-CAM041751,https://zenodo.org/record/4291095/files/CAM041751_d.JPG,0,test,39971,lativitta,39971_CAM041751_d.JPG,major
-CAM041723,https://zenodo.org/record/4291095/files/CAM041723_d.JPG,0,test,39859,lativitta,39859_CAM041723_d.JPG,major
-CAM041722,https://zenodo.org/record/4291095/files/CAM041722_d.JPG,0,test,39855,lativitta,39855_CAM041722_d.JPG,major
-CAM041721,https://zenodo.org/record/4291095/files/CAM041721_d.JPG,0,test,39851,lativitta,39851_CAM041721_d.JPG,major
-CAM041720,https://zenodo.org/record/4291095/files/CAM041720_d.JPG,0,test,39847,lativitta,39847_CAM041720_d.JPG,major
-CAM041719,https://zenodo.org/record/4291095/files/CAM041719_d.JPG,0,test,39843,lativitta,39843_CAM041719_d.JPG,major
-CAM041718,https://zenodo.org/record/4291095/files/CAM041718_d.JPG,0,test,39839,lativitta,39839_CAM041718_d.JPG,major
-CAM041717,https://zenodo.org/record/4291095/files/CAM041717_d.JPG,0,test,39835,lativitta,39835_CAM041717_d.JPG,major
-CAM041716,https://zenodo.org/record/4291095/files/CAM041716_d.JPG,0,test,39831,lativitta,39831_CAM041716_d.JPG,major
-CAM041715,https://zenodo.org/record/4291095/files/CAM041715_d.JPG,0,test,39827,lativitta,39827_CAM041715_d.JPG,major
-CAM041714,https://zenodo.org/record/4291095/files/CAM041714_d.JPG,0,test,39823,lativitta,39823_CAM041714_d.JPG,major
-CAM041713,https://zenodo.org/record/4291095/files/CAM041713_d.JPG,0,test,39819,lativitta,39819_CAM041713_d.JPG,major
-CAM041712,https://zenodo.org/record/4291095/files/CAM041712_d.JPG,0,test,39815,lativitta,39815_CAM041712_d.JPG,major
-CAM041711,https://zenodo.org/record/4291095/files/CAM041711_d.JPG,0,test,39811,lativitta,39811_CAM041711_d.JPG,major
-CAM041710,https://zenodo.org/record/4291095/files/CAM041710_d.JPG,0,test,39807,lativitta,39807_CAM041710_d.JPG,major
-CAM041709,https://zenodo.org/record/4291095/files/CAM041709_d.JPG,0,test,39803,lativitta,39803_CAM041709_d.JPG,major
-CAM041708,https://zenodo.org/record/4291095/files/CAM041708_d.JPG,0,test,39799,lativitta,39799_CAM041708_d.JPG,major
-CAM041707,https://zenodo.org/record/4291095/files/CAM041707_d.JPG,0,test,39795,lativitta,39795_CAM041707_d.JPG,major
-CAM041706,https://zenodo.org/record/4291095/files/CAM041706_d.JPG,0,test,39791,lativitta,39791_CAM041706_d.JPG,major
-CAM041705,https://zenodo.org/record/4291095/files/CAM041705_d.JPG,0,test,39787,lativitta,39787_CAM041705_d.JPG,major
-CAM041704,https://zenodo.org/record/4291095/files/CAM041704_d.JPG,0,test,39783,lativitta,39783_CAM041704_d.JPG,major
-CAM041703,https://zenodo.org/record/4291095/files/CAM041703_d.JPG,0,test,39779,lativitta,39779_CAM041703_d.JPG,major
-CAM041702,https://zenodo.org/record/4291095/files/CAM041702_d.JPG,0,test,39775,lativitta,39775_CAM041702_d.JPG,major
-CAM041701,https://zenodo.org/record/4291095/files/CAM041701_d.JPG,0,test,39771,lativitta,39771_CAM041701_d.JPG,major
-CAM041724,https://zenodo.org/record/4291095/files/CAM041724_d.JPG,0,test,39863,lativitta,39863_CAM041724_d.JPG,major
-CAM041752,https://zenodo.org/record/4291095/files/CAM041752_d.JPG,0,test,39975,lativitta,39975_CAM041752_d.JPG,major
-CAM041725,https://zenodo.org/record/4291095/files/CAM041725_d.JPG,0,test,39867,lativitta,39867_CAM041725_d.JPG,major
-CAM041727,https://zenodo.org/record/4291095/files/CAM041727_d.JPG,0,test,39875,lativitta,39875_CAM041727_d.JPG,major
-CAM041750,https://zenodo.org/record/4291095/files/CAM041750_d.JPG,0,test,39967,lativitta,39967_CAM041750_d.JPG,major
-CAM041749,https://zenodo.org/record/4291095/files/CAM041749_d.JPG,0,test,39963,lativitta,39963_CAM041749_d.JPG,major
-CAM041748,https://zenodo.org/record/4291095/files/CAM041748_d.JPG,0,test,39959,lativitta,39959_CAM041748_d.JPG,major
-CAM041747,https://zenodo.org/record/4291095/files/CAM041747_d.JPG,0,test,39955,lativitta,39955_CAM041747_d.JPG,major
-CAM041746,https://zenodo.org/record/4291095/files/CAM041746_d.JPG,0,test,39951,lativitta,39951_CAM041746_d.JPG,major
-CAM041745,https://zenodo.org/record/4291095/files/CAM041745_d.JPG,0,test,39947,lativitta,39947_CAM041745_d.JPG,major
-CAM041744,https://zenodo.org/record/4291095/files/CAM041744_d.JPG,0,test,39943,lativitta,39943_CAM041744_d.JPG,major
-CAM041743,https://zenodo.org/record/4291095/files/CAM041743_d.JPG,0,test,39939,lativitta,39939_CAM041743_d.JPG,major
-CAM041742,https://zenodo.org/record/4291095/files/CAM041742_d.JPG,0,test,39935,lativitta,39935_CAM041742_d.JPG,major
-CAM041741,https://zenodo.org/record/4291095/files/CAM041741_d.JPG,0,test,39931,lativitta,39931_CAM041741_d.JPG,major
-CAM041740,https://zenodo.org/record/4291095/files/CAM041740_d.JPG,0,test,39927,lativitta,39927_CAM041740_d.JPG,major
-CAM041739,https://zenodo.org/record/4291095/files/CAM041739_d.JPG,0,test,39923,lativitta,39923_CAM041739_d.JPG,major
-CAM041738,https://zenodo.org/record/4291095/files/CAM041738_d.JPG,0,test,39919,lativitta,39919_CAM041738_d.JPG,major
-CAM041737,https://zenodo.org/record/4291095/files/CAM041737_d.JPG,0,test,39915,lativitta,39915_CAM041737_d.JPG,major
-CAM041736,https://zenodo.org/record/4291095/files/CAM041736_d.JPG,0,test,39911,lativitta,39911_CAM041736_d.JPG,major
-CAM041735,https://zenodo.org/record/4291095/files/CAM041735_d.JPG,0,test,39907,lativitta,39907_CAM041735_d.JPG,major
-CAM041734,https://zenodo.org/record/4291095/files/CAM041734_d.JPG,0,test,39903,lativitta,39903_CAM041734_d.JPG,major
-CAM041733,https://zenodo.org/record/4291095/files/CAM041733_d.JPG,0,test,39899,lativitta,39899_CAM041733_d.JPG,major
-CAM041732,https://zenodo.org/record/4291095/files/CAM041732_d.JPG,0,test,39895,lativitta,39895_CAM041732_d.JPG,major
-CAM041731,https://zenodo.org/record/4291095/files/CAM041731_d.JPG,0,test,39891,lativitta,39891_CAM041731_d.JPG,major
-CAM041730,https://zenodo.org/record/4291095/files/CAM041730_d.JPG,0,test,39887,lativitta,39887_CAM041730_d.JPG,major
-CAM041729,https://zenodo.org/record/4291095/files/CAM041729_d.JPG,0,test,39883,lativitta,39883_CAM041729_d.JPG,major
-CAM041728,https://zenodo.org/record/4291095/files/CAM041728_d.JPG,0,test,39879,lativitta,39879_CAM041728_d.JPG,major
-CAM041726,https://zenodo.org/record/4291095/files/CAM041726_d.JPG,0,test,39871,lativitta,39871_CAM041726_d.JPG,major
-CAM041806,https://zenodo.org/record/4291095/files/CAM041806_d.JPG,0,test,40191,lativitta,40191_CAM041806_d.JPG,major
-CAM041779,https://zenodo.org/record/4291095/files/CAM041779_d.JPG,0,test,40083,lativitta,40083_CAM041779_d.JPG,major
-CAM041808,https://zenodo.org/record/4291095/files/CAM041808_d.JPG,0,test,40199,lativitta,40199_CAM041808_d.JPG,major
-CAM041885,https://zenodo.org/record/4291095/files/CAM041885_d.JPG,0,test,40504,lativitta,40504_CAM041885_d.JPG,major
-CAM041884,https://zenodo.org/record/4291095/files/CAM041884_d.JPG,0,test,40500,lativitta,40500_CAM041884_d.JPG,major
-CAM041883,https://zenodo.org/record/4291095/files/CAM041883_d.JPG,0,test,40496,lativitta,40496_CAM041883_d.JPG,major
-CAM041882,https://zenodo.org/record/4291095/files/CAM041882_d.JPG,0,test,40492,lativitta,40492_CAM041882_d.JPG,major
-CAM041881,https://zenodo.org/record/4291095/files/CAM041881_d.JPG,0,test,40488,lativitta,40488_CAM041881_d.JPG,major
-CAM041880,https://zenodo.org/record/4291095/files/CAM041880_d.JPG,0,test,40484,lativitta,40484_CAM041880_d.JPG,major
-CAM041879,https://zenodo.org/record/4291095/files/CAM041879_d.JPG,0,test,40480,lativitta,40480_CAM041879_d.JPG,major
-CAM041878,https://zenodo.org/record/4291095/files/CAM041878_d.JPG,0,test,40476,lativitta,40476_CAM041878_d.JPG,major
-CAM041877,https://zenodo.org/record/4291095/files/CAM041877_d.JPG,0,test,40472,lativitta,40472_CAM041877_d.JPG,major
-CAM041876,https://zenodo.org/record/4291095/files/CAM041876_d.JPG,0,test,40468,lativitta,40468_CAM041876_d.JPG,major
-CAM041886,https://zenodo.org/record/4291095/files/CAM041886_d.JPG,0,test,40508,lativitta,40508_CAM041886_d.JPG,major
-CAM041875,https://zenodo.org/record/4291095/files/CAM041875_d.JPG,0,test,40464,lativitta,40464_CAM041875_d.JPG,major
-CAM041873,https://zenodo.org/record/4291095/files/CAM041873_d.JPG,0,test,40456,lativitta,40456_CAM041873_d.JPG,major
-CAM041872,https://zenodo.org/record/4291095/files/CAM041872_d.JPG,0,test,40452,lativitta,40452_CAM041872_d.JPG,major
-CAM041871,https://zenodo.org/record/4291095/files/CAM041871_d.JPG,0,test,40448,lativitta,40448_CAM041871_d.JPG,major
-CAM041870,https://zenodo.org/record/4291095/files/CAM041870_d.JPG,0,test,40444,lativitta,40444_CAM041870_d.JPG,major
-CAM041869,https://zenodo.org/record/4291095/files/CAM041869_d.JPG,0,test,40440,lativitta,40440_CAM041869_d.JPG,major
-CAM041868,https://zenodo.org/record/4291095/files/CAM041868_d.JPG,0,test,40436,lativitta,40436_CAM041868_d.JPG,major
-CAM041867,https://zenodo.org/record/4291095/files/CAM041867_d.JPG,0,test,40432,lativitta,40432_CAM041867_d.JPG,major
-CAM041866,https://zenodo.org/record/4291095/files/CAM041866_d.JPG,0,test,40428,lativitta,40428_CAM041866_d.JPG,major
-CAM041865,https://zenodo.org/record/4291095/files/CAM041865_d.JPG,0,test,40424,lativitta,40424_CAM041865_d.JPG,major
-CAM041864,https://zenodo.org/record/4291095/files/CAM041864_d.JPG,0,test,40420,lativitta,40420_CAM041864_d.JPG,major
-CAM041874,https://zenodo.org/record/4291095/files/CAM041874_d.JPG,0,test,40460,lativitta,40460_CAM041874_d.JPG,major
-CAM041888,https://zenodo.org/record/4291095/files/CAM041888_d.JPG,0,test,40516,lativitta,40516_CAM041888_d.JPG,major
-CAM041807,https://zenodo.org/record/4291095/files/CAM041807_d.JPG,0,test,40195,lativitta,40195_CAM041807_d.JPG,major
-CAM041890,https://zenodo.org/record/4291095/files/CAM041890_d.JPG,0,test,40524,lativitta,40524_CAM041890_d.JPG,major
-CAM041354,https://zenodo.org/record/4291095/files/CAM041354_d.JPG,0,test,38396,lativitta,38396_CAM041354_d.JPG,major
-CAM041912,https://zenodo.org/record/4291095/files/CAM041912_d.JPG,0,test,40612,lativitta,40612_CAM041912_d.JPG,major
-CAM041911,https://zenodo.org/record/4291095/files/CAM041911_d.JPG,0,test,40608,lativitta,40608_CAM041911_d.JPG,major
-CAM041910,https://zenodo.org/record/4291095/files/CAM041910_d.JPG,0,test,40604,lativitta,40604_CAM041910_d.JPG,major
-CAM041909,https://zenodo.org/record/4291095/files/CAM041909_d.JPG,0,test,40600,lativitta,40600_CAM041909_d.JPG,major
-CAM041908,https://zenodo.org/record/4291095/files/CAM041908_d.JPG,0,test,40596,lativitta,40596_CAM041908_d.JPG,major
-CAM041907,https://zenodo.org/record/4291095/files/CAM041907_d.JPG,0,test,40592,lativitta,40592_CAM041907_d.JPG,major
-CAM041906,https://zenodo.org/record/4291095/files/CAM041906_d.JPG,0,test,40588,lativitta,40588_CAM041906_d.JPG,major
-CAM041905,https://zenodo.org/record/4291095/files/CAM041905_d.JPG,0,test,40584,lativitta,40584_CAM041905_d.JPG,major
-CAM041904,https://zenodo.org/record/4291095/files/CAM041904_d.JPG,0,test,40580,lativitta,40580_CAM041904_d.JPG,major
-CAM041903,https://zenodo.org/record/4291095/files/CAM041903_d.JPG,0,test,40576,lativitta,40576_CAM041903_d.JPG,major
-CAM041902,https://zenodo.org/record/4291095/files/CAM041902_d.JPG,0,test,40572,lativitta,40572_CAM041902_d.JPG,major
-CAM041901,https://zenodo.org/record/4291095/files/CAM041901_d.JPG,0,test,40568,lativitta,40568_CAM041901_d.JPG,major
-CAM041900,https://zenodo.org/record/4291095/files/CAM041900_d.JPG,0,test,40564,lativitta,40564_CAM041900_d.JPG,major
-CAM041899,https://zenodo.org/record/4291095/files/CAM041899_d.JPG,0,test,40560,lativitta,40560_CAM041899_d.JPG,major
-CAM041898,https://zenodo.org/record/4291095/files/CAM041898_d.JPG,0,test,40556,lativitta,40556_CAM041898_d.JPG,major
-CAM041897,https://zenodo.org/record/4291095/files/CAM041897_d.JPG,0,test,40552,lativitta,40552_CAM041897_d.JPG,major
-CAM041896,https://zenodo.org/record/4291095/files/CAM041896_d.JPG,0,test,40548,lativitta,40548_CAM041896_d.JPG,major
-CAM041895,https://zenodo.org/record/4291095/files/CAM041895_d.JPG,0,test,40544,lativitta,40544_CAM041895_d.JPG,major
-CAM041894,https://zenodo.org/record/4291095/files/CAM041894_d.JPG,0,test,40540,lativitta,40540_CAM041894_d.JPG,major
-CAM041893,https://zenodo.org/record/4291095/files/CAM041893_d.JPG,0,test,40536,lativitta,40536_CAM041893_d.JPG,major
-CAM041892,https://zenodo.org/record/4291095/files/CAM041892_d.JPG,0,test,40532,lativitta,40532_CAM041892_d.JPG,major
-CAM041891,https://zenodo.org/record/4291095/files/CAM041891_d.JPG,0,test,40528,lativitta,40528_CAM041891_d.JPG,major
-CAM041863,https://zenodo.org/record/4291095/files/CAM041863_d.JPG,0,test,40416,lativitta,40416_CAM041863_d.JPG,major
-CAM041862,https://zenodo.org/record/4291095/files/CAM041862_d.JPG,0,test,40412,lativitta,40412_CAM041862_d.JPG,major
-CAM041889,https://zenodo.org/record/4291095/files/CAM041889_d.JPG,0,test,40520,lativitta,40520_CAM041889_d.JPG,major
-CAM041860,https://zenodo.org/record/4291095/files/CAM041860_d.JPG,0,test,40404,lativitta,40404_CAM041860_d.JPG,major
-CAM041831,https://zenodo.org/record/4291095/files/CAM041831_d.JPG,0,test,40291,lativitta,40291_CAM041831_d.JPG,major
-CAM041830,https://zenodo.org/record/4291095/files/CAM041830_d.JPG,0,test,40287,lativitta,40287_CAM041830_d.JPG,major
-CAM041829,https://zenodo.org/record/4291095/files/CAM041829_d.JPG,0,test,40283,lativitta,40283_CAM041829_d.JPG,major
-CAM041828,https://zenodo.org/record/4291095/files/CAM041828_d.JPG,0,test,40279,lativitta,40279_CAM041828_d.JPG,major
-CAM041827,https://zenodo.org/record/4291095/files/CAM041827_d.JPG,0,test,40275,lativitta,40275_CAM041827_d.JPG,major
-CAM041826,https://zenodo.org/record/4291095/files/CAM041826_d.JPG,0,test,40271,lativitta,40271_CAM041826_d.JPG,major
-CAM041825,https://zenodo.org/record/4291095/files/CAM041825_d.JPG,0,test,40267,lativitta,40267_CAM041825_d.JPG,major
-CAM041824,https://zenodo.org/record/4291095/files/CAM041824_d.JPG,0,test,40263,lativitta,40263_CAM041824_d.JPG,major
-CAM041823,https://zenodo.org/record/4291095/files/CAM041823_d.JPG,0,test,40259,lativitta,40259_CAM041823_d.JPG,major
-CAM041822,https://zenodo.org/record/4291095/files/CAM041822_d.JPG,0,test,40255,lativitta,40255_CAM041822_d.JPG,major
-CAM041820,https://zenodo.org/record/4291095/files/CAM041820_d.JPG,0,test,40247,lativitta,40247_CAM041820_d.JPG,major
-CAM041819,https://zenodo.org/record/4291095/files/CAM041819_d.JPG,0,test,40243,lativitta,40243_CAM041819_d.JPG,major
-CAM041818,https://zenodo.org/record/4291095/files/CAM041818_d.JPG,0,test,40239,lativitta,40239_CAM041818_d.JPG,major
-CAM041817,https://zenodo.org/record/4291095/files/CAM041817_d.JPG,0,test,40235,lativitta,40235_CAM041817_d.JPG,major
-CAM041816,https://zenodo.org/record/4291095/files/CAM041816_d.JPG,0,test,40231,lativitta,40231_CAM041816_d.JPG,major
-CAM041815,https://zenodo.org/record/4291095/files/CAM041815_d.JPG,0,test,40227,lativitta,40227_CAM041815_d.JPG,major
-CAM041814,https://zenodo.org/record/4291095/files/CAM041814_d.JPG,0,test,40223,lativitta,40223_CAM041814_d.JPG,major
-CAM041813,https://zenodo.org/record/4291095/files/CAM041813_d.JPG,0,test,40219,lativitta,40219_CAM041813_d.JPG,major
-CAM041812,https://zenodo.org/record/4291095/files/CAM041812_d.JPG,0,test,40215,lativitta,40215_CAM041812_d.JPG,major
-CAM041811,https://zenodo.org/record/4291095/files/CAM041811_d.JPG,0,test,40211,lativitta,40211_CAM041811_d.JPG,major
-CAM041810,https://zenodo.org/record/4291095/files/CAM041810_d.JPG,0,test,40207,lativitta,40207_CAM041810_d.JPG,major
-CAM041861,https://zenodo.org/record/4291095/files/CAM041861_d.JPG,0,test,40408,lativitta,40408_CAM041861_d.JPG,major
-CAM041809,https://zenodo.org/record/4291095/files/CAM041809_d.JPG,0,test,40203,lativitta,40203_CAM041809_d.JPG,major
-CAM041832,https://zenodo.org/record/4291095/files/CAM041832_d.JPG,0,test,40295,lativitta,40295_CAM041832_d.JPG,major
-CAM041833,https://zenodo.org/record/4291095/files/CAM041833_d.JPG,0,test,40299,lativitta,40299_CAM041833_d.JPG,major
-CAM041821,https://zenodo.org/record/4291095/files/CAM041821_d.JPG,0,test,40251,lativitta,40251_CAM041821_d.JPG,major
-CAM041851,https://zenodo.org/record/4291095/files/CAM041851_d.JPG,0,test,40371,lativitta,40371_CAM041851_d.JPG,major
-CAM041859,https://zenodo.org/record/4291095/files/CAM041859_d.JPG,0,test,40400,lativitta,40400_CAM041859_d.JPG,major
-CAM041834,https://zenodo.org/record/4291095/files/CAM041834_d.JPG,0,test,40303,lativitta,40303_CAM041834_d.JPG,major
-CAM041857,https://zenodo.org/record/4291095/files/CAM041857_d.JPG,0,test,40392,lativitta,40392_CAM041857_d.JPG,major
-CAM041856,https://zenodo.org/record/4291095/files/CAM041856_d.JPG,0,test,40388,lativitta,40388_CAM041856_d.JPG,major
-CAM041855,https://zenodo.org/record/4291095/files/CAM041855_d.JPG,0,test,40384,lativitta,40384_CAM041855_d.JPG,major
-CAM041853,https://zenodo.org/record/4291095/files/CAM041853_d.JPG,0,test,40379,lativitta,40379_CAM041853_d.JPG,major
-CAM041852,https://zenodo.org/record/4291095/files/CAM041852_d.JPG,0,test,40375,lativitta,40375_CAM041852_d.JPG,major
-CAM041850,https://zenodo.org/record/4291095/files/CAM041850_d.JPG,0,test,40367,lativitta,40367_CAM041850_d.JPG,major
-CAM041849,https://zenodo.org/record/4291095/files/CAM041849_d.JPG,0,test,40363,lativitta,40363_CAM041849_d.JPG,major
-CAM041848,https://zenodo.org/record/4291095/files/CAM041848_d.JPG,0,test,40359,lativitta,40359_CAM041848_d.JPG,major
-CAM041858,https://zenodo.org/record/4291095/files/CAM041858_d.JPG,0,test,40396,lativitta,40396_CAM041858_d.JPG,major
-CAM041846,https://zenodo.org/record/4291095/files/CAM041846_d.JPG,0,test,40351,lativitta,40351_CAM041846_d.JPG,major
-CAM041847,https://zenodo.org/record/4291095/files/CAM041847_d.JPG,0,test,40355,lativitta,40355_CAM041847_d.JPG,major
-CAM041845,https://zenodo.org/record/4291095/files/CAM041845_d.JPG,0,test,40347,lativitta,40347_CAM041845_d.JPG,major
-CAM041844,https://zenodo.org/record/4291095/files/CAM041844_d.JPG,0,test,40343,lativitta,40343_CAM041844_d.JPG,major
-CAM041843,https://zenodo.org/record/4291095/files/CAM041843_d.JPG,0,test,40339,lativitta,40339_CAM041843_d.JPG,major
-CAM041842,https://zenodo.org/record/4291095/files/CAM041842_d.JPG,0,test,40335,lativitta,40335_CAM041842_d.JPG,major
-CAM041841,https://zenodo.org/record/4291095/files/CAM041841_d.JPG,0,test,40331,lativitta,40331_CAM041841_d.JPG,major
-CAM041840,https://zenodo.org/record/4291095/files/CAM041840_d.JPG,0,test,40327,lativitta,40327_CAM041840_d.JPG,major
-CAM041839,https://zenodo.org/record/4291095/files/CAM041839_d.JPG,0,test,40323,lativitta,40323_CAM041839_d.JPG,major
-CAM041838,https://zenodo.org/record/4291095/files/CAM041838_d.JPG,0,test,40319,lativitta,40319_CAM041838_d.JPG,major
-CAM041837,https://zenodo.org/record/4291095/files/CAM041837_d.JPG,0,test,40315,lativitta,40315_CAM041837_d.JPG,major
-CAM041836,https://zenodo.org/record/4291095/files/CAM041836_d.JPG,0,test,40311,lativitta,40311_CAM041836_d.JPG,major
-CAM041835,https://zenodo.org/record/4291095/files/CAM041835_d.JPG,0,test,40307,lativitta,40307_CAM041835_d.JPG,major
-CAM045262,https://zenodo.org/record/5526257/files/CAM045262_d.JPG,0,test,43611,cyrbia,43611_CAM045262_d.JPG,minor
-CAM045263,https://zenodo.org/record/5526257/files/CAM045263_d.JPG,0,test,43615,cyrbia,43615_CAM045263_d.JPG,minor
-CAM045248,https://zenodo.org/record/5526257/files/CAM045248_d.JPG,0,test,43555,cyrbia,43555_CAM045248_d.JPG,minor
-CAM045264,https://zenodo.org/record/5526257/files/CAM045264_d.JPG,0,test,43619,cyrbia,43619_CAM045264_d.JPG,minor
-CAM045230,https://zenodo.org/record/5526257/files/CAM045230_d.JPG,0,test,43483,cyrbia,43483_CAM045230_d.JPG,minor
-CAM045228,https://zenodo.org/record/5526257/files/CAM045228_d.JPG,0,test,43475,cyrbia,43475_CAM045228_d.JPG,minor
-CAM045136,https://zenodo.org/record/5526257/files/CAM045136_d.JPG,0,test,43111,cyrbia,43111_CAM045136_d.JPG,minor
-CAM045199,https://zenodo.org/record/5526257/files/CAM045199_d.JPG,0,test,43361,cyrbia,43361_CAM045199_d.JPG,minor
-CAM045200,https://zenodo.org/record/5526257/files/CAM045200_d.JPG,0,test,43365,cyrbia,43365_CAM045200_d.JPG,minor
-CAM045201,https://zenodo.org/record/5526257/files/CAM045201_d.JPG,0,test,43367,cyrbia,43367_CAM045201_d.JPG,minor
-CAM045202,https://zenodo.org/record/5526257/files/CAM045202_d.JPG,0,test,43371,cyrbia,43371_CAM045202_d.JPG,minor
-CAM045203,https://zenodo.org/record/5526257/files/CAM045203_d.JPG,0,test,43375,cyrbia,43375_CAM045203_d.JPG,minor
-CAM045204,https://zenodo.org/record/5526257/files/CAM045204_d.JPG,0,test,43379,cyrbia,43379_CAM045204_d.JPG,minor
-CAM045205,https://zenodo.org/record/5526257/files/CAM045205_d.JPG,0,test,43383,cyrbia,43383_CAM045205_d.JPG,minor
-CAM045206,https://zenodo.org/record/5526257/files/CAM045206_d.JPG,0,test,43387,cyrbia,43387_CAM045206_d.JPG,minor
-CAM045207,https://zenodo.org/record/5526257/files/CAM045207_d.JPG,0,test,43391,cyrbia,43391_CAM045207_d.JPG,minor
-CAM045208,https://zenodo.org/record/5526257/files/CAM045208_d.JPG,0,test,43395,cyrbia,43395_CAM045208_d.JPG,minor
-CAM045209,https://zenodo.org/record/5526257/files/CAM045209_d.JPG,0,test,43399,cyrbia,43399_CAM045209_d.JPG,minor
-CAM045210,https://zenodo.org/record/5526257/files/CAM045210_d.JPG,0,test,43403,cyrbia,43403_CAM045210_d.JPG,minor
-CAM045211,https://zenodo.org/record/5526257/files/CAM045211_d.JPG,0,test,43407,cyrbia,43407_CAM045211_d.JPG,minor
-CAM045229,https://zenodo.org/record/5526257/files/CAM045229_d.JPG,0,test,43479,cyrbia,43479_CAM045229_d.JPG,minor
-CAM045212,https://zenodo.org/record/5526257/files/CAM045212_d.JPG,0,test,43411,cyrbia,43411_CAM045212_d.JPG,minor
-CAM045214,https://zenodo.org/record/5526257/files/CAM045214_d.JPG,0,test,43419,cyrbia,43419_CAM045214_d.JPG,minor
-CAM045215,https://zenodo.org/record/5526257/files/CAM045215_d.JPG,0,test,43423,cyrbia,43423_CAM045215_d.JPG,minor
-CAM045216,https://zenodo.org/record/5526257/files/CAM045216_d.JPG,0,test,43427,cyrbia,43427_CAM045216_d.JPG,minor
-CAM045217,https://zenodo.org/record/5526257/files/CAM045217_d.JPG,0,test,43431,cyrbia,43431_CAM045217_d.JPG,minor
-CAM045218,https://zenodo.org/record/5526257/files/CAM045218_d.JPG,0,test,43435,cyrbia,43435_CAM045218_d.JPG,minor
-CAM045219,https://zenodo.org/record/5526257/files/CAM045219_d.JPG,0,test,43439,cyrbia,43439_CAM045219_d.JPG,minor
-CAM045220,https://zenodo.org/record/5526257/files/CAM045220_d.JPG,0,test,43443,cyrbia,43443_CAM045220_d.JPG,minor
-CAM045221,https://zenodo.org/record/5526257/files/CAM045221_d.JPG,0,test,43447,cyrbia,43447_CAM045221_d.JPG,minor
-CAM045222,https://zenodo.org/record/5526257/files/CAM045222_d.JPG,0,test,43451,cyrbia,43451_CAM045222_d.JPG,minor
-CAM045223,https://zenodo.org/record/5526257/files/CAM045223_d.JPG,0,test,43455,cyrbia,43455_CAM045223_d.JPG,minor
-CAM045224,https://zenodo.org/record/5526257/files/CAM045224_d.JPG,0,test,43459,cyrbia,43459_CAM045224_d.JPG,minor
-CAM045225,https://zenodo.org/record/5526257/files/CAM045225_d.JPG,0,test,43463,cyrbia,43463_CAM045225_d.JPG,minor
-CAM045226,https://zenodo.org/record/5526257/files/CAM045226_d.JPG,0,test,43467,cyrbia,43467_CAM045226_d.JPG,minor
-CAM045227,https://zenodo.org/record/5526257/files/CAM045227_d.JPG,0,test,43471,cyrbia,43471_CAM045227_d.JPG,minor
-CAM045213,https://zenodo.org/record/5526257/files/CAM045213_d.JPG,0,test,43415,cyrbia,43415_CAM045213_d.JPG,minor
-CAM045265,https://zenodo.org/record/5526257/files/CAM045265_d.JPG,0,test,43623,cyrbia,43623_CAM045265_d.JPG,minor
-CAM045251,https://zenodo.org/record/5526257/files/CAM045251_d.JPG,0,test,43567,cyrbia,43567_CAM045251_d.JPG,minor
-CAM045198,https://zenodo.org/record/5526257/files/CAM045198_d.JPG,0,test,43357,cyrbia,43357_CAM045198_d.JPG,minor
-CAM045168,https://zenodo.org/record/5526257/files/CAM045168_d.JPG,0,test,43237,cyrbia,43237_CAM045168_d.JPG,minor
-CAM045167,https://zenodo.org/record/5526257/files/CAM045167_d.JPG,0,test,43233,cyrbia,43233_CAM045167_d.JPG,minor
-CAM045166,https://zenodo.org/record/5526257/files/CAM045166_d.JPG,0,test,43229,cyrbia,43229_CAM045166_d.JPG,minor
-CAM045165,https://zenodo.org/record/5526257/files/CAM045165_d.JPG,0,test,43225,cyrbia,43225_CAM045165_d.JPG,minor
-CAM045164,https://zenodo.org/record/5526257/files/CAM045164_d.JPG,0,test,43221,cyrbia,43221_CAM045164_d.JPG,minor
-CAM045163,https://zenodo.org/record/5526257/files/CAM045163_d.JPG,0,test,43217,cyrbia,43217_CAM045163_d.JPG,minor
-CAM045162,https://zenodo.org/record/5526257/files/CAM045162_d.JPG,0,test,43213,cyrbia,43213_CAM045162_d.JPG,minor
-CAM045161,https://zenodo.org/record/5526257/files/CAM045161_d.JPG,0,test,43209,cyrbia,43209_CAM045161_d.JPG,minor
-CAM045160,https://zenodo.org/record/5526257/files/CAM045160_d.JPG,0,test,43205,cyrbia,43205_CAM045160_d.JPG,minor
-CAM045159,https://zenodo.org/record/5526257/files/CAM045159_d.JPG,0,test,43201,cyrbia,43201_CAM045159_d.JPG,minor
-CAM045158,https://zenodo.org/record/5526257/files/CAM045158_d.JPG,0,test,43197,cyrbia,43197_CAM045158_d.JPG,minor
-CAM045157,https://zenodo.org/record/5526257/files/CAM045157_d.JPG,0,test,43193,cyrbia,43193_CAM045157_d.JPG,minor
-CAM045266,https://zenodo.org/record/5526257/files/CAM045266_d.JPG,0,test,43627,cyrbia,43627_CAM045266_d.JPG,minor
-CAM045155,https://zenodo.org/record/5526257/files/CAM045155_d.JPG,0,test,43187,cyrbia,43187_CAM045155_d.JPG,minor
-CAM045154,https://zenodo.org/record/5526257/files/CAM045154_d.JPG,0,test,43183,cyrbia,43183_CAM045154_d.JPG,minor
-CAM045153,https://zenodo.org/record/5526257/files/CAM045153_d.JPG,0,test,43179,cyrbia,43179_CAM045153_d.JPG,minor
-CAM045152,https://zenodo.org/record/5526257/files/CAM045152_d.JPG,0,test,43175,cyrbia,43175_CAM045152_d.JPG,minor
-CAM045138,https://zenodo.org/record/5526257/files/CAM045138_d.JPG,0,test,43119,cyrbia,43119_CAM045138_d.JPG,minor
-CAM045139,https://zenodo.org/record/5526257/files/CAM045139_d.JPG,0,test,43123,cyrbia,43123_CAM045139_d.JPG,minor
-CAM045140,https://zenodo.org/record/5526257/files/CAM045140_d.JPG,0,test,43127,cyrbia,43127_CAM045140_d.JPG,minor
-CAM045141,https://zenodo.org/record/5526257/files/CAM045141_d.JPG,0,test,43131,cyrbia,43131_CAM045141_d.JPG,minor
-CAM045142,https://zenodo.org/record/5526257/files/CAM045142_d.JPG,0,test,43135,cyrbia,43135_CAM045142_d.JPG,minor
-CAM045143,https://zenodo.org/record/5526257/files/CAM045143_d.JPG,0,test,43139,cyrbia,43139_CAM045143_d.JPG,minor
-CAM045169,https://zenodo.org/record/5526257/files/CAM045169_d.JPG,0,test,43241,cyrbia,43241_CAM045169_d.JPG,minor
-CAM045144,https://zenodo.org/record/5526257/files/CAM045144_d.JPG,0,test,43143,cyrbia,43143_CAM045144_d.JPG,minor
-CAM045146,https://zenodo.org/record/5526257/files/CAM045146_d.JPG,0,test,43151,cyrbia,43151_CAM045146_d.JPG,minor
-CAM045147,https://zenodo.org/record/5526257/files/CAM045147_d.JPG,0,test,43155,cyrbia,43155_CAM045147_d.JPG,minor
-CAM045148,https://zenodo.org/record/5526257/files/CAM045148_d.JPG,0,test,43159,cyrbia,43159_CAM045148_d.JPG,minor
-CAM045149,https://zenodo.org/record/5526257/files/CAM045149_d.JPG,0,test,43163,cyrbia,43163_CAM045149_d.JPG,minor
-CAM045150,https://zenodo.org/record/5526257/files/CAM045150_d.JPG,0,test,43167,cyrbia,43167_CAM045150_d.JPG,minor
-CAM045151,https://zenodo.org/record/5526257/files/CAM045151_d.JPG,0,test,43171,cyrbia,43171_CAM045151_d.JPG,minor
-CAM045145,https://zenodo.org/record/5526257/files/CAM045145_d.JPG,0,test,43147,cyrbia,43147_CAM045145_d.JPG,minor
-CAM045170,https://zenodo.org/record/5526257/files/CAM045170_d.JPG,0,test,43245,cyrbia,43245_CAM045170_d.JPG,minor
-CAM045156,https://zenodo.org/record/5526257/files/CAM045156_d.JPG,0,test,43191,cyrbia,43191_CAM045156_d.JPG,minor
-CAM045172,https://zenodo.org/record/5526257/files/CAM045172_d.JPG,0,test,43253,cyrbia,43253_CAM045172_d.JPG,minor
-CAM045267,https://zenodo.org/record/5526257/files/CAM045267_d.JPG,0,test,43631,cyrbia,43631_CAM045267_d.JPG,minor
-CAM045171,https://zenodo.org/record/5526257/files/CAM045171_d.JPG,0,test,43249,cyrbia,43249_CAM045171_d.JPG,minor
-CAM045269,https://zenodo.org/record/5526257/files/CAM045269_d.JPG,0,test,43639,cyrbia,43639_CAM045269_d.JPG,minor
-CAM045270,https://zenodo.org/record/5526257/files/CAM045270_d.JPG,0,test,43643,cyrbia,43643_CAM045270_d.JPG,minor
-CAM045271,https://zenodo.org/record/5526257/files/CAM045271_d.JPG,0,test,43647,cyrbia,43647_CAM045271_d.JPG,minor
-CAM045197,https://zenodo.org/record/5526257/files/CAM045197_d.JPG,0,test,43353,cyrbia,43353_CAM045197_d.JPG,minor
-CAM045196,https://zenodo.org/record/5526257/files/CAM045196_d.JPG,0,test,43349,cyrbia,43349_CAM045196_d.JPG,minor
-CAM045195,https://zenodo.org/record/5526257/files/CAM045195_d.JPG,0,test,43345,cyrbia,43345_CAM045195_d.JPG,minor
-CAM045194,https://zenodo.org/record/5526257/files/CAM045194_d.JPG,0,test,43341,cyrbia,43341_CAM045194_d.JPG,minor
-CAM045193,https://zenodo.org/record/5526257/files/CAM045193_d.JPG,0,test,43337,cyrbia,43337_CAM045193_d.JPG,minor
-CAM045192,https://zenodo.org/record/5526257/files/CAM045192_d.JPG,0,test,43333,cyrbia,43333_CAM045192_d.JPG,minor
-CAM045191,https://zenodo.org/record/5526257/files/CAM045191_d.JPG,0,test,43329,cyrbia,43329_CAM045191_d.JPG,minor
-CAM045190,https://zenodo.org/record/5526257/files/CAM045190_d.JPG,0,test,43325,cyrbia,43325_CAM045190_d.JPG,minor
-CAM045189,https://zenodo.org/record/5526257/files/CAM045189_d.JPG,0,test,43321,cyrbia,43321_CAM045189_d.JPG,minor
-CAM045188,https://zenodo.org/record/5526257/files/CAM045188_d.JPG,0,test,43317,cyrbia,43317_CAM045188_d.JPG,minor
-CAM045268,https://zenodo.org/record/5526257/files/CAM045268_d.JPG,0,test,43635,cyrbia,43635_CAM045268_d.JPG,minor
-CAM045186,https://zenodo.org/record/5526257/files/CAM045186_d.JPG,0,test,43309,cyrbia,43309_CAM045186_d.JPG,minor
-CAM045187,https://zenodo.org/record/5526257/files/CAM045187_d.JPG,0,test,43313,cyrbia,43313_CAM045187_d.JPG,minor
-CAM045174,https://zenodo.org/record/5526257/files/CAM045174_d.JPG,0,test,43261,cyrbia,43261_CAM045174_d.JPG,minor
-CAM045175,https://zenodo.org/record/5526257/files/CAM045175_d.JPG,0,test,43265,cyrbia,43265_CAM045175_d.JPG,minor
-CAM045176,https://zenodo.org/record/5526257/files/CAM045176_d.JPG,0,test,43269,cyrbia,43269_CAM045176_d.JPG,minor
-CAM045177,https://zenodo.org/record/5526257/files/CAM045177_d.JPG,0,test,43273,cyrbia,43273_CAM045177_d.JPG,minor
-CAM045178,https://zenodo.org/record/5526257/files/CAM045178_d.JPG,0,test,43277,cyrbia,43277_CAM045178_d.JPG,minor
-CAM045179,https://zenodo.org/record/5526257/files/CAM045179_d.JPG,0,test,43281,cyrbia,43281_CAM045179_d.JPG,minor
-CAM045173,https://zenodo.org/record/5526257/files/CAM045173_d.JPG,0,test,43257,cyrbia,43257_CAM045173_d.JPG,minor
-CAM045181,https://zenodo.org/record/5526257/files/CAM045181_d.JPG,0,test,43289,cyrbia,43289_CAM045181_d.JPG,minor
-CAM045182,https://zenodo.org/record/5526257/files/CAM045182_d.JPG,0,test,43293,cyrbia,43293_CAM045182_d.JPG,minor
-CAM045183,https://zenodo.org/record/5526257/files/CAM045183_d.JPG,0,test,43297,cyrbia,43297_CAM045183_d.JPG,minor
-CAM045184,https://zenodo.org/record/5526257/files/CAM045184_d.JPG,0,test,43301,cyrbia,43301_CAM045184_d.JPG,minor
-CAM045185,https://zenodo.org/record/5526257/files/CAM045185_d.JPG,0,test,43305,cyrbia,43305_CAM045185_d.JPG,minor
-CAM045180,https://zenodo.org/record/5526257/files/CAM045180_d.JPG,0,test,43285,cyrbia,43285_CAM045180_d.JPG,minor
-CAM036275,https://zenodo.org/record/5561246/files/CAM036275_d.JPG,0,test,41755,phyllis,41755_CAM036275_d.JPG,minor
-CAM036274,https://zenodo.org/record/5561246/files/CAM036274_d.JPG,0,test,41751,phyllis,41751_CAM036274_d.JPG,minor
-CAM036260,https://zenodo.org/record/5561246/files/CAM036260_d.JPG,0,test,41719,phyllis,41719_CAM036260_d.JPG,minor
-CAM036257,https://zenodo.org/record/5561246/files/CAM036257_d.JPG,0,test,41707,phyllis,41707_CAM036257_d.JPG,minor
-CAM036256,https://zenodo.org/record/5561246/files/CAM036256_d.JPG,0,test,41703,phyllis,41703_CAM036256_d.JPG,minor
-CAM036255,https://zenodo.org/record/5561246/files/CAM036255_d.JPG,0,test,41699,phyllis,41699_CAM036255_d.JPG,minor
-CAM036254,https://zenodo.org/record/5561246/files/CAM036254_d.JPG,0,test,41695,phyllis,41695_CAM036254_d.JPG,minor
-CAM036253,https://zenodo.org/record/5561246/files/CAM036253_d.JPG,0,test,41691,phyllis,41691_CAM036253_d.JPG,minor
-CAM036232,https://zenodo.org/record/5561246/files/CAM036232_d.JPG,0,test,41639,phyllis,41639_CAM036232_d.JPG,minor
-CAM036231,https://zenodo.org/record/5561246/files/CAM036231_d.JPG,0,test,41635,phyllis,41635_CAM036231_d.JPG,minor
-CAM036230,https://zenodo.org/record/5561246/files/CAM036230_d.JPG,0,test,41631,phyllis,41631_CAM036230_d.JPG,minor
-CAM036229,https://zenodo.org/record/5561246/files/CAM036229_d.JPG,0,test,41627,phyllis,41627_CAM036229_d.JPG,minor
-CAM036226,https://zenodo.org/record/5561246/files/CAM036226_d.JPG,0,test,41615,phyllis,41615_CAM036226_d.JPG,minor
-CAM036225,https://zenodo.org/record/5561246/files/CAM036225_d.JPG,0,test,41611,phyllis,41611_CAM036225_d.JPG,minor
-CAM036587,https://zenodo.org/record/5561246/files/CAM036587_d.JPG,0,test,42515,phyllis,42515_CAM036587_d.JPG,minor
-CAM017800,https://zenodo.org/record/1748277/files/CAM017800_v_whitestandard.JPG,0,test-2,16459,plesseni,16459_CAM017800_v_whitestandard.JPG,mimic
-CAM017908,https://zenodo.org/record/1748277/files/CAM017908_v_whitestandard.JPG,0,test-2,16887,malleti,16887_CAM017908_v_whitestandard.JPG,mimic
-CAM017449,https://zenodo.org/record/1748277/files/CAM017449_d_whitestandard.JPG,0,test-2,15259,malleti,15259_CAM017449_d_whitestandard.JPG,mimic
-CAM017453,https://zenodo.org/record/1748277/files/CAM017453_d_whitestandard.JPG,0,test-2,15275,plesseni,15275_CAM017453_d_whitestandard.JPG,mimic
-CAM017455,https://zenodo.org/record/1748277/files/CAM017455_d_whitestandard.JPG,0,test-2,15283,malleti,15283_CAM017455_d_whitestandard.JPG,mimic
-CAM017458,https://zenodo.org/record/1748277/files/CAM017458_d_whitestandard.JPG,0,test-2,15295,plesseni,15295_CAM017458_d_whitestandard.JPG,mimic
-CAM017704,https://zenodo.org/record/1748277/files/CAM017704_d_whitestandard.JPG,0,test-2,16079,plesseni,16079_CAM017704_d_whitestandard.JPG,mimic
-CAM018268,https://zenodo.org/record/2548678/files/CAM018268_v_whitestandard.JPG,0,test-2,17501,plesseni,17501_CAM018268_v_whitestandard.JPG,mimic
-CAM018282,https://zenodo.org/record/2548678/files/CAM018282_v_whitestandard.JPG,0,test-2,17557,malleti,17557_CAM018282_v_whitestandard.JPG,mimic
-CAM018353,https://zenodo.org/record/2548678/files/CAM018353_v_whitestandard.JPG,0,test-2,17829,malleti,17829_CAM018353_v_whitestandard.JPG,mimic
-CAM018339,https://zenodo.org/record/2548678/files/CAM018339_v_whitestandard.JPG,0,test-2,17773,plesseni,17773_CAM018339_v_whitestandard.JPG,mimic
-CAM018357,https://zenodo.org/record/2548678/files/CAM018357_v_whitestandard.JPG,1,test-2,17845,plesseni x malleti,17845_CAM018357_v_whitestandard.JPG,mimic
-CAM018438,https://zenodo.org/record/2548678/files/CAM018438_v_whitestandard.JPG,0,test-2,18165,malleti,18165_CAM018438_v_whitestandard.JPG,mimic
-CAM018447,https://zenodo.org/record/2548678/files/CAM018447_v_whitestandard.JPG,0,test-2,18201,plesseni,18201_CAM018447_v_whitestandard.JPG,mimic
-CAM018528,https://zenodo.org/record/2548678/files/CAM018528_v_whitestandard.JPG,0,test-2,18525,malleti,18525_CAM018528_v_whitestandard.JPG,mimic
-CAM010077,https://zenodo.org/record/2549524/files/CAM010077_d.JPG,0,test-2,26327,malleti,26327_CAM010077_d.JPG,mimic
-CAM010014,https://zenodo.org/record/2549524/files/CAM010014_d.JPG,0,test-2,26227,malleti,26227_CAM010014_d.JPG,mimic
-CAM010006,https://zenodo.org/record/2549524/files/CAM010006_d.JPG,0,test-2,26215,malleti,26215_CAM010006_d.JPG,mimic
-CAM010089,https://zenodo.org/record/2549524/files/CAM010089_d.JPG,0,test-2,26347,malleti,26347_CAM010089_d.JPG,mimic
-CAM011423,https://zenodo.org/record/2550097/files/CAM011423_d.JPG,0,test-2,28192,plesseni,28192_CAM011423_d.JPG,mimic
-CAM011411,https://zenodo.org/record/2550097/files/CAM011411_d.JPG,0,test-2,28144,plesseni,28144_CAM011411_d.JPG,mimic
-CAM011428,https://zenodo.org/record/2550097/files/CAM011428_d.JPG,0,test-2,28212,malleti,28212_CAM011428_d.JPG,mimic
-CAM011410,https://zenodo.org/record/2550097/files/CAM011410_d.JPG,0,test-2,28140,plesseni,28140_CAM011410_d.JPG,mimic
-CAM011438,https://zenodo.org/record/2550097/files/CAM011438_d.JPG,0,test-2,28244,plesseni,28244_CAM011438_d.JPG,mimic
-CAM011406,https://zenodo.org/record/2550097/files/CAM011406_d.JPG,0,test-2,28124,plesseni,28124_CAM011406_d.JPG,mimic
-CAM011296,https://zenodo.org/record/2550097/files/CAM011296_d.JPG,0,test-2,27822,malleti,27822_CAM011296_d.JPG,mimic
-CAM011443,https://zenodo.org/record/2550097/files/CAM011443_d.JPG,0,test-2,28264,plesseni,28264_CAM011443_d.JPG,mimic
-CAM011449,https://zenodo.org/record/2550097/files/CAM011449_d.JPG,0,test-2,28288,plesseni,28288_CAM011449_d.JPG,mimic
-CAM011444,https://zenodo.org/record/2550097/files/CAM011444_d.JPG,0,test-2,28268,malleti,28268_CAM011444_d.JPG,mimic
-CAM011447,https://zenodo.org/record/2550097/files/CAM011447_d.JPG,0,test-2,28280,malleti,28280_CAM011447_d.JPG,mimic
-CAM011456,https://zenodo.org/record/2550097/files/CAM011456_d.JPG,0,test-2,28316,plesseni,28316_CAM011456_d.JPG,mimic
-CAM010035,https://zenodo.org/record/2552371/files/10035d.jpg,0,test-2,23118,malleti,23118_10035d.jpg,mimic
-CAM011437,https://zenodo.org/record/2552371/files/11437d.jpg,0,test-2,24550,plesseni,24550_11437d.jpg,mimic
-CAM011440,https://zenodo.org/record/2552371/files/11440d.jpg,0,test-2,24552,plesseni,24552_11440d.jpg,mimic
-CAM011446,https://zenodo.org/record/2552371/files/11446d.jpg,0,test-2,24556,plesseni,24556_11446d.jpg,mimic
-CS003830,https://zenodo.org/record/2553501/files/CS3830 dorsal.jpeg,0,test-2,25987,malleti,25987_CS3830 dorsal.jpeg,mimic
-CS003815,https://zenodo.org/record/2553501/files/CS3815 dorsal.jpeg,0,test-2,25983,malleti,25983_CS3815 dorsal.jpeg,mimic
-CS003728,https://zenodo.org/record/2553501/files/CS3728 dorsal.jpeg,0,test-2,25967,malleti,25967_CS3728 dorsal.jpeg,mimic
-CS003730,https://zenodo.org/record/2553501/files/CS3730 dorsal.jpeg,0,test-2,25969,malleti,25969_CS3730 dorsal.jpeg,mimic
-CS003820,https://zenodo.org/record/2553501/files/CS3820 dorsal.jpeg,0,test-2,25985,malleti,25985_CS3820 dorsal.jpeg,mimic
-CS003709,https://zenodo.org/record/2553501/files/CS3709 dorsal.jpeg,0,test-2,25965,malleti,25965_CS3709 dorsal.jpeg,mimic
-CS003706,https://zenodo.org/record/2553501/files/CS3706 dorsal.jpeg,0,test-2,25963,malleti,25963_CS3706 dorsal.jpeg,mimic
-CS001011,https://zenodo.org/record/2553501/files/CS1011 dorsal.jpeg,0,test-2,25595,malleti,25595_CS1011 dorsal.jpeg,mimic
-CS001002,https://zenodo.org/record/2553501/files/CS1002 dorsal.jpeg,0,test-2,25591,malleti,25591_CS1002 dorsal.jpeg,mimic
-CS001286,https://zenodo.org/record/2553501/files/CS1286 dorsal.jpeg,0,test-2,25625,malleti,25625_CS1286 dorsal.jpeg,mimic
-CS000615,https://zenodo.org/record/2553501/files/CS615 dorsal.jpeg,0,test-2,26011,malleti,26011_CS615 dorsal.jpeg,mimic
-CS000594,https://zenodo.org/record/2553501/files/CS594 dorsal.jpeg,0,test-2,26007,malleti,26007_CS594 dorsal.jpeg,mimic
-CS000583,https://zenodo.org/record/2553501/files/CS583 dorsal.jpeg,0,test-2,26003,malleti,26003_CS583 dorsal.jpeg,mimic
-CS000470,https://zenodo.org/record/2553501/files/CS470 dorsal.jpeg,0,test-2,25997,malleti,25997_CS470 dorsal.jpeg,mimic
-CS000604,https://zenodo.org/record/2553501/files/CS604 dorsal.jpeg,0,test-2,26009,malleti,26009_CS604 dorsal.jpeg,mimic
-CS001321,https://zenodo.org/record/2553501/files/CS1321 dorsal.jpeg,0,test-2,25627,malleti,25627_CS1321 dorsal.jpeg,mimic
-CS000586,https://zenodo.org/record/2553501/files/CS586 dorsal.jpeg,0,test-2,26005,malleti,26005_CS586 dorsal.jpeg,mimic
-CS003544,https://zenodo.org/record/2553501/files/CS3544 dorsal.jpeg,0,test-2,25941,malleti,25941_CS3544 dorsal.jpeg,mimic
-CS003543,https://zenodo.org/record/2553501/files/CS3543 dorsal.jpeg,0,test-2,25939,malleti,25939_CS3543 dorsal.jpeg,mimic
-CS003542,https://zenodo.org/record/2553501/files/CS3542 dorsal.jpeg,0,test-2,25937,malleti,25937_CS3542 dorsal.jpeg,mimic
-CS003541,https://zenodo.org/record/2553501/files/CS3541 dorsal.jpeg,0,test-2,25935,malleti,25935_CS3541 dorsal.jpeg,mimic
-CS003447,https://zenodo.org/record/2553501/files/CS3447 dorsal.jpeg,0,test-2,25933,malleti,25933_CS3447 dorsal.jpeg,mimic
-CS003366,https://zenodo.org/record/2553501/files/CS3366 dorsal.jpeg,0,test-2,25901,malleti,25901_CS3366 dorsal.jpeg,mimic
-CS003109,https://zenodo.org/record/2553501/files/CS3109 dorsal.jpeg,0,test-2,25847,malleti,25847_CS3109 dorsal.jpeg,mimic
-CS002311,https://zenodo.org/record/2553501/files/CS2311 dorsal.jpeg,0,test-2,25701,malleti,25701_CS2311 dorsal.jpeg,mimic
-CS001815,https://zenodo.org/record/2553501/files/CS1815 dorsal.jpeg,0,test-2,25643,malleti,25643_CS1815 dorsal.jpeg,mimic
-CAM017162,https://zenodo.org/record/2553977/files/17162_H_melpomene_malleti_D.JPG.jpg,0,test-2,26053,malleti,26053_17162_H_melpomene_malleti_D.JPG.jpg,mimic
-CAM016293,https://zenodo.org/record/2553977/files/16293_H_melpomene_plesseni_D.JPG.jpg,0,test-2,26047,plesseni,26047_16293_H_melpomene_plesseni_D.JPG.jpg,mimic
-F875,https://zenodo.org/record/2555086/files/F875_d.JPG,0,test,38136,demophoon,38136_F875_d.JPG,minor
-F876,https://zenodo.org/record/2555086/files/F876_d.JPG,0,test,38140,demophoon,38140_F876_d.JPG,minor
-F880,https://zenodo.org/record/2555086/files/F880_d.JPG,0,test,38144,demophoon,38144_F880_d.JPG,minor
-F884,https://zenodo.org/record/2555086/files/F884_d.JPG,0,test,38148,demophoon,38148_F884_d.JPG,minor
-F868,https://zenodo.org/record/2555086/files/F868_d.JPG,0,test,38120,demophoon,38120_F868_d.JPG,minor
-F889,https://zenodo.org/record/2555086/files/F889_d.JPG,0,test,38152,demophoon,38152_F889_d.JPG,minor
-F895,https://zenodo.org/record/2555086/files/F895_d.JPG,0,test,38160,demophoon,38160_F895_d.JPG,minor
-F901,https://zenodo.org/record/2555086/files/F901_d.JPG,0,test,38168,demophoon,38168_F901_d.JPG,minor
-F902,https://zenodo.org/record/2555086/files/F902_d.JPG,0,test,38172,demophoon,38172_F902_d.JPG,minor
-F905,https://zenodo.org/record/2555086/files/F905_d.JPG,0,test,38176,demophoon,38176_F905_d.JPG,minor
-F906,https://zenodo.org/record/2555086/files/F906_d.JPG,0,test,38180,demophoon,38180_F906_d.JPG,minor
-F907,https://zenodo.org/record/2555086/files/F907_d.JPG,0,test,38184,demophoon,38184_F907_d.JPG,minor
-F794,https://zenodo.org/record/2555086/files/F794_d.JPG,0,test,38040,demophoon,38040_F794_d.JPG,minor
-F891,https://zenodo.org/record/2555086/files/F891_d.JPG,0,test,38156,demophoon,38156_F891_d.JPG,minor
-F867,https://zenodo.org/record/2555086/files/F867_d.JPG,0,test,38116,demophoon,38116_F867_d.JPG,minor
-F900,https://zenodo.org/record/2555086/files/F900_d.JPG,0,test,38164,demophoon,38164_F900_d.JPG,minor
-F865,https://zenodo.org/record/2555086/files/F865_d.JPG,0,test,38108,demophoon,38108_F865_d.JPG,minor
-CAM000057,https://zenodo.org/record/2677821/files/CAM000057_d.JPG,1,test,5949,chestertonii x venus,5949_CAM000057_d.JPG,minor
-CAM000171,https://zenodo.org/record/2677821/files/CAM000171_d.JPG,0,test,6174,chestertonii,6174_CAM000171_d.JPG,minor
-CAM000170,https://zenodo.org/record/2677821/files/CAM000170_d.JPG,0,test,6172,chestertonii,6172_CAM000170_d.JPG,minor
-CAM000169,https://zenodo.org/record/2677821/files/CAM000169_d.JPG,0,test,6170,chestertonii,6170_CAM000169_d.JPG,minor
-CAM000149,https://zenodo.org/record/2677821/files/CAM000149_d.JPG,0,test,6130,chestertonii,6130_CAM000149_d.JPG,minor
-CAM000148,https://zenodo.org/record/2677821/files/CAM000148_d.JPG,0,test,6128,chestertonii,6128_CAM000148_d.JPG,minor
-CAM000230,https://zenodo.org/record/2677821/files/CAM000230_d.JPG,0,test,6286,chestertonii,6286_CAM000230_d.JPG,minor
-CAM000231,https://zenodo.org/record/2677821/files/CAM000231_d.JPG,0,test,6288,chestertonii,6288_CAM000231_d.JPG,minor
-CAM000232,https://zenodo.org/record/2677821/files/CAM000232_d.JPG,0,test,6290,chestertonii,6290_CAM000232_d.JPG,minor
-CAM000233,https://zenodo.org/record/2677821/files/CAM000233_d.JPG,0,test,6292,chestertonii,6292_CAM000233_d.JPG,minor
-CAM000243,https://zenodo.org/record/2677821/files/CAM000243_d.JPG,0,test,6312,chestertonii,6312_CAM000243_d.JPG,minor
-CAM002903,https://zenodo.org/record/2684906/files/CAM002903_d.JPG,1,test,8491,hydara x petiverana,8491_CAM002903_d.JPG,minor
-CAM008158,https://zenodo.org/record/2684906/files/CAM008158_d.JPG,0,test-2,8762,malleti,8762_CAM008158_d.JPG,mimic
-CAM008226,https://zenodo.org/record/2684906/files/CAM008226_d.JPG,0,test-2,8895,malleti,8895_CAM008226_d.JPG,mimic
-CAM008163,https://zenodo.org/record/2684906/files/CAM008163_d.JPG,0,test-2,8772,malleti,8772_CAM008163_d.JPG,mimic
-CAM008160,https://zenodo.org/record/2684906/files/CAM008160_d.JPG,0,test-2,8766,malleti,8766_CAM008160_d.JPG,mimic
-CAM008159,https://zenodo.org/record/2684906/files/CAM008159_d.JPG,0,test-2,8764,malleti,8764_CAM008159_d.JPG,mimic
-CAM008161,https://zenodo.org/record/2684906/files/CAM008161_d.JPG,0,test-2,8768,malleti,8768_CAM008161_d.JPG,mimic
-CAM008546,https://zenodo.org/record/2684906/files/CAM008546_d.JPG,0,test-2,9444,plesseni,9444_CAM008546_d.JPG,mimic
-CAM008545,https://zenodo.org/record/2684906/files/CAM008545_d.JPG,0,test-2,9442,plesseni,9442_CAM008545_d.JPG,mimic
-CAM008544,https://zenodo.org/record/2684906/files/CAM008544_d.JPG,0,test-2,9440,plesseni,9440_CAM008544_d.JPG,mimic
-CAM008543,https://zenodo.org/record/2684906/files/CAM008543_d.JPG,0,test-2,9438,plesseni,9438_CAM008543_d.JPG,mimic
-CAM008539,https://zenodo.org/record/2684906/files/CAM008539_d.JPG,0,test-2,9432,plesseni,9432_CAM008539_d.JPG,mimic
-CAM008542,https://zenodo.org/record/2684906/files/CAM008542_d.JPG,0,test-2,9436,plesseni,9436_CAM008542_d.JPG,mimic
-CAM008244,https://zenodo.org/record/2684906/files/CAM008244_d.JPG,0,test-2,8923,malleti,8923_CAM008244_d.JPG,mimic
-CAM009424,https://zenodo.org/record/2686762/files/CAM009424_d.JPG,0,test-2,10646,plesseni,10646_CAM009424_d.JPG,mimic
-CAM009416,https://zenodo.org/record/2686762/files/CAM009416_d.JPG,0,test-2,10630,plesseni,10630_CAM009416_d.JPG,mimic
-CAM009417,https://zenodo.org/record/2686762/files/CAM009417_d.JPG,0,test-2,10632,plesseni,10632_CAM009417_d.JPG,mimic
-CAM009423,https://zenodo.org/record/2686762/files/CAM009423_d.JPG,0,test-2,10644,plesseni,10644_CAM009423_d.JPG,mimic
-CAM009429,https://zenodo.org/record/2686762/files/CAM009429_d.JPG,0,test-2,10656,plesseni,10656_CAM009429_d.JPG,mimic
-CAM009436,https://zenodo.org/record/2686762/files/CAM009436_d.JPG,0,test-2,10670,plesseni,10670_CAM009436_d.JPG,mimic
-CAM009437,https://zenodo.org/record/2686762/files/CAM009437_d.JPG,0,test-2,10672,plesseni,10672_CAM009437_d.JPG,mimic
-CAM009438,https://zenodo.org/record/2686762/files/CAM009438_d.JPG,0,test-2,10674,plesseni,10674_CAM009438_d.JPG,mimic
-CAM009439,https://zenodo.org/record/2686762/files/CAM009439_d.JPG,0,test-2,10676,plesseni,10676_CAM009439_d.JPG,mimic
-CAM009442,https://zenodo.org/record/2686762/files/CAM009442_d.JPG,0,test-2,10682,plesseni,10682_CAM009442_d.JPG,mimic
-CAM009500,https://zenodo.org/record/2686762/files/CAM009500_d.JPG,1,test,10742,hydara x petiverana,10742_CAM009500_d.JPG,minor
-CAM009407,https://zenodo.org/record/2686762/files/CAM009407_d.JPG,0,test-2,10612,malleti,10612_CAM009407_d.JPG,mimic
-CAM009544,https://zenodo.org/record/2686762/files/CAM009544_d.JPG,1,test,10830,hydara x petiverana,10830_CAM009544_d.JPG,minor
-CAM009504,https://zenodo.org/record/2686762/files/CAM009504_d.JPG,1,test,10750,hydara x petiverana,10750_CAM009504_d.JPG,minor
-CAM009546,https://zenodo.org/record/2686762/files/CAM009546_d.JPG,1,test,10834,hydara x petiverana,10834_CAM009546_d.JPG,minor
-CAM009549,https://zenodo.org/record/2686762/files/CAM009549_d.JPG,1,test,10840,hydara x petiverana,10840_CAM009549_d.JPG,minor
-CAM009551,https://zenodo.org/record/2686762/files/CAM009551_d.JPG,1,test,10844,hydara x petiverana,10844_CAM009551_d.JPG,minor
-CAM009552,https://zenodo.org/record/2686762/files/CAM009552_d.JPG,1,test,10846,hydara x petiverana,10846_CAM009552_d.JPG,minor
-CAM009524,https://zenodo.org/record/2686762/files/CAM009524_d.JPG,0,test,10790,petiverana,10790_CAM009524_d.JPG,minor
-CAM009525,https://zenodo.org/record/2686762/files/CAM009525_d.JPG,0,test,10792,petiverana,10792_CAM009525_d.JPG,minor
-CAM009206,https://zenodo.org/record/2686762/files/CAM009206_d.JPG,0,test-2,10381,plesseni,10381_CAM009206_d.JPG,mimic
-CAM009008,https://zenodo.org/record/2686762/files/CAM009008_d.JPG,0,test,10121,hydara,10121_CAM009008_d.JPG,minor
-CAM009007,https://zenodo.org/record/2686762/files/CAM009007_d.JPG,0,test,10119,hydara,10119_CAM009007_d.JPG,minor
-CAM009006,https://zenodo.org/record/2686762/files/CAM009006_d.JPG,0,test,10117,hydara,10117_CAM009006_d.JPG,minor
-CAM009004,https://zenodo.org/record/2686762/files/CAM009004_d.JPG,0,test,10113,hydara,10113_CAM009004_d.JPG,minor
-CAM009003,https://zenodo.org/record/2686762/files/CAM009003_d.JPG,0,test,10111,hydara,10111_CAM009003_d.JPG,minor
-CAM009002,https://zenodo.org/record/2686762/files/CAM009002_d.JPG,0,test,10109,hydara,10109_CAM009002_d.JPG,minor
-CAM009001,https://zenodo.org/record/2686762/files/CAM009001_d.JPG,0,test,10107,hydara,10107_CAM009001_d.JPG,minor
-CAM008999,https://zenodo.org/record/2686762/files/CAM008999_d.JPG,0,test,10103,hydara,10103_CAM008999_d.JPG,minor
-CAM008998,https://zenodo.org/record/2686762/files/CAM008998_d.JPG,0,test,10101,hydara,10101_CAM008998_d.JPG,minor
-CAM008997,https://zenodo.org/record/2686762/files/CAM008997_d.JPG,0,test,10099,hydara,10099_CAM008997_d.JPG,minor
-CAM008986,https://zenodo.org/record/2686762/files/CAM008986_d.JPG,0,test,10077,hydara,10077_CAM008986_d.JPG,minor
-CAM008985,https://zenodo.org/record/2686762/files/CAM008985_d.JPG,0,test,10075,hydara,10075_CAM008985_d.JPG,minor
-CAM009000,https://zenodo.org/record/2686762/files/CAM009000_d.JPG,0,test,10105,hydara,10105_CAM009000_d.JPG,minor
-CAM008867,https://zenodo.org/record/2686762/files/CAM008867_d.JPG,0,test,9955,hydara,9955_CAM008867_d.JPG,minor
-CAM008866,https://zenodo.org/record/2686762/files/CAM008866_d.JPG,0,test,9953,hydara,9953_CAM008866_d.JPG,minor
-CAM009332,https://zenodo.org/record/2686762/files/CAM009332_d.JPG,0,test,10516,hydara,10516_CAM009332_d.JPG,minor
-CAM008865,https://zenodo.org/record/2686762/files/CAM008865_d.JPG,0,test,9951,hydara,9951_CAM008865_d.JPG,minor
-CAM008864,https://zenodo.org/record/2686762/files/CAM008864_d.JPG,0,test,9949,hydara,9949_CAM008864_d.JPG,minor
-CAM008801,https://zenodo.org/record/2686762/files/CAM008801_d.JPG,0,test,9855,hydara,9855_CAM008801_d.JPG,minor
-CAM008961,https://zenodo.org/record/2686762/files/CAM008961_d.JPG,0,test,10027,hydara,10027_CAM008961_d.JPG,minor
-CAM009300,https://zenodo.org/record/2686762/files/CAM009300_d.JPG,0,test,10452,hydara,10452_CAM009300_d.JPG,minor
-CAM009237,https://zenodo.org/record/2686762/files/CAM009237_d.JPG,0,test-2,10442,plesseni,10442_CAM009237_d.JPG,mimic
-CAM009236,https://zenodo.org/record/2686762/files/CAM009236_d.JPG,0,test-2,10440,plesseni,10440_CAM009236_d.JPG,mimic
-CAM009235,https://zenodo.org/record/2686762/files/CAM009235_d.JPG,0,test-2,10438,plesseni,10438_CAM009235_d.JPG,mimic
-CAM009233,https://zenodo.org/record/2686762/files/CAM009233_d.JPG,0,test-2,10434,plesseni,10434_CAM009233_d.JPG,mimic
-CAM009232,https://zenodo.org/record/2686762/files/CAM009232_d.JPG,0,test-2,10432,plesseni,10432_CAM009232_d.JPG,mimic
-CAM009231,https://zenodo.org/record/2686762/files/CAM009231_d.JPG,0,test-2,10430,plesseni,10430_CAM009231_d.JPG,mimic
-CAM009230,https://zenodo.org/record/2686762/files/CAM009230_d.JPG,0,test-2,10428,plesseni,10428_CAM009230_d.JPG,mimic
-CAM009229,https://zenodo.org/record/2686762/files/CAM009229_d.JPG,0,test-2,10426,plesseni,10426_CAM009229_d.JPG,mimic
-CAM009234,https://zenodo.org/record/2686762/files/CAM009234_d.JPG,0,test-2,10436,plesseni,10436_CAM009234_d.JPG,mimic
-CAM009207,https://zenodo.org/record/2686762/files/CAM009207_d.JPG,0,test-2,10383,plesseni,10383_CAM009207_d.JPG,mimic
-CAM009205,https://zenodo.org/record/2686762/files/CAM009205_d.JPG,0,test-2,10379,plesseni,10379_CAM009205_d.JPG,mimic
-CAM009228,https://zenodo.org/record/2686762/files/CAM009228_d.JPG,0,test-2,10424,plesseni,10424_CAM009228_d.JPG,mimic
-CAM009203,https://zenodo.org/record/2686762/files/CAM009203_d.JPG,0,test-2,10375,plesseni,10375_CAM009203_d.JPG,mimic
-CAM009159,https://zenodo.org/record/2686762/files/CAM009159_d.JPG,0,test-2,10287,plesseni,10287_CAM009159_d.JPG,mimic
-CAM009204,https://zenodo.org/record/2686762/files/CAM009204_d.JPG,0,test-2,10377,plesseni,10377_CAM009204_d.JPG,mimic
-CAM009157,https://zenodo.org/record/2686762/files/CAM009157_d.JPG,0,test-2,10283,plesseni,10283_CAM009157_d.JPG,mimic
-CAM009156,https://zenodo.org/record/2686762/files/CAM009156_d.JPG,0,test-2,10281,plesseni,10281_CAM009156_d.JPG,mimic
-CAM009126,https://zenodo.org/record/2686762/files/CAM009126_d.JPG,0,test,10221,etylus,10221_CAM009126_d.JPG,minor
-CAM009160,https://zenodo.org/record/2686762/files/CAM009160_d.JPG,0,test-2,10289,plesseni,10289_CAM009160_d.JPG,mimic
-CAM009161,https://zenodo.org/record/2686762/files/CAM009161_d.JPG,0,test-2,10291,plesseni,10291_CAM009161_d.JPG,mimic
-CAM009158,https://zenodo.org/record/2686762/files/CAM009158_d.JPG,0,test-2,10285,plesseni,10285_CAM009158_d.JPG,mimic
-CAM009194,https://zenodo.org/record/2686762/files/CAM009194_d.JPG,0,test-2,10357,plesseni,10357_CAM009194_d.JPG,mimic
-CAM009197,https://zenodo.org/record/2686762/files/CAM009197_d.JPG,0,test-2,10363,plesseni,10363_CAM009197_d.JPG,mimic
-CAM009198,https://zenodo.org/record/2686762/files/CAM009198_d.JPG,0,test-2,10365,plesseni,10365_CAM009198_d.JPG,mimic
-CAM009193,https://zenodo.org/record/2686762/files/CAM009193_d.JPG,0,test-2,10355,plesseni,10355_CAM009193_d.JPG,mimic
-CAM009199,https://zenodo.org/record/2686762/files/CAM009199_d.JPG,0,test-2,10367,plesseni,10367_CAM009199_d.JPG,mimic
-CAM009192,https://zenodo.org/record/2686762/files/CAM009192_d.JPG,0,test-2,10353,plesseni,10353_CAM009192_d.JPG,mimic
-CAM009191,https://zenodo.org/record/2686762/files/CAM009191_d.JPG,0,test-2,10351,plesseni,10351_CAM009191_d.JPG,mimic
-CAM009195,https://zenodo.org/record/2686762/files/CAM009195_d.JPG,0,test-2,10359,plesseni,10359_CAM009195_d.JPG,mimic
-CAM009200,https://zenodo.org/record/2686762/files/CAM009200_d.JPG,0,test-2,10369,plesseni,10369_CAM009200_d.JPG,mimic
-CAM009201,https://zenodo.org/record/2686762/files/CAM009201_d.JPG,0,test-2,10371,plesseni,10371_CAM009201_d.JPG,mimic
-CAM009202,https://zenodo.org/record/2686762/files/CAM009202_d.JPG,0,test-2,10373,plesseni,10373_CAM009202_d.JPG,mimic
-CAM009189,https://zenodo.org/record/2686762/files/CAM009189_d.JPG,0,test-2,10347,plesseni,10347_CAM009189_d.JPG,mimic
-CAM009188,https://zenodo.org/record/2686762/files/CAM009188_d.JPG,0,test-2,10345,plesseni,10345_CAM009188_d.JPG,mimic
-CAM009190,https://zenodo.org/record/2686762/files/CAM009190_d.JPG,0,test-2,10349,plesseni,10349_CAM009190_d.JPG,mimic
-CAM009196,https://zenodo.org/record/2686762/files/CAM009196_d.JPG,0,test-2,10361,plesseni,10361_CAM009196_d.JPG,mimic
-CAM018530,https://zenodo.org/record/2702457/files/CAM018530_d.JPG,1,test-2,11391,malleti x plesseni,11391_CAM018530_d.JPG,mimic
-CAM018532,https://zenodo.org/record/2702457/files/CAM018532_d.JPG,1,test-2,11393,plesseni x malleti,11393_CAM018532_d.JPG,mimic
-CAM017998,https://zenodo.org/record/2702457/files/CAM017998_d.JPG,1,test-2,10916,plesseni x malleti,10916_CAM017998_d.JPG,mimic
-CAM018529,https://zenodo.org/record/2702457/files/CAM018529_d.JPG,1,test-2,11389,malleti x plesseni,11389_CAM018529_d.JPG,mimic
-CAM018517,https://zenodo.org/record/2702457/files/CAM018517_d.JPG,1,test-2,11369,plesseni x malleti,11369_CAM018517_d.JPG,mimic
-CAM018518,https://zenodo.org/record/2702457/files/CAM018518_d.JPG,1,test-2,11371,malleti x plesseni,11371_CAM018518_d.JPG,mimic
-CAM018519,https://zenodo.org/record/2702457/files/CAM018519_d.JPG,1,test-2,11373,plesseni x malleti,11373_CAM018519_d.JPG,mimic
-CAM018520,https://zenodo.org/record/2702457/files/CAM018520_d.JPG,1,test-2,11375,malleti x plesseni,11375_CAM018520_d.JPG,mimic
-CAM021060,https://zenodo.org/record/2702457/files/CAM021060_d.JPG,0,test,11549,erato,11549_CAM021060_d.JPG,minor
-CAM021062,https://zenodo.org/record/2702457/files/CAM021062_d.JPG,0,test,11553,erato,11553_CAM021062_d.JPG,minor
-CAM021077,https://zenodo.org/record/2702457/files/CAM021077_d.JPG,0,test,11581,erato,11581_CAM021077_d.JPG,minor
-CAM021073,https://zenodo.org/record/2702457/files/CAM021073_d.JPG,0,test,11575,erato,11575_CAM021073_d.JPG,minor
-CAM021068,https://zenodo.org/record/2702457/files/CAM021068_d.JPG,0,test,11565,erato,11565_CAM021068_d.JPG,minor
-CAM021054,https://zenodo.org/record/2702457/files/CAM021054_d.JPG,1,test,11540,hydara x erato,11540_CAM021054_d.JPG,minor
-CAM021021,https://zenodo.org/record/2702457/files/CAM021021_d.JPG,0,test,11480,amalfreda,11480_CAM021021_d.JPG,minor
-CAM021022,https://zenodo.org/record/2702457/files/CAM021022_d.JPG,0,test,11482,amalfreda,11482_CAM021022_d.JPG,minor
-CAM021023,https://zenodo.org/record/2702457/files/CAM021023_d.JPG,0,test,11484,amalfreda,11484_CAM021023_d.JPG,minor
-CAM021025,https://zenodo.org/record/2702457/files/CAM021025_d.JPG,0,test,11488,amalfreda,11488_CAM021025_d.JPG,minor
-CAM021028,https://zenodo.org/record/2702457/files/CAM021028_d.JPG,1,test,11490,hydara x amalfreda,11490_CAM021028_d.JPG,minor
-CAM021029,https://zenodo.org/record/2702457/files/CAM021029_d.JPG,1,test,11492,hydara x amalfreda,11492_CAM021029_d.JPG,minor
-CAM021030,https://zenodo.org/record/2702457/files/CAM021030_d.JPG,1,test,11494,hydara x amalfreda,11494_CAM021030_d.JPG,minor
-CAM021031,https://zenodo.org/record/2702457/files/CAM021031_d.JPG,1,test,11496,hydara x amalfreda,11496_CAM021031_d.JPG,minor
-CAM018315,https://zenodo.org/record/2702457/files/CAM018315_d.JPG,1,test-2,11060,plesseni x malleti,11060_CAM018315_d.JPG,mimic
-CAM018309,https://zenodo.org/record/2702457/files/CAM018309_d.JPG,1,test-2,11052,plesseni x malleti,11052_CAM018309_d.JPG,mimic
-CAM018405,https://zenodo.org/record/2702457/files/CAM018405_d.JPG,1,test-2,11174,plesseni x malleti,11174_CAM018405_d.JPG,mimic
-CAM018360,https://zenodo.org/record/2702457/files/CAM018360_d.JPG,1,test-2,11127,plesseni x malleti,11127_CAM018360_d.JPG,mimic
-CAM018361,https://zenodo.org/record/2702457/files/CAM018361_d.JPG,1,test-2,11128,plesseni x malleti,11128_CAM018361_d.JPG,mimic
-CAM018365,https://zenodo.org/record/2702457/files/CAM018365_d.JPG,1,test-2,11130,malleti x plesseni,11130_CAM018365_d.JPG,mimic
-CAM018391,https://zenodo.org/record/2702457/files/CAM018391_d.JPG,1,test-2,11156,malleti x plesseni,11156_CAM018391_d.JPG,mimic
-CAM018401,https://zenodo.org/record/2702457/files/CAM018401_d.JPG,1,test-2,11166,plesseni x malleti,11166_CAM018401_d.JPG,mimic
-CAM018402,https://zenodo.org/record/2702457/files/CAM018402_d.JPG,1,test-2,11168,plesseni x malleti,11168_CAM018402_d.JPG,mimic
-CAM018403,https://zenodo.org/record/2702457/files/CAM018403_d.JPG,1,test-2,11170,plesseni x malleti,11170_CAM018403_d.JPG,mimic
-CAM018404,https://zenodo.org/record/2702457/files/CAM018404_d.JPG,1,test-2,11172,plesseni x malleti,11172_CAM018404_d.JPG,mimic
-CAM018338,https://zenodo.org/record/2702457/files/CAM018338_d.JPG,1,test-2,11096,malleti x plesseni,11096_CAM018338_d.JPG,mimic
-CAM018466,https://zenodo.org/record/2702457/files/CAM018466_d.JPG,1,test-2,11274,plesseni x malleti,11274_CAM018466_d.JPG,mimic
-CAM018259,https://zenodo.org/record/2702457/files/CAM018259_d.JPG,1,test-2,10990,plesseni x malleti,10990_CAM018259_d.JPG,mimic
-CAM018258,https://zenodo.org/record/2702457/files/CAM018258_d.JPG,1,test-2,10988,plesseni x malleti,10988_CAM018258_d.JPG,mimic
-CAM018482,https://zenodo.org/record/2702457/files/CAM018482_d.JPG,1,test-2,11305,plesseni x malleti,11305_CAM018482_d.JPG,mimic
-CAM018257,https://zenodo.org/record/2702457/files/CAM018257_d.JPG,1,test-2,10986,plesseni x malleti,10986_CAM018257_d.JPG,mimic
-CAM018256,https://zenodo.org/record/2702457/files/CAM018256_d.JPG,1,test-2,10984,plesseni x malleti,10984_CAM018256_d.JPG,mimic
-CAM018250,https://zenodo.org/record/2702457/files/CAM018250_d.JPG,1,test-2,10974,plesseni x malleti,10974_CAM018250_d.JPG,mimic
-CAM018296,https://zenodo.org/record/2702457/files/CAM018296_d.JPG,1,test-2,11034,malleti x plesseni,11034_CAM018296_d.JPG,mimic
-CAM018295,https://zenodo.org/record/2702457/files/CAM018295_d.JPG,1,test-2,11032,plesseni x malleti,11032_CAM018295_d.JPG,mimic
-CAM018294,https://zenodo.org/record/2702457/files/CAM018294_d.JPG,1,test-2,11030,plesseni x malleti,11030_CAM018294_d.JPG,mimic
-CAM018285,https://zenodo.org/record/2702457/files/CAM018285_d.JPG,1,test-2,11022,plesseni x malleti,11022_CAM018285_d.JPG,mimic
-CAM018281,https://zenodo.org/record/2702457/files/CAM018281_d.JPG,1,test-2,11018,plesseni x malleti,11018_CAM018281_d.JPG,mimic
-CAM040293,https://zenodo.org/record/2707828/files/CAM040293_d.JPG,0,test-2,12202,malleti,12202_CAM040293_d.JPG,mimic
-CAM040440,https://zenodo.org/record/2707828/files/CAM040440_d.JPG,0,test-2,12492,malleti,12492_CAM040440_d.JPG,mimic
-CAM040129,https://zenodo.org/record/2707828/files/CAM040129_d.JPG,0,test-2,11898,malleti,11898_CAM040129_d.JPG,mimic
-CAM040150,https://zenodo.org/record/2707828/files/CAM040150_d.JPG,0,test-2,11936,malleti,11936_CAM040150_d.JPG,mimic
-CAM040149,https://zenodo.org/record/2707828/files/CAM040149_d.JPG,0,test-2,11934,malleti,11934_CAM040149_d.JPG,mimic
-CAM040038,https://zenodo.org/record/2707828/files/CAM040038_d.JPG,0,test,11756,dignus,11756_CAM040038_d.JPG,minor
-CAM040023,https://zenodo.org/record/2707828/files/CAM040023_d.JPG,0,test-2,11730,malleti,11730_CAM040023_d.JPG,mimic
-CAM040022,https://zenodo.org/record/2707828/files/CAM040022_d.JPG,0,test-2,11728,malleti,11728_CAM040022_d.JPG,mimic
-CAM040021,https://zenodo.org/record/2707828/files/CAM040021_d.JPG,0,test-2,11726,malleti,11726_CAM040021_d.JPG,mimic
-CAM040020,https://zenodo.org/record/2707828/files/CAM040020_d.JPG,0,test-2,11724,malleti,11724_CAM040020_d.JPG,mimic
-CAM040019,https://zenodo.org/record/2707828/files/CAM040019_d.JPG,0,test-2,11722,malleti,11722_CAM040019_d.JPG,mimic
-CAM040018,https://zenodo.org/record/2707828/files/CAM040018_d.JPG,0,test,11720,dignus,11720_CAM040018_d.JPG,minor
-CAM040017,https://zenodo.org/record/2707828/files/CAM040017_d.JPG,0,test,11718,dignus,11718_CAM040017_d.JPG,minor
-CAM040294,https://zenodo.org/record/2707828/files/CAM040294_d.JPG,0,test-2,12204,malleti,12204_CAM040294_d.JPG,mimic
-CAM040292,https://zenodo.org/record/2707828/files/CAM040292_d.JPG,0,test-2,12200,malleti,12200_CAM040292_d.JPG,mimic
-CAM040291,https://zenodo.org/record/2707828/files/CAM040291_d.JPG,0,test-2,12198,malleti,12198_CAM040291_d.JPG,mimic
-CAM040290,https://zenodo.org/record/2707828/files/CAM040290_d.JPG,0,test-2,12196,malleti,12196_CAM040290_d.JPG,mimic
-CAM040289,https://zenodo.org/record/2707828/files/CAM040289_d.JPG,0,test-2,12194,malleti,12194_CAM040289_d.JPG,mimic
-CAM040288,https://zenodo.org/record/2707828/files/CAM040288_d.JPG,0,test-2,12192,malleti,12192_CAM040288_d.JPG,mimic
-CAM040287,https://zenodo.org/record/2707828/files/CAM040287_d.JPG,0,test-2,12190,malleti,12190_CAM040287_d.JPG,mimic
-CAM040286,https://zenodo.org/record/2707828/files/CAM040286_d.JPG,0,test-2,12188,malleti,12188_CAM040286_d.JPG,mimic
-CAM040285,https://zenodo.org/record/2707828/files/CAM040285_d.JPG,0,test-2,12186,malleti,12186_CAM040285_d.JPG,mimic
-CAM040284,https://zenodo.org/record/2707828/files/CAM040284_d.JPG,0,test-2,12184,malleti,12184_CAM040284_d.JPG,mimic
-CAM040283,https://zenodo.org/record/2707828/files/CAM040283_d.JPG,0,test-2,12182,malleti,12182_CAM040283_d.JPG,mimic
-CAM040282,https://zenodo.org/record/2707828/files/CAM040282_d.JPG,0,test-2,12180,malleti,12180_CAM040282_d.JPG,mimic
-CAM040281,https://zenodo.org/record/2707828/files/CAM040281_d.JPG,0,test-2,12178,malleti,12178_CAM040281_d.JPG,mimic
-CAM040269,https://zenodo.org/record/2707828/files/CAM040269_d.JPG,0,test-2,12154,malleti,12154_CAM040269_d.JPG,mimic
-CAM040268,https://zenodo.org/record/2707828/files/CAM040268_d.JPG,0,test-2,12152,malleti,12152_CAM040268_d.JPG,mimic
-CAM040267,https://zenodo.org/record/2707828/files/CAM040267_d.JPG,0,test-2,12150,malleti,12150_CAM040267_d.JPG,mimic
-CAM040266,https://zenodo.org/record/2707828/files/CAM040266_d.JPG,0,test-2,12148,malleti,12148_CAM040266_d.JPG,mimic
-CAM040265,https://zenodo.org/record/2707828/files/CAM040265_d.JPG,0,test-2,12146,malleti,12146_CAM040265_d.JPG,mimic
-CAM040264,https://zenodo.org/record/2707828/files/CAM040264_d.JPG,0,test-2,12144,malleti,12144_CAM040264_d.JPG,mimic
-CAM040263,https://zenodo.org/record/2707828/files/CAM040263_d.JPG,0,test-2,12142,malleti,12142_CAM040263_d.JPG,mimic
-CAM040262,https://zenodo.org/record/2707828/files/CAM040262_d.JPG,0,test-2,12140,malleti,12140_CAM040262_d.JPG,mimic
-CAM040261,https://zenodo.org/record/2707828/files/CAM040261_d.JPG,0,test-2,12138,malleti,12138_CAM040261_d.JPG,mimic
-CAM040260,https://zenodo.org/record/2707828/files/CAM040260_d.JPG,0,test-2,12136,malleti,12136_CAM040260_d.JPG,mimic
-CAM040295,https://zenodo.org/record/2707828/files/CAM040295_d.JPG,0,test-2,12206,malleti,12206_CAM040295_d.JPG,mimic
-CAM040259,https://zenodo.org/record/2707828/files/CAM040259_d.JPG,0,test-2,12134,malleti,12134_CAM040259_d.JPG,mimic
-CAM040296,https://zenodo.org/record/2707828/files/CAM040296_d.JPG,0,test-2,12208,malleti,12208_CAM040296_d.JPG,mimic
-CAM040298,https://zenodo.org/record/2707828/files/CAM040298_d.JPG,0,test-2,12212,malleti,12212_CAM040298_d.JPG,mimic
-CAM040297,https://zenodo.org/record/2707828/files/CAM040297_d.JPG,0,test-2,12210,malleti,12210_CAM040297_d.JPG,mimic
-CAM040258,https://zenodo.org/record/2707828/files/CAM040258_d.JPG,0,test-2,12132,malleti,12132_CAM040258_d.JPG,mimic
-CAM040256,https://zenodo.org/record/2707828/files/CAM040256_d.JPG,0,test-2,12128,malleti,12128_CAM040256_d.JPG,mimic
-CAM040198,https://zenodo.org/record/2707828/files/CAM040198_d.JPG,0,test-2,12022,malleti,12022_CAM040198_d.JPG,mimic
-CAM040197,https://zenodo.org/record/2707828/files/CAM040197_d.JPG,0,test-2,12020,malleti,12020_CAM040197_d.JPG,mimic
-CAM040192,https://zenodo.org/record/2707828/files/CAM040192_d.JPG,0,test-2,12012,malleti,12012_CAM040192_d.JPG,mimic
-CAM040190,https://zenodo.org/record/2707828/files/CAM040190_d.JPG,0,test-2,12008,malleti,12008_CAM040190_d.JPG,mimic
-CAM040183,https://zenodo.org/record/2707828/files/CAM040183_d.JPG,0,test-2,11994,malleti,11994_CAM040183_d.JPG,mimic
-CAM040181,https://zenodo.org/record/2707828/files/CAM040181_d.JPG,0,test-2,11992,malleti,11992_CAM040181_d.JPG,mimic
-CAM040180,https://zenodo.org/record/2707828/files/CAM040180_d.JPG,0,test-2,11990,malleti,11990_CAM040180_d.JPG,mimic
-CAM040172,https://zenodo.org/record/2707828/files/CAM040172_d.JPG,0,test-2,11974,malleti,11974_CAM040172_d.JPG,mimic
-CAM040171,https://zenodo.org/record/2707828/files/CAM040171_d.JPG,0,test-2,11972,malleti,11972_CAM040171_d.JPG,mimic
-CAM040257,https://zenodo.org/record/2707828/files/CAM040257_d.JPG,0,test-2,12130,malleti,12130_CAM040257_d.JPG,mimic
-CAM040201,https://zenodo.org/record/2707828/files/CAM040201_d.JPG,0,test-2,12028,malleti,12028_CAM040201_d.JPG,mimic
-CAM040210,https://zenodo.org/record/2707828/files/CAM040210_d.JPG,0,test-2,12044,malleti,12044_CAM040210_d.JPG,mimic
-CAM040240,https://zenodo.org/record/2707828/files/CAM040240_d.JPG,0,test-2,12096,malleti,12096_CAM040240_d.JPG,mimic
-CAM040255,https://zenodo.org/record/2707828/files/CAM040255_d.JPG,0,test-2,12126,malleti,12126_CAM040255_d.JPG,mimic
-CAM040253,https://zenodo.org/record/2707828/files/CAM040253_d.JPG,0,test-2,12122,malleti,12122_CAM040253_d.JPG,mimic
-CAM040245,https://zenodo.org/record/2707828/files/CAM040245_d.JPG,0,test-2,12106,malleti,12106_CAM040245_d.JPG,mimic
-CAM040238,https://zenodo.org/record/2707828/files/CAM040238_d.JPG,0,test-2,12092,malleti,12092_CAM040238_d.JPG,mimic
-CAM040237,https://zenodo.org/record/2707828/files/CAM040237_d.JPG,0,test-2,12090,malleti,12090_CAM040237_d.JPG,mimic
-CAM040235,https://zenodo.org/record/2707828/files/CAM040235_d.JPG,0,test-2,12086,malleti,12086_CAM040235_d.JPG,mimic
-CAM040254,https://zenodo.org/record/2707828/files/CAM040254_d.JPG,0,test-2,12124,malleti,12124_CAM040254_d.JPG,mimic
-CAM040222,https://zenodo.org/record/2707828/files/CAM040222_d.JPG,0,test-2,12064,malleti,12064_CAM040222_d.JPG,mimic
-CAM041061,https://zenodo.org/record/2714333/files/CAM041061_d.JPG,0,test-2,13761,malleti,13761_CAM041061_d.JPG,mimic
-CAM041093,https://zenodo.org/record/2714333/files/CAM041093_d.JPG,0,test-2,13824,malleti,13824_CAM041093_d.JPG,mimic
-CAM041091,https://zenodo.org/record/2714333/files/CAM041091_d.JPG,0,test-2,13820,malleti,13820_CAM041091_d.JPG,mimic
-CAM041100,https://zenodo.org/record/2714333/files/CAM041100_d.JPG,0,test-2,13838,malleti,13838_CAM041100_d.JPG,mimic
-CAM041067,https://zenodo.org/record/2714333/files/CAM041067_d.JPG,0,test-2,13773,malleti,13773_CAM041067_d.JPG,mimic
-CAM041065,https://zenodo.org/record/2714333/files/CAM041065_d.JPG,0,test-2,13769,malleti,13769_CAM041065_d.JPG,mimic
-CAM041064,https://zenodo.org/record/2714333/files/CAM041064_d.JPG,0,test-2,13767,malleti,13767_CAM041064_d.JPG,mimic
-CAM041063,https://zenodo.org/record/2714333/files/CAM041063_d.JPG,0,test-2,13765,malleti,13765_CAM041063_d.JPG,mimic
-CAM041101,https://zenodo.org/record/2714333/files/CAM041101_d.JPG,0,test-2,13840,malleti,13840_CAM041101_d.JPG,mimic
-CAM041138,https://zenodo.org/record/2714333/files/CAM041138_d.JPG,0,test-2,13914,malleti,13914_CAM041138_d.JPG,mimic
-CAM041121,https://zenodo.org/record/2714333/files/CAM041121_d.JPG,0,test-2,13880,malleti,13880_CAM041121_d.JPG,mimic
-CAM041062,https://zenodo.org/record/2714333/files/CAM041062_d.JPG,0,test-2,13763,malleti,13763_CAM041062_d.JPG,mimic
-CAM041060,https://zenodo.org/record/2714333/files/CAM041060_d.JPG,0,test-2,13759,malleti,13759_CAM041060_d.JPG,mimic
-CAM041053,https://zenodo.org/record/2714333/files/CAM041053_d.JPG,0,test-2,13745,malleti,13745_CAM041053_d.JPG,mimic
-CAM041013,https://zenodo.org/record/2714333/files/CAM041013_d.JPG,0,test-2,13665,malleti,13665_CAM041013_d.JPG,mimic
-CAM040999,https://zenodo.org/record/2714333/files/CAM040999_d.JPG,0,test-2,13637,malleti,13637_CAM040999_d.JPG,mimic
-CAM040992,https://zenodo.org/record/2714333/files/CAM040992_d.JPG,0,test-2,13623,malleti,13623_CAM040992_d.JPG,mimic
-CAM041000,https://zenodo.org/record/2714333/files/CAM041000_d.JPG,0,test-2,13639,malleti,13639_CAM041000_d.JPG,mimic
-CAM041052,https://zenodo.org/record/2714333/files/CAM041052_d.JPG,0,test-2,13743,malleti,13743_CAM041052_d.JPG,mimic
-CAM041051,https://zenodo.org/record/2714333/files/CAM041051_d.JPG,0,test-2,13741,malleti,13741_CAM041051_d.JPG,mimic
-CAM041048,https://zenodo.org/record/2714333/files/CAM041048_d.JPG,0,test-2,13735,malleti,13735_CAM041048_d.JPG,mimic
-CAM041046,https://zenodo.org/record/2714333/files/CAM041046_d.JPG,0,test-2,13731,malleti,13731_CAM041046_d.JPG,mimic
-CAM041038,https://zenodo.org/record/2714333/files/CAM041038_d.JPG,0,test-2,13715,malleti,13715_CAM041038_d.JPG,mimic
-CAM041036,https://zenodo.org/record/2714333/files/CAM041036_d.JPG,0,test-2,13711,malleti,13711_CAM041036_d.JPG,mimic
-CAM041035,https://zenodo.org/record/2714333/files/CAM041035_d.JPG,0,test-2,13709,malleti,13709_CAM041035_d.JPG,mimic
-CAM041027,https://zenodo.org/record/2714333/files/CAM041027_d.JPG,0,test-2,13693,malleti,13693_CAM041027_d.JPG,mimic
-CAM041021,https://zenodo.org/record/2714333/files/CAM041021_d.JPG,0,test-2,13681,malleti,13681_CAM041021_d.JPG,mimic
-CAM041191,https://zenodo.org/record/2714333/files/CAM041191_d.JPG,0,test-2,14019,malleti,14019_CAM041191_d.JPG,mimic
-CAM041187,https://zenodo.org/record/2714333/files/CAM041187_d.JPG,0,test-2,14011,malleti,14011_CAM041187_d.JPG,mimic
-CAM041186,https://zenodo.org/record/2714333/files/CAM041186_d.JPG,0,test-2,14009,malleti,14009_CAM041186_d.JPG,mimic
-CAM041185,https://zenodo.org/record/2714333/files/CAM041185_d.JPG,0,test-2,14007,malleti,14007_CAM041185_d.JPG,mimic
-CAM041184,https://zenodo.org/record/2714333/files/CAM041184_d.JPG,0,test-2,14005,malleti,14005_CAM041184_d.JPG,mimic
-CAM041183,https://zenodo.org/record/2714333/files/CAM041183_d.JPG,0,test-2,14003,malleti,14003_CAM041183_d.JPG,mimic
-CAM041182,https://zenodo.org/record/2714333/files/CAM041182_d.JPG,0,test-2,14001,malleti,14001_CAM041182_d.JPG,mimic
-CAM041181,https://zenodo.org/record/2714333/files/CAM041181_d.JPG,0,test-2,13999,malleti,13999_CAM041181_d.JPG,mimic
-CAM041180,https://zenodo.org/record/2714333/files/CAM041180_d.JPG,0,test-2,13997,malleti,13997_CAM041180_d.JPG,mimic
-CAM041179,https://zenodo.org/record/2714333/files/CAM041179_d.JPG,0,test-2,13995,malleti,13995_CAM041179_d.JPG,mimic
-CAM041159,https://zenodo.org/record/2714333/files/CAM041159_d.JPG,0,test-2,13955,malleti,13955_CAM041159_d.JPG,mimic
-CAM041200,https://zenodo.org/record/2714333/files/CAM041200_d.JPG,0,test-2,14037,malleti,14037_CAM041200_d.JPG,mimic
-CAM041168,https://zenodo.org/record/2714333/files/CAM041168_d.JPG,0,test-2,13973,malleti,13973_CAM041168_d.JPG,mimic
-CAM041174,https://zenodo.org/record/2714333/files/CAM041174_d.JPG,0,test-2,13985,malleti,13985_CAM041174_d.JPG,mimic
-CAM041176,https://zenodo.org/record/2714333/files/CAM041176_d.JPG,0,test-2,13989,malleti,13989_CAM041176_d.JPG,mimic
-CAM041177,https://zenodo.org/record/2714333/files/CAM041177_d.JPG,0,test-2,13991,malleti,13991_CAM041177_d.JPG,mimic
-CAM041178,https://zenodo.org/record/2714333/files/CAM041178_d.JPG,0,test-2,13993,malleti,13993_CAM041178_d.JPG,mimic
-CAM041201,https://zenodo.org/record/2714333/files/CAM041201_d.JPG,0,test-2,14039,malleti,14039_CAM041201_d.JPG,mimic
-CAM041202,https://zenodo.org/record/2714333/files/CAM041202_d.JPG,0,test-2,14041,malleti,14041_CAM041202_d.JPG,mimic
-CAM041203,https://zenodo.org/record/2714333/files/CAM041203_d.JPG,0,test-2,14043,malleti,14043_CAM041203_d.JPG,mimic
-CAM041221,https://zenodo.org/record/2714333/files/CAM041221_d.JPG,0,test-2,14079,malleti,14079_CAM041221_d.JPG,mimic
-CAM041222,https://zenodo.org/record/2714333/files/CAM041222_d.JPG,0,test-2,14081,malleti,14081_CAM041222_d.JPG,mimic
-CAM041223,https://zenodo.org/record/2714333/files/CAM041223_d.JPG,0,test-2,14083,malleti,14083_CAM041223_d.JPG,mimic
-CAM041224,https://zenodo.org/record/2714333/files/CAM041224_d.JPG,0,test-2,14085,malleti,14085_CAM041224_d.JPG,mimic
-CAM041220,https://zenodo.org/record/2714333/files/CAM041220_d.JPG,0,test-2,14077,malleti,14077_CAM041220_d.JPG,mimic
-CAM041218,https://zenodo.org/record/2714333/files/CAM041218_d.JPG,0,test-2,14073,malleti,14073_CAM041218_d.JPG,mimic
-CAM041204,https://zenodo.org/record/2714333/files/CAM041204_d.JPG,0,test-2,14045,malleti,14045_CAM041204_d.JPG,mimic
-CAM041205,https://zenodo.org/record/2714333/files/CAM041205_d.JPG,0,test-2,14047,malleti,14047_CAM041205_d.JPG,mimic
-CAM041206,https://zenodo.org/record/2714333/files/CAM041206_d.JPG,0,test-2,14049,malleti,14049_CAM041206_d.JPG,mimic
-CAM041207,https://zenodo.org/record/2714333/files/CAM041207_d.JPG,0,test-2,14051,malleti,14051_CAM041207_d.JPG,mimic
-CAM041208,https://zenodo.org/record/2714333/files/CAM041208_d.JPG,0,test-2,14053,malleti,14053_CAM041208_d.JPG,mimic
-CAM041209,https://zenodo.org/record/2714333/files/CAM041209_d.JPG,0,test-2,14055,malleti,14055_CAM041209_d.JPG,mimic
-CAM041219,https://zenodo.org/record/2714333/files/CAM041219_d.JPG,0,test-2,14075,malleti,14075_CAM041219_d.JPG,mimic
-CAM041210,https://zenodo.org/record/2714333/files/CAM041210_d.JPG,0,test-2,14057,malleti,14057_CAM041210_d.JPG,mimic
-CAM041212,https://zenodo.org/record/2714333/files/CAM041212_d.JPG,0,test-2,14061,malleti,14061_CAM041212_d.JPG,mimic
-CAM041213,https://zenodo.org/record/2714333/files/CAM041213_d.JPG,0,test-2,14063,malleti,14063_CAM041213_d.JPG,mimic
-CAM041214,https://zenodo.org/record/2714333/files/CAM041214_d.JPG,0,test-2,14065,malleti,14065_CAM041214_d.JPG,mimic
-CAM041215,https://zenodo.org/record/2714333/files/CAM041215_d.JPG,0,test-2,14067,malleti,14067_CAM041215_d.JPG,mimic
-CAM041216,https://zenodo.org/record/2714333/files/CAM041216_d.JPG,0,test-2,14069,malleti,14069_CAM041216_d.JPG,mimic
-CAM041217,https://zenodo.org/record/2714333/files/CAM041217_d.JPG,0,test-2,14071,malleti,14071_CAM041217_d.JPG,mimic
-CAM041211,https://zenodo.org/record/2714333/files/CAM041211_d.JPG,0,test-2,14059,malleti,14059_CAM041211_d.JPG,mimic
-CAM040731,https://zenodo.org/record/2714333/files/CAM040731_d.JPG,0,test-2,13093,malleti,13093_CAM040731_d.JPG,mimic
-CAM040732,https://zenodo.org/record/2714333/files/CAM040732_d.JPG,0,test-2,13097,malleti,13097_CAM040732_d.JPG,mimic
-CAM040708,https://zenodo.org/record/2714333/files/CAM040708_d.JPG,0,test-2,13001,malleti,13001_CAM040708_d.JPG,mimic
-CAM041147,https://zenodo.org/record/2714333/files/CAM041147_d.JPG,0,test-2,13931,malleti,13931_CAM041147_d.JPG,mimic
-CAM041149,https://zenodo.org/record/2714333/files/CAM041149_d.JPG,0,test-2,13935,malleti,13935_CAM041149_d.JPG,mimic
-CAM041274,https://zenodo.org/record/2714333/files/CAM041274_d.JPG,0,test-2,14184,malleti,14184_CAM041274_d.JPG,mimic
-CAM041276,https://zenodo.org/record/2714333/files/CAM041276_d.JPG,0,test-2,14188,malleti,14188_CAM041276_d.JPG,mimic
-CAM041275,https://zenodo.org/record/2714333/files/CAM041275_d.JPG,0,test-2,14186,malleti,14186_CAM041275_d.JPG,mimic
-CS002633,https://zenodo.org/record/2735056/files/CS002633_d.JPG,0,test,40923,venus,40923_CS002633_d.JPG,minor
-CS002631,https://zenodo.org/record/2735056/files/CS002631_d.JPG,0,test,40919,venus,40919_CS002631_d.JPG,minor
-CS002627,https://zenodo.org/record/2735056/files/CS002627_d.JPG,0,test,40915,venus,40915_CS002627_d.JPG,minor
-CS003358,https://zenodo.org/record/2735056/files/CS003358_d.JPG,0,test,40991,venus,40991_CS003358_d.JPG,minor
-CS003660,https://zenodo.org/record/2735056/files/CS003660_d.JPG,0,test,41075,venus,41075_CS003660_d.JPG,minor
-CS003652,https://zenodo.org/record/2735056/files/CS003652_d.JPG,0,test,41043,venus,41043_CS003652_d.JPG,minor
-CS002280,https://zenodo.org/record/2735056/files/CS002280_d.JPG,0,test,40875,venus,40875_CS002280_d.JPG,minor
-CS002272,https://zenodo.org/record/2735056/files/CS002272_d.JPG,0,test,40843,venus,40843_CS002272_d.JPG,minor
-CS002281,https://zenodo.org/record/2735056/files/CS002281_d.JPG,0,test,40879,venus,40879_CS002281_d.JPG,minor
-CS002273,https://zenodo.org/record/2735056/files/CS002273_d.JPG,0,test,40847,venus,40847_CS002273_d.JPG,minor
-CS002274,https://zenodo.org/record/2735056/files/CS002274_d.JPG,0,test,40851,venus,40851_CS002274_d.JPG,minor
-CS002276,https://zenodo.org/record/2735056/files/CS002276_d.JPG,0,test,40859,venus,40859_CS002276_d.JPG,minor
-CS002279,https://zenodo.org/record/2735056/files/CS002279_d.JPG,0,test,40871,venus,40871_CS002279_d.JPG,minor
-CS002275,https://zenodo.org/record/2735056/files/CS002275_d.JPG,0,test,40855,venus,40855_CS002275_d.JPG,minor
-CS002277,https://zenodo.org/record/2735056/files/CS002277_d.JPG,0,test,40863,venus,40863_CS002277_d.JPG,minor
-CAM120557,https://zenodo.org/record/2813153/files/CAM120557_d.JPG,0,test-2,14891,malleti,14891_CAM120557_d.JPG,mimic
-CAM120448,https://zenodo.org/record/2813153/files/CAM120448_d.JPG,0,test-2,14885,malleti,14885_CAM120448_d.JPG,mimic
-CS004030,https://zenodo.org/record/2813153/files/CS004030_d.JPG,0,test-2,14346,malleti,14346_CS004030_d.JPG,mimic
-CS004032,https://zenodo.org/record/2813153/files/CS004032_d.JPG,0,test-2,14350,malleti,14350_CS004032_d.JPG,mimic
-CS004034,https://zenodo.org/record/2813153/files/CS004034_d.JPG,0,test-2,14354,malleti,14354_CS004034_d.JPG,mimic
-CS004038,https://zenodo.org/record/2813153/files/CS004038_d.JPG,0,test-2,14362,malleti,14362_CS004038_d.JPG,mimic
-CS004039,https://zenodo.org/record/2813153/files/CS004039_d.JPG,0,test-2,14364,malleti,14364_CS004039_d.JPG,mimic
-CS004058,https://zenodo.org/record/2813153/files/CS004058_d.JPG,0,test,14382,reductimacula,14382_CS004058_d.JPG,minor
-CAM016792,https://zenodo.org/record/3082688/files/CAM016792_d.JPG,1,test-2,4006,plesseni x malleti,4006_CAM016792_d.JPG,mimic
-CAM016803,https://zenodo.org/record/3082688/files/CAM016803_d.JPG,0,test-2,4028,plesseni,4028_CAM016803_d.JPG,mimic
-CAM016765,https://zenodo.org/record/3082688/files/CAM016765_d.JPG,1,test-2,3966,plesseni x malleti,3966_CAM016765_d.JPG,mimic
-CAM016766,https://zenodo.org/record/3082688/files/CAM016766_d.JPG,0,test-2,3968,malleti,3968_CAM016766_d.JPG,mimic
-CAM016772,https://zenodo.org/record/3082688/files/CAM016772_d.JPG,0,test-2,3978,malleti,3978_CAM016772_d.JPG,mimic
-CAM016778,https://zenodo.org/record/3082688/files/CAM016778_d.JPG,1,test-2,3982,plesseni x malleti,3982_CAM016778_d.JPG,mimic
-CAM016785,https://zenodo.org/record/3082688/files/CAM016785_d.JPG,1,test-2,3992,plesseni x malleti,3992_CAM016785_d.JPG,mimic
-CAM016769,https://zenodo.org/record/3082688/files/CAM016769_d.JPG,1,test-2,3974,plesseni x malleti,3974_CAM016769_d.JPG,mimic
-CAM016808,https://zenodo.org/record/3082688/files/CAM016808_d.JPG,1,test-2,4038,plesseni x malleti,4038_CAM016808_d.JPG,mimic
-CAM016810,https://zenodo.org/record/3082688/files/CAM016810_d.JPG,0,test-2,4042,plesseni,4042_CAM016810_d.JPG,mimic
-CAM016834,https://zenodo.org/record/3082688/files/CAM016834_d.JPG,1,test-2,4089,plesseni x malleti,4089_CAM016834_d.JPG,mimic
-CAM016836,https://zenodo.org/record/3082688/files/CAM016836_d.JPG,1,test-2,4091,plesseni x malleti,4091_CAM016836_d.JPG,mimic
-CAM016843,https://zenodo.org/record/3082688/files/CAM016843_d.JPG,1,test-2,4105,plesseni x malleti,4105_CAM016843_d.JPG,mimic
-CAM016844,https://zenodo.org/record/3082688/files/CAM016844_d.JPG,1,test-2,4107,plesseni x malleti,4107_CAM016844_d.JPG,mimic
-CAM016846,https://zenodo.org/record/3082688/files/CAM016846_d.JPG,1,test-2,4111,plesseni x malleti,4111_CAM016846_d.JPG,mimic
-CAM016847,https://zenodo.org/record/3082688/files/CAM016847_d.JPG,1,test-2,4113,plesseni x malleti,4113_CAM016847_d.JPG,mimic
-CAM016849,https://zenodo.org/record/3082688/files/CAM016849_d.JPG,1,test-2,4117,plesseni x malleti,4117_CAM016849_d.JPG,mimic
-CAM016829,https://zenodo.org/record/3082688/files/CAM016829_d.JPG,1,test-2,4080,plesseni x malleti,4080_CAM016829_d.JPG,mimic
-CAM016809,https://zenodo.org/record/3082688/files/CAM016809_d.JPG,1,test-2,4040,plesseni x malleti,4040_CAM016809_d.JPG,mimic
-CAM016819,https://zenodo.org/record/3082688/files/CAM016819_d.JPG,1,test-2,4060,plesseni x malleti,4060_CAM016819_d.JPG,mimic
-CAM016821,https://zenodo.org/record/3082688/files/CAM016821_d.JPG,1,test-2,4064,plesseni x malleti,4064_CAM016821_d.JPG,mimic
-CAM016822,https://zenodo.org/record/3082688/files/CAM016822_d.JPG,1,test-2,4066,plesseni x malleti,4066_CAM016822_d.JPG,mimic
-CAM016826,https://zenodo.org/record/3082688/files/CAM016826_d.JPG,1,test-2,4074,plesseni x malleti,4074_CAM016826_d.JPG,mimic
-CAM016828,https://zenodo.org/record/3082688/files/CAM016828_d.JPG,1,test-2,4078,plesseni x malleti,4078_CAM016828_d.JPG,mimic
-CAM016820,https://zenodo.org/record/3082688/files/CAM016820_d.JPG,1,test-2,4062,plesseni x malleti,4062_CAM016820_d.JPG,mimic
-CAM016851,https://zenodo.org/record/3082688/files/CAM016851_d.JPG,1,test-2,4121,plesseni x malleti,4121_CAM016851_d.JPG,mimic
-CAM016066,https://zenodo.org/record/3082688/files/CAM016066_d.JPG,1,test-2,3040,plesseni x malleti,3040_CAM016066_d.JPG,mimic
-CAM016065,https://zenodo.org/record/3082688/files/CAM016065_d.JPG,1,test-2,3038,plesseni x malleti,3038_CAM016065_d.JPG,mimic
-CAM016055,https://zenodo.org/record/3082688/files/CAM016055_d.JPG,1,test-2,3019,plesseni x malleti,3019_CAM016055_d.JPG,mimic
-CAM016655,https://zenodo.org/record/3082688/files/CAM016655_d.JPG,1,test-2,3845,plesseni x malleti,3845_CAM016655_d.JPG,mimic
-CAM016656,https://zenodo.org/record/3082688/files/CAM016656_d.JPG,1,test-2,3847,plesseni x malleti,3847_CAM016656_d.JPG,mimic
-CAM016657,https://zenodo.org/record/3082688/files/CAM016657_d.JPG,1,test-2,3849,plesseni x malleti,3849_CAM016657_d.JPG,mimic
-CAM016658,https://zenodo.org/record/3082688/files/CAM016658_d.JPG,1,test-2,3851,plesseni x malleti,3851_CAM016658_d.JPG,mimic
-CAM016659,https://zenodo.org/record/3082688/files/CAM016659_d.JPG,1,test-2,3853,plesseni x malleti,3853_CAM016659_d.JPG,mimic
-CAM016660,https://zenodo.org/record/3082688/files/CAM016660_d.JPG,1,test-2,3855,plesseni x malleti,3855_CAM016660_d.JPG,mimic
-CAM016661,https://zenodo.org/record/3082688/files/CAM016661_d.JPG,1,test-2,3857,plesseni x malleti,3857_CAM016661_d.JPG,mimic
-CAM016662,https://zenodo.org/record/3082688/files/CAM016662_d.JPG,1,test-2,3859,plesseni x malleti,3859_CAM016662_d.JPG,mimic
-CAM016663,https://zenodo.org/record/3082688/files/CAM016663_d.JPG,1,test-2,3861,plesseni x malleti,3861_CAM016663_d.JPG,mimic
-CAM016672,https://zenodo.org/record/3082688/files/CAM016672_d.JPG,1,test-2,3878,plesseni x malleti,3878_CAM016672_d.JPG,mimic
-CAM016042,https://zenodo.org/record/3082688/files/CAM016042_d.JPG,1,test-2,2993,plesseni x malleti,2993_CAM016042_d.JPG,mimic
-CAM016751,https://zenodo.org/record/3082688/files/CAM016751_d.JPG,1,test-2,3938,plesseni x malleti,3938_CAM016751_d.JPG,mimic
-CAM016753,https://zenodo.org/record/3082688/files/CAM016753_d.JPG,1,test-2,3942,plesseni x malleti,3942_CAM016753_d.JPG,mimic
-CAM016754,https://zenodo.org/record/3082688/files/CAM016754_d.JPG,1,test-2,3944,plesseni x malleti,3944_CAM016754_d.JPG,mimic
-CAM016043,https://zenodo.org/record/3082688/files/CAM016043_d.JPG,1,test-2,2995,plesseni x malleti,2995_CAM016043_d.JPG,mimic
-CAM016044,https://zenodo.org/record/3082688/files/CAM016044_d.JPG,1,test-2,2997,plesseni x malleti,2997_CAM016044_d.JPG,mimic
-CAM016050,https://zenodo.org/record/3082688/files/CAM016050_d.JPG,1,test-2,3009,plesseni x malleti,3009_CAM016050_d.JPG,mimic
-CAM017018,https://zenodo.org/record/3082688/files/CAM017018_d.JPG,1,test-2,4391,plesseni x malleti,4391_CAM017018_d.JPG,mimic
-CAM017019,https://zenodo.org/record/3082688/files/CAM017019_d.JPG,0,test-2,4393,malleti,4393_CAM017019_d.JPG,mimic
-CAM016990,https://zenodo.org/record/3082688/files/CAM016990_d.JPG,0,test-2,4342,malleti,4342_CAM016990_d.JPG,mimic
-CAM016998,https://zenodo.org/record/3082688/files/CAM016998_d.JPG,1,test,4355,notabilis x lativitta,4355_CAM016998_d.JPG,major
-CAM017000,https://zenodo.org/record/3082688/files/CAM017000_d.JPG,1,test,4359,notabilis x lativitta,4359_CAM017000_d.JPG,major
-CAM017001,https://zenodo.org/record/3082688/files/CAM017001_d.JPG,1,test,4361,notabilis x lativitta,4361_CAM017001_d.JPG,major
-CAM017002,https://zenodo.org/record/3082688/files/CAM017002_d.JPG,1,test,4363,notabilis x lativitta,4363_CAM017002_d.JPG,major
-CAM017003,https://zenodo.org/record/3082688/files/CAM017003_d.JPG,1,test,4365,notabilis x lativitta,4365_CAM017003_d.JPG,major
-CAM017004,https://zenodo.org/record/3082688/files/CAM017004_d.JPG,1,test,4367,notabilis x lativitta,4367_CAM017004_d.JPG,major
-CAM016997,https://zenodo.org/record/3082688/files/CAM016997_d.JPG,1,test,4354,notabilis x lativitta,4354_CAM016997_d.JPG,major
-CAM016978,https://zenodo.org/record/3082688/files/CAM016978_d.JPG,1,test,4326,notabilis x lativitta,4326_CAM016978_d.JPG,major
-CAM017022,https://zenodo.org/record/3082688/files/CAM017022_d.JPG,1,test,4399,notabilis x lativitta,4399_CAM017022_d.JPG,major
-CAM017963,https://zenodo.org/record/3082688/files/CAM017963_d.JPG,1,test,5806,lativitta x notabilis,5806_CAM017963_d.JPG,major
-CAM017039,https://zenodo.org/record/3082688/files/CAM017039_d.JPG,1,test,4431,notabilis x lativitta,4431_CAM017039_d.JPG,major
-CAM017040,https://zenodo.org/record/3082688/files/CAM017040_d.JPG,1,test-2,4433,plesseni x malleti,4433_CAM017040_d.JPG,mimic
-CAM017041,https://zenodo.org/record/3082688/files/CAM017041_d.JPG,0,test-2,4435,malleti,4435_CAM017041_d.JPG,mimic
-CAM017042,https://zenodo.org/record/3082688/files/CAM017042_d.JPG,1,test,4437,notabilis x lativitta,4437_CAM017042_d.JPG,major
-CAM016282,https://zenodo.org/record/3082688/files/CAM016282_d.JPG,0,test-2,3396,plesseni,3396_CAM016282_d.JPG,mimic
-CAM017044,https://zenodo.org/record/3082688/files/CAM017044_d.JPG,1,test,4441,notabilis x lativitta,4441_CAM017044_d.JPG,major
-CAM017045,https://zenodo.org/record/3082688/files/CAM017045_d.JPG,1,test,4443,notabilis x lativitta,4443_CAM017045_d.JPG,major
-CAM017046,https://zenodo.org/record/3082688/files/CAM017046_d.JPG,1,test,4445,notabilis x lativitta,4445_CAM017046_d.JPG,major
-CAM017038,https://zenodo.org/record/3082688/files/CAM017038_d.JPG,1,test,4429,notabilis x lativitta,4429_CAM017038_d.JPG,major
-CAM017037,https://zenodo.org/record/3082688/files/CAM017037_d.JPG,1,test,4427,notabilis x lativitta,4427_CAM017037_d.JPG,major
-CAM017036,https://zenodo.org/record/3082688/files/CAM017036_d.JPG,1,test,4425,notabilis x lativitta,4425_CAM017036_d.JPG,major
-CAM017034,https://zenodo.org/record/3082688/files/CAM017034_d.JPG,1,test,4423,notabilis x lativitta,4423_CAM017034_d.JPG,major
-CAM017023,https://zenodo.org/record/3082688/files/CAM017023_d.JPG,1,test,4401,notabilis x lativitta,4401_CAM017023_d.JPG,major
-CAM017976,https://zenodo.org/record/3082688/files/CAM017976_d.JPG,1,test-2,5819,plesseni x malleti,5819_CAM017976_d.JPG,mimic
-CAM017025,https://zenodo.org/record/3082688/files/CAM017025_d.JPG,1,test,4405,notabilis x lativitta,4405_CAM017025_d.JPG,major
-CAM017028,https://zenodo.org/record/3082688/files/CAM017028_d.JPG,1,test,4411,notabilis x lativitta,4411_CAM017028_d.JPG,major
-CAM017030,https://zenodo.org/record/3082688/files/CAM017030_d.JPG,0,test-2,4415,malleti,4415_CAM017030_d.JPG,mimic
-CAM017031,https://zenodo.org/record/3082688/files/CAM017031_d.JPG,1,test,4417,notabilis x lativitta,4417_CAM017031_d.JPG,major
-CAM017032,https://zenodo.org/record/3082688/files/CAM017032_d.JPG,1,test,4419,notabilis x lativitta,4419_CAM017032_d.JPG,major
-CAM017033,https://zenodo.org/record/3082688/files/CAM017033_d.JPG,1,test,4421,notabilis x lativitta,4421_CAM017033_d.JPG,major
-CAM017029,https://zenodo.org/record/3082688/files/CAM017029_d.JPG,1,test,4413,notabilis x lativitta,4413_CAM017029_d.JPG,major
-CAM016976,https://zenodo.org/record/3082688/files/CAM016976_d.JPG,1,test,4322,notabilis x lativitta,4322_CAM016976_d.JPG,major
-CAM016970,https://zenodo.org/record/3082688/files/CAM016970_d.JPG,1,test,4310,notabilis x lativitta,4310_CAM016970_d.JPG,major
-CAM016858,https://zenodo.org/record/3082688/files/CAM016858_d.JPG,1,test-2,4135,plesseni x malleti,4135_CAM016858_d.JPG,mimic
-CAM016859,https://zenodo.org/record/3082688/files/CAM016859_d.JPG,1,test-2,4137,plesseni x malleti,4137_CAM016859_d.JPG,mimic
-CAM016860,https://zenodo.org/record/3082688/files/CAM016860_d.JPG,1,test-2,4139,plesseni x malleti,4139_CAM016860_d.JPG,mimic
-CAM016861,https://zenodo.org/record/3082688/files/CAM016861_d.JPG,1,test-2,4141,plesseni x malleti,4141_CAM016861_d.JPG,mimic
-CAM016862,https://zenodo.org/record/3082688/files/CAM016862_d.JPG,1,test,4143,notabilis x lativitta,4143_CAM016862_d.JPG,major
-CAM016863,https://zenodo.org/record/3082688/files/CAM016863_d.JPG,1,test-2,4145,plesseni x malleti,4145_CAM016863_d.JPG,mimic
-CAM016864,https://zenodo.org/record/3082688/files/CAM016864_d.JPG,1,test,4147,notabilis x lativitta,4147_CAM016864_d.JPG,major
-CAM016865,https://zenodo.org/record/3082688/files/CAM016865_d.JPG,1,test-2,4149,plesseni x malleti,4149_CAM016865_d.JPG,mimic
-CAM016866,https://zenodo.org/record/3082688/files/CAM016866_d.JPG,1,test,4151,notabilis x lativitta,4151_CAM016866_d.JPG,major
-CAM016869,https://zenodo.org/record/3082688/files/CAM016869_d.JPG,1,test-2,4155,plesseni x malleti,4155_CAM016869_d.JPG,mimic
-CAM016867,https://zenodo.org/record/3082688/files/CAM016867_d.JPG,1,test-2,4153,plesseni x malleti,4153_CAM016867_d.JPG,mimic
-CAM016927,https://zenodo.org/record/3082688/files/CAM016927_d.JPG,1,test,4255,notabilis x lativitta,4255_CAM016927_d.JPG,major
-CAM016930,https://zenodo.org/record/3082688/files/CAM016930_d.JPG,1,test,4261,notabilis x lativitta,4261_CAM016930_d.JPG,major
-CAM016947,https://zenodo.org/record/3082688/files/CAM016947_d.JPG,1,test,4277,notabilis x lativitta,4277_CAM016947_d.JPG,major
-CAM016954,https://zenodo.org/record/3082688/files/CAM016954_d.JPG,0,test-2,4285,malleti,4285_CAM016954_d.JPG,mimic
-CAM016924,https://zenodo.org/record/3082688/files/CAM016924_d.JPG,1,test,4249,notabilis x lativitta,4249_CAM016924_d.JPG,major
-CAM016955,https://zenodo.org/record/3082688/files/CAM016955_d.JPG,0,test-2,4287,malleti,4287_CAM016955_d.JPG,mimic
-CAM016961,https://zenodo.org/record/3082688/files/CAM016961_d.JPG,1,test,4297,notabilis x lativitta,4297_CAM016961_d.JPG,major
-CAM016964,https://zenodo.org/record/3082688/files/CAM016964_d.JPG,1,test,4303,notabilis x lativitta,4303_CAM016964_d.JPG,major
-CAM016965,https://zenodo.org/record/3082688/files/CAM016965_d.JPG,1,test,4305,notabilis x lativitta,4305_CAM016965_d.JPG,major
-CAM016968,https://zenodo.org/record/3082688/files/CAM016968_d.JPG,1,test,4307,notabilis x lativitta,4307_CAM016968_d.JPG,major
-CAM016969,https://zenodo.org/record/3082688/files/CAM016969_d.JPG,1,test,4308,notabilis x lativitta,4308_CAM016969_d.JPG,major
-CAM016956,https://zenodo.org/record/3082688/files/CAM016956_d.JPG,0,test-2,4289,malleti,4289_CAM016956_d.JPG,mimic
-CAM016654,https://zenodo.org/record/3082688/files/CAM016654_d.JPG,1,test-2,3843,plesseni x malleti,3843_CAM016654_d.JPG,mimic
-CAM016923,https://zenodo.org/record/3082688/files/CAM016923_d.JPG,1,test-2,4247,plesseni x malleti,4247_CAM016923_d.JPG,mimic
-CAM016041,https://zenodo.org/record/3082688/files/CAM016041_d.JPG,1,test-2,2991,plesseni x malleti,2991_CAM016041_d.JPG,mimic
-CAM016040,https://zenodo.org/record/3082688/files/CAM016040_d.JPG,1,test,2989,notabilis x lativitta,2989_CAM016040_d.JPG,major
-CAM016039,https://zenodo.org/record/3082688/files/CAM016039_d.JPG,1,test,2987,notabilis x lativitta,2987_CAM016039_d.JPG,major
-CAM016038,https://zenodo.org/record/3082688/files/CAM016038_d.JPG,1,test,2985,notabilis x lativitta,2985_CAM016038_d.JPG,major
-CAM016036,https://zenodo.org/record/3082688/files/CAM016036_d.JPG,1,test-2,2981,plesseni x malleti,2981_CAM016036_d.JPG,mimic
-CAM016035,https://zenodo.org/record/3082688/files/CAM016035_d.JPG,1,test,2979,notabilis x lativitta,2979_CAM016035_d.JPG,major
-CAM016922,https://zenodo.org/record/3082688/files/CAM016922_d.JPG,1,test-2,4245,plesseni x malleti,4245_CAM016922_d.JPG,mimic
-CAM016034,https://zenodo.org/record/3082688/files/CAM016034_d.JPG,1,test,2977,notabilis x lativitta,2977_CAM016034_d.JPG,major
-CAM016033,https://zenodo.org/record/3082688/files/CAM016033_d.JPG,1,test,2975,notabilis x lativitta,2975_CAM016033_d.JPG,major
-CAM016920,https://zenodo.org/record/3082688/files/CAM016920_d.JPG,1,test-2,4241,plesseni x malleti,4241_CAM016920_d.JPG,mimic
-CAM016653,https://zenodo.org/record/3082688/files/CAM016653_d.JPG,1,test,3841,notabilis x lativitta,3841_CAM016653_d.JPG,major
-CAM016652,https://zenodo.org/record/3082688/files/CAM016652_d.JPG,1,test,3839,notabilis x lativitta,3839_CAM016652_d.JPG,major
-CAM016651,https://zenodo.org/record/3082688/files/CAM016651_d.JPG,1,test,3837,notabilis x lativitta,3837_CAM016651_d.JPG,major
-CAM016117,https://zenodo.org/record/3082688/files/CAM016117_d.JPG,1,test-2,3142,plesseni x malleti,3142_CAM016117_d.JPG,mimic
-CAM016116,https://zenodo.org/record/3082688/files/CAM016116_d.JPG,0,test-2,3140,plesseni,3140_CAM016116_d.JPG,mimic
-CAM016115,https://zenodo.org/record/3082688/files/CAM016115_d.JPG,1,test,3138,notabilis x lativitta,3138_CAM016115_d.JPG,major
-CAM016114,https://zenodo.org/record/3082688/files/CAM016114_d.JPG,1,test,3136,notabilis x lativitta,3136_CAM016114_d.JPG,major
-CAM016113,https://zenodo.org/record/3082688/files/CAM016113_d.JPG,0,test-2,3134,plesseni,3134_CAM016113_d.JPG,mimic
-CAM016112,https://zenodo.org/record/3082688/files/CAM016112_d.JPG,1,test,3132,notabilis x lativitta,3132_CAM016112_d.JPG,major
-CAM016111,https://zenodo.org/record/3082688/files/CAM016111_d.JPG,1,test-2,3130,plesseni x malleti,3130_CAM016111_d.JPG,mimic
-CAM016110,https://zenodo.org/record/3082688/files/CAM016110_d.JPG,1,test,3128,notabilis x lativitta,3128_CAM016110_d.JPG,major
-CAM016106,https://zenodo.org/record/3082688/files/CAM016106_d.JPG,1,test-2,3120,plesseni x malleti,3120_CAM016106_d.JPG,mimic
-CAM016105,https://zenodo.org/record/3082688/files/CAM016105_d.JPG,1,test,3118,notabilis x lativitta,3118_CAM016105_d.JPG,major
-CAM016296,https://zenodo.org/record/3082688/files/CAM016296_d.JPG,0,test-2,3408,plesseni,3408_CAM016296_d.JPG,mimic
-CAM016102,https://zenodo.org/record/3082688/files/CAM016102_d.JPG,1,test,3112,notabilis x lativitta,3112_CAM016102_d.JPG,major
-CAM016118,https://zenodo.org/record/3082688/files/CAM016118_d.JPG,1,test-2,3144,plesseni x malleti,3144_CAM016118_d.JPG,mimic
-CAM016119,https://zenodo.org/record/3082688/files/CAM016119_d.JPG,1,test-2,3146,plesseni x malleti,3146_CAM016119_d.JPG,mimic
-CAM016120,https://zenodo.org/record/3082688/files/CAM016120_d.JPG,1,test-2,3148,plesseni x malleti,3148_CAM016120_d.JPG,mimic
-CAM016121,https://zenodo.org/record/3082688/files/CAM016121_d.JPG,1,test,3150,notabilis x lativitta,3150_CAM016121_d.JPG,major
-CAM016139,https://zenodo.org/record/3082688/files/CAM016139_d.JPG,1,test,3186,notabilis x lativitta,3186_CAM016139_d.JPG,major
-CAM016138,https://zenodo.org/record/3082688/files/CAM016138_d.JPG,1,test,3184,notabilis x lativitta,3184_CAM016138_d.JPG,major
-CAM016137,https://zenodo.org/record/3082688/files/CAM016137_d.JPG,1,test-2,3182,plesseni x malleti,3182_CAM016137_d.JPG,mimic
-CAM016136,https://zenodo.org/record/3082688/files/CAM016136_d.JPG,1,test-2,3180,plesseni x malleti,3180_CAM016136_d.JPG,mimic
-CAM016135,https://zenodo.org/record/3082688/files/CAM016135_d.JPG,1,test-2,3178,plesseni x malleti,3178_CAM016135_d.JPG,mimic
-CAM016134,https://zenodo.org/record/3082688/files/CAM016134_d.JPG,0,test-2,3176,plesseni,3176_CAM016134_d.JPG,mimic
-CAM016133,https://zenodo.org/record/3082688/files/CAM016133_d.JPG,1,test-2,3174,plesseni x malleti,3174_CAM016133_d.JPG,mimic
-CAM016132,https://zenodo.org/record/3082688/files/CAM016132_d.JPG,1,test-2,3172,plesseni x malleti,3172_CAM016132_d.JPG,mimic
-CAM016131,https://zenodo.org/record/3082688/files/CAM016131_d.JPG,1,test-2,3170,plesseni x malleti,3170_CAM016131_d.JPG,mimic
-CAM016129,https://zenodo.org/record/3082688/files/CAM016129_d.JPG,1,test,3166,notabilis x lativitta,3166_CAM016129_d.JPG,major
-CAM016128,https://zenodo.org/record/3082688/files/CAM016128_d.JPG,1,test,3164,notabilis x lativitta,3164_CAM016128_d.JPG,major
-CAM016127,https://zenodo.org/record/3082688/files/CAM016127_d.JPG,1,test-2,3162,plesseni x malleti,3162_CAM016127_d.JPG,mimic
-CAM016126,https://zenodo.org/record/3082688/files/CAM016126_d.JPG,1,test-2,3160,plesseni x malleti,3160_CAM016126_d.JPG,mimic
-CAM016125,https://zenodo.org/record/3082688/files/CAM016125_d.JPG,1,test-2,3158,plesseni x malleti,3158_CAM016125_d.JPG,mimic
-CAM016124,https://zenodo.org/record/3082688/files/CAM016124_d.JPG,1,test,3156,notabilis x lativitta,3156_CAM016124_d.JPG,major
-CAM016122,https://zenodo.org/record/3082688/files/CAM016122_d.JPG,1,test-2,3152,plesseni x malleti,3152_CAM016122_d.JPG,mimic
-CAM016130,https://zenodo.org/record/3082688/files/CAM016130_d.JPG,1,test-2,3168,plesseni x malleti,3168_CAM016130_d.JPG,mimic
-CAM016140,https://zenodo.org/record/3082688/files/CAM016140_d.JPG,1,test,3188,notabilis x lativitta,3188_CAM016140_d.JPG,major
-CAM016100,https://zenodo.org/record/3082688/files/CAM016100_d.JPG,1,test-2,3108,plesseni x malleti,3108_CAM016100_d.JPG,mimic
-CAM016306,https://zenodo.org/record/3082688/files/CAM016306_d.JPG,1,test-2,3412,plesseni x malleti,3412_CAM016306_d.JPG,mimic
-CAM016088,https://zenodo.org/record/3082688/files/CAM016088_d.JPG,1,test,3084,notabilis x lativitta,3084_CAM016088_d.JPG,major
-CAM016354,https://zenodo.org/record/3082688/files/CAM016354_d.JPG,0,test-2,3438,plesseni,3438_CAM016354_d.JPG,mimic
-CAM016355,https://zenodo.org/record/3082688/files/CAM016355_d.JPG,0,test-2,3440,plesseni,3440_CAM016355_d.JPG,mimic
-CAM016087,https://zenodo.org/record/3082688/files/CAM016087_d.JPG,1,test-2,3082,plesseni x malleti,3082_CAM016087_d.JPG,mimic
-CAM016086,https://zenodo.org/record/3082688/files/CAM016086_d.JPG,1,test-2,3080,plesseni x malleti,3080_CAM016086_d.JPG,mimic
-CAM016084,https://zenodo.org/record/3082688/files/CAM016084_d.JPG,1,test-2,3076,plesseni x malleti,3076_CAM016084_d.JPG,mimic
-CAM016089,https://zenodo.org/record/3082688/files/CAM016089_d.JPG,1,test-2,3086,plesseni x malleti,3086_CAM016089_d.JPG,mimic
-CAM016350,https://zenodo.org/record/3082688/files/CAM016350_d.JPG,1,test-2,3436,plesseni x malleti,3436_CAM016350_d.JPG,mimic
-CAM016349,https://zenodo.org/record/3082688/files/CAM016349_d.JPG,0,test-2,3434,plesseni,3434_CAM016349_d.JPG,mimic
-CAM016347,https://zenodo.org/record/3082688/files/CAM016347_d.JPG,0,test-2,3432,plesseni,3432_CAM016347_d.JPG,mimic
-CAM016098,https://zenodo.org/record/3082688/files/CAM016098_d.JPG,1,test-2,3104,plesseni x malleti,3104_CAM016098_d.JPG,mimic
-CAM016097,https://zenodo.org/record/3082688/files/CAM016097_d.JPG,1,test-2,3102,plesseni x malleti,3102_CAM016097_d.JPG,mimic
-CAM016309,https://zenodo.org/record/3082688/files/CAM016309_d.JPG,1,test-2,3414,plesseni x malleti,3414_CAM016309_d.JPG,mimic
-CAM016096,https://zenodo.org/record/3082688/files/CAM016096_d.JPG,1,test,3100,notabilis x lativitta,3100_CAM016096_d.JPG,major
-CAM016312,https://zenodo.org/record/3082688/files/CAM016312_d.JPG,1,test-2,3416,plesseni x malleti,3416_CAM016312_d.JPG,mimic
-CAM016313,https://zenodo.org/record/3082688/files/CAM016313_d.JPG,1,test-2,3418,plesseni x malleti,3418_CAM016313_d.JPG,mimic
-CAM016094,https://zenodo.org/record/3082688/files/CAM016094_d.JPG,1,test,3096,notabilis x lativitta,3096_CAM016094_d.JPG,major
-CAM016099,https://zenodo.org/record/3082688/files/CAM016099_d.JPG,1,test,3106,notabilis x lativitta,3106_CAM016099_d.JPG,major
-CAM016091,https://zenodo.org/record/3082688/files/CAM016091_d.JPG,1,test,3090,notabilis x lativitta,3090_CAM016091_d.JPG,major
-CAM016338,https://zenodo.org/record/3082688/files/CAM016338_d.JPG,1,test-2,3424,plesseni x malleti,3424_CAM016338_d.JPG,mimic
-CAM016339,https://zenodo.org/record/3082688/files/CAM016339_d.JPG,1,test-2,3426,plesseni x malleti,3426_CAM016339_d.JPG,mimic
-CAM016340,https://zenodo.org/record/3082688/files/CAM016340_d.JPG,1,test-2,3428,plesseni x malleti,3428_CAM016340_d.JPG,mimic
-CAM016234,https://zenodo.org/record/3082688/files/CAM016234_d.JPG,0,test-2,3344,malleti,3344_CAM016234_d.JPG,mimic
-CAM016224,https://zenodo.org/record/3082688/files/CAM016224_d.JPG,0,test-2,3334,malleti,3334_CAM016224_d.JPG,mimic
-CAM016205,https://zenodo.org/record/3082688/files/CAM016205_d.JPG,0,test-2,3316,malleti,3316_CAM016205_d.JPG,mimic
-CAM016197,https://zenodo.org/record/3082688/files/CAM016197_d.JPG,0,test-2,3302,malleti,3302_CAM016197_d.JPG,mimic
-CAM016194,https://zenodo.org/record/3082688/files/CAM016194_d.JPG,1,test,3296,notabilis x lativitta,3296_CAM016194_d.JPG,major
-CAM016193,https://zenodo.org/record/3082688/files/CAM016193_d.JPG,1,test,3294,notabilis x lativitta,3294_CAM016193_d.JPG,major
-CAM016192,https://zenodo.org/record/3082688/files/CAM016192_d.JPG,1,test,3292,notabilis x lativitta,3292_CAM016192_d.JPG,major
-CAM016190,https://zenodo.org/record/3082688/files/CAM016190_d.JPG,0,test-2,3288,malleti,3288_CAM016190_d.JPG,mimic
-CAM016274,https://zenodo.org/record/3082688/files/CAM016274_d.JPG,0,test-2,3392,malleti,3392_CAM016274_d.JPG,mimic
-CAM016273,https://zenodo.org/record/3082688/files/CAM016273_d.JPG,0,test-2,3390,malleti,3390_CAM016273_d.JPG,mimic
-CAM016267,https://zenodo.org/record/3082688/files/CAM016267_d.JPG,0,test-2,3380,malleti,3380_CAM016267_d.JPG,mimic
-CAM016266,https://zenodo.org/record/3082688/files/CAM016266_d.JPG,0,test-2,3378,malleti,3378_CAM016266_d.JPG,mimic
-CAM016268,https://zenodo.org/record/3082688/files/CAM016268_d.JPG,0,test-2,3382,malleti,3382_CAM016268_d.JPG,mimic
-CAM016188,https://zenodo.org/record/3082688/files/CAM016188_d.JPG,1,test,3284,notabilis x lativitta,3284_CAM016188_d.JPG,major
-CAM016187,https://zenodo.org/record/3082688/files/CAM016187_d.JPG,1,test,3282,notabilis x lativitta,3282_CAM016187_d.JPG,major
-CAM016186,https://zenodo.org/record/3082688/files/CAM016186_d.JPG,1,test,3280,notabilis x lativitta,3280_CAM016186_d.JPG,major
-CAM016157,https://zenodo.org/record/3082688/files/CAM016157_d.JPG,1,test,3222,notabilis x lativitta,3222_CAM016157_d.JPG,major
-CAM016156,https://zenodo.org/record/3082688/files/CAM016156_d.JPG,1,test,3220,notabilis x lativitta,3220_CAM016156_d.JPG,major
-CAM016155,https://zenodo.org/record/3082688/files/CAM016155_d.JPG,1,test,3218,notabilis x lativitta,3218_CAM016155_d.JPG,major
-CAM016154,https://zenodo.org/record/3082688/files/CAM016154_d.JPG,1,test,3216,notabilis x lativitta,3216_CAM016154_d.JPG,major
-CAM016162,https://zenodo.org/record/3082688/files/CAM016162_d.JPG,1,test,3232,notabilis x lativitta,3232_CAM016162_d.JPG,major
-CAM016153,https://zenodo.org/record/3082688/files/CAM016153_d.JPG,1,test,3214,notabilis x lativitta,3214_CAM016153_d.JPG,major
-CAM016151,https://zenodo.org/record/3082688/files/CAM016151_d.JPG,1,test,3210,notabilis x lativitta,3210_CAM016151_d.JPG,major
-CAM016150,https://zenodo.org/record/3082688/files/CAM016150_d.JPG,1,test,3208,notabilis x lativitta,3208_CAM016150_d.JPG,major
-CAM016149,https://zenodo.org/record/3082688/files/CAM016149_d.JPG,1,test,3206,notabilis x lativitta,3206_CAM016149_d.JPG,major
-CAM016148,https://zenodo.org/record/3082688/files/CAM016148_d.JPG,1,test,3204,notabilis x lativitta,3204_CAM016148_d.JPG,major
-CAM016147,https://zenodo.org/record/3082688/files/CAM016147_d.JPG,1,test,3202,notabilis x lativitta,3202_CAM016147_d.JPG,major
-CAM016146,https://zenodo.org/record/3082688/files/CAM016146_d.JPG,1,test,3200,notabilis x lativitta,3200_CAM016146_d.JPG,major
-CAM016145,https://zenodo.org/record/3082688/files/CAM016145_d.JPG,1,test,3198,notabilis x lativitta,3198_CAM016145_d.JPG,major
-CAM016144,https://zenodo.org/record/3082688/files/CAM016144_d.JPG,0,test-2,3196,malleti,3196_CAM016144_d.JPG,mimic
-CAM016152,https://zenodo.org/record/3082688/files/CAM016152_d.JPG,1,test,3212,notabilis x lativitta,3212_CAM016152_d.JPG,major
-CAM016163,https://zenodo.org/record/3082688/files/CAM016163_d.JPG,1,test,3234,notabilis x lativitta,3234_CAM016163_d.JPG,major
-CAM016185,https://zenodo.org/record/3082688/files/CAM016185_d.JPG,1,test,3278,notabilis x lativitta,3278_CAM016185_d.JPG,major
-CAM016184,https://zenodo.org/record/3082688/files/CAM016184_d.JPG,1,test,3276,notabilis x lativitta,3276_CAM016184_d.JPG,major
-CAM016183,https://zenodo.org/record/3082688/files/CAM016183_d.JPG,1,test,3274,notabilis x lativitta,3274_CAM016183_d.JPG,major
-CAM016182,https://zenodo.org/record/3082688/files/CAM016182_d.JPG,1,test,3272,notabilis x lativitta,3272_CAM016182_d.JPG,major
-CAM016181,https://zenodo.org/record/3082688/files/CAM016181_d.JPG,1,test,3270,notabilis x lativitta,3270_CAM016181_d.JPG,major
-CAM016180,https://zenodo.org/record/3082688/files/CAM016180_d.JPG,1,test,3268,notabilis x lativitta,3268_CAM016180_d.JPG,major
-CAM016179,https://zenodo.org/record/3082688/files/CAM016179_d.JPG,1,test,3266,notabilis x lativitta,3266_CAM016179_d.JPG,major
-CAM016178,https://zenodo.org/record/3082688/files/CAM016178_d.JPG,1,test,3264,notabilis x lativitta,3264_CAM016178_d.JPG,major
-CAM016164,https://zenodo.org/record/3082688/files/CAM016164_d.JPG,1,test,3236,notabilis x lativitta,3236_CAM016164_d.JPG,major
-CAM016177,https://zenodo.org/record/3082688/files/CAM016177_d.JPG,1,test,3262,notabilis x lativitta,3262_CAM016177_d.JPG,major
-CAM016174,https://zenodo.org/record/3082688/files/CAM016174_d.JPG,1,test,3256,notabilis x lativitta,3256_CAM016174_d.JPG,major
-CAM016172,https://zenodo.org/record/3082688/files/CAM016172_d.JPG,1,test,3252,notabilis x lativitta,3252_CAM016172_d.JPG,major
-CAM016171,https://zenodo.org/record/3082688/files/CAM016171_d.JPG,1,test,3250,notabilis x lativitta,3250_CAM016171_d.JPG,major
-CAM016170,https://zenodo.org/record/3082688/files/CAM016170_d.JPG,1,test,3248,notabilis x lativitta,3248_CAM016170_d.JPG,major
-CAM016169,https://zenodo.org/record/3082688/files/CAM016169_d.JPG,1,test,3246,notabilis x lativitta,3246_CAM016169_d.JPG,major
-CAM016168,https://zenodo.org/record/3082688/files/CAM016168_d.JPG,1,test,3244,notabilis x lativitta,3244_CAM016168_d.JPG,major
-CAM016167,https://zenodo.org/record/3082688/files/CAM016167_d.JPG,1,test,3242,notabilis x lativitta,3242_CAM016167_d.JPG,major
-CAM016176,https://zenodo.org/record/3082688/files/CAM016176_d.JPG,1,test,3260,notabilis x lativitta,3260_CAM016176_d.JPG,major
-CAM017049,https://zenodo.org/record/3082688/files/CAM017049_d.JPG,0,test-2,4447,malleti,4447_CAM017049_d.JPG,mimic
-CAM016552,https://zenodo.org/record/3082688/files/CAM016552_d.JPG,0,test-2,3713,malleti,3713_CAM016552_d.JPG,mimic
-CAM016557,https://zenodo.org/record/3082688/files/CAM016557_d.JPG,1,test,3719,notabilis x lativitta,3719_CAM016557_d.JPG,major
-CAM016559,https://zenodo.org/record/3082688/files/CAM016559_d.JPG,1,test,3723,notabilis x lativitta,3723_CAM016559_d.JPG,major
-CAM016560,https://zenodo.org/record/3082688/files/CAM016560_d.JPG,1,test,3725,notabilis x lativitta,3725_CAM016560_d.JPG,major
-CAM016562,https://zenodo.org/record/3082688/files/CAM016562_d.JPG,1,test,3729,notabilis x lativitta,3729_CAM016562_d.JPG,major
-CAM016566,https://zenodo.org/record/3082688/files/CAM016566_d.JPG,1,test,3737,notabilis x lativitta,3737_CAM016566_d.JPG,major
-CAM016567,https://zenodo.org/record/3082688/files/CAM016567_d.JPG,0,test-2,3739,malleti,3739_CAM016567_d.JPG,mimic
-CAM016551,https://zenodo.org/record/3082688/files/CAM016551_d.JPG,0,test-2,3711,malleti,3711_CAM016551_d.JPG,mimic
-CAM016550,https://zenodo.org/record/3082688/files/CAM016550_d.JPG,0,test-2,3709,malleti,3709_CAM016550_d.JPG,mimic
-CAM016549,https://zenodo.org/record/3082688/files/CAM016549_d.JPG,0,test-2,3707,malleti,3707_CAM016549_d.JPG,mimic
-CAM016548,https://zenodo.org/record/3082688/files/CAM016548_d.JPG,0,test-2,3705,malleti,3705_CAM016548_d.JPG,mimic
-CAM016518,https://zenodo.org/record/3082688/files/CAM016518_d.JPG,1,test,3669,notabilis x lativitta,3669_CAM016518_d.JPG,major
-CAM016520,https://zenodo.org/record/3082688/files/CAM016520_d.JPG,1,test,3671,notabilis x lativitta,3671_CAM016520_d.JPG,major
-CAM016521,https://zenodo.org/record/3082688/files/CAM016521_d.JPG,1,test,3673,notabilis x lativitta,3673_CAM016521_d.JPG,major
-CAM016522,https://zenodo.org/record/3082688/files/CAM016522_d.JPG,1,test,3675,notabilis x lativitta,3675_CAM016522_d.JPG,major
-CAM016523,https://zenodo.org/record/3082688/files/CAM016523_d.JPG,1,test,3677,notabilis x lativitta,3677_CAM016523_d.JPG,major
-CAM016524,https://zenodo.org/record/3082688/files/CAM016524_d.JPG,1,test,3679,notabilis x lativitta,3679_CAM016524_d.JPG,major
-CAM016525,https://zenodo.org/record/3082688/files/CAM016525_d.JPG,1,test,3681,notabilis x lativitta,3681_CAM016525_d.JPG,major
-CAM016526,https://zenodo.org/record/3082688/files/CAM016526_d.JPG,1,test,3683,notabilis x lativitta,3683_CAM016526_d.JPG,major
-CAM016527,https://zenodo.org/record/3082688/files/CAM016527_d.JPG,1,test,3685,notabilis x lativitta,3685_CAM016527_d.JPG,major
-CAM016540,https://zenodo.org/record/3082688/files/CAM016540_d.JPG,0,test-2,3691,malleti,3691_CAM016540_d.JPG,mimic
-CAM016541,https://zenodo.org/record/3082688/files/CAM016541_d.JPG,0,test-2,3693,malleti,3693_CAM016541_d.JPG,mimic
-CAM016542,https://zenodo.org/record/3082688/files/CAM016542_d.JPG,0,test-2,3695,malleti,3695_CAM016542_d.JPG,mimic
-CAM016544,https://zenodo.org/record/3082688/files/CAM016544_d.JPG,0,test-2,3697,malleti,3697_CAM016544_d.JPG,mimic
-CAM016545,https://zenodo.org/record/3082688/files/CAM016545_d.JPG,0,test-2,3699,malleti,3699_CAM016545_d.JPG,mimic
-CAM016546,https://zenodo.org/record/3082688/files/CAM016546_d.JPG,0,test-2,3701,malleti,3701_CAM016546_d.JPG,mimic
-CAM016547,https://zenodo.org/record/3082688/files/CAM016547_d.JPG,0,test-2,3703,malleti,3703_CAM016547_d.JPG,mimic
-CAM016538,https://zenodo.org/record/3082688/files/CAM016538_d.JPG,0,test-2,3687,malleti,3687_CAM016538_d.JPG,mimic
-CAM016517,https://zenodo.org/record/3082688/files/CAM016517_d.JPG,1,test,3667,notabilis x lativitta,3667_CAM016517_d.JPG,major
-CAM016577,https://zenodo.org/record/3082688/files/CAM016577_d.JPG,1,test,3745,notabilis x lativitta,3745_CAM016577_d.JPG,major
-CAM016635,https://zenodo.org/record/3082688/files/CAM016635_d.JPG,1,test,3811,notabilis x lativitta,3811_CAM016635_d.JPG,major
-CAM016636,https://zenodo.org/record/3082688/files/CAM016636_d.JPG,1,test,3813,notabilis x lativitta,3813_CAM016636_d.JPG,major
-CAM016639,https://zenodo.org/record/3082688/files/CAM016639_d.JPG,1,test,3817,notabilis x lativitta,3817_CAM016639_d.JPG,major
-CAM016641,https://zenodo.org/record/3082688/files/CAM016641_d.JPG,1,test,3819,notabilis x lativitta,3819_CAM016641_d.JPG,major
-CAM016643,https://zenodo.org/record/3082688/files/CAM016643_d.JPG,1,test,3821,notabilis x lativitta,3821_CAM016643_d.JPG,major
-CAM016644,https://zenodo.org/record/3082688/files/CAM016644_d.JPG,1,test,3823,notabilis x lativitta,3823_CAM016644_d.JPG,major
-CAM016645,https://zenodo.org/record/3082688/files/CAM016645_d.JPG,1,test,3825,notabilis x lativitta,3825_CAM016645_d.JPG,major
-CAM016646,https://zenodo.org/record/3082688/files/CAM016646_d.JPG,1,test,3827,notabilis x lativitta,3827_CAM016646_d.JPG,major
-CAM016647,https://zenodo.org/record/3082688/files/CAM016647_d.JPG,1,test,3829,notabilis x lativitta,3829_CAM016647_d.JPG,major
-CAM016648,https://zenodo.org/record/3082688/files/CAM016648_d.JPG,1,test,3831,notabilis x lativitta,3831_CAM016648_d.JPG,major
-CAM016649,https://zenodo.org/record/3082688/files/CAM016649_d.JPG,1,test,3833,notabilis x lativitta,3833_CAM016649_d.JPG,major
-CAM016650,https://zenodo.org/record/3082688/files/CAM016650_d.JPG,1,test,3835,notabilis x lativitta,3835_CAM016650_d.JPG,major
-CAM016611,https://zenodo.org/record/3082688/files/CAM016611_d.JPG,0,test-2,3807,malleti,3807_CAM016611_d.JPG,mimic
-CAM016610,https://zenodo.org/record/3082688/files/CAM016610_d.JPG,0,test-2,3805,malleti,3805_CAM016610_d.JPG,mimic
-CAM016609,https://zenodo.org/record/3082688/files/CAM016609_d.JPG,0,test-2,3803,malleti,3803_CAM016609_d.JPG,mimic
-CAM016580,https://zenodo.org/record/3082688/files/CAM016580_d.JPG,1,test,3751,notabilis x lativitta,3751_CAM016580_d.JPG,major
-CAM016582,https://zenodo.org/record/3082688/files/CAM016582_d.JPG,1,test,3755,notabilis x lativitta,3755_CAM016582_d.JPG,major
-CAM016584,https://zenodo.org/record/3082688/files/CAM016584_d.JPG,1,test,3759,notabilis x lativitta,3759_CAM016584_d.JPG,major
-CAM016585,https://zenodo.org/record/3082688/files/CAM016585_d.JPG,1,test,3761,notabilis x lativitta,3761_CAM016585_d.JPG,major
-CAM016578,https://zenodo.org/record/3082688/files/CAM016578_d.JPG,1,test,3747,notabilis x lativitta,3747_CAM016578_d.JPG,major
-CAM016588,https://zenodo.org/record/3082688/files/CAM016588_d.JPG,1,test,3767,notabilis x lativitta,3767_CAM016588_d.JPG,major
-CAM016590,https://zenodo.org/record/3082688/files/CAM016590_d.JPG,1,test,3771,notabilis x lativitta,3771_CAM016590_d.JPG,major
-CAM016594,https://zenodo.org/record/3082688/files/CAM016594_d.JPG,0,test-2,3777,malleti,3777_CAM016594_d.JPG,mimic
-CAM016595,https://zenodo.org/record/3082688/files/CAM016595_d.JPG,0,test-2,3779,malleti,3779_CAM016595_d.JPG,mimic
-CAM016598,https://zenodo.org/record/3082688/files/CAM016598_d.JPG,0,test-2,3783,malleti,3783_CAM016598_d.JPG,mimic
-CAM016599,https://zenodo.org/record/3082688/files/CAM016599_d.JPG,0,test-2,3785,malleti,3785_CAM016599_d.JPG,mimic
-CAM016606,https://zenodo.org/record/3082688/files/CAM016606_d.JPG,0,test-2,3799,malleti,3799_CAM016606_d.JPG,mimic
-CAM016516,https://zenodo.org/record/3082688/files/CAM016516_d.JPG,1,test,3665,notabilis x lativitta,3665_CAM016516_d.JPG,major
-CAM016515,https://zenodo.org/record/3082688/files/CAM016515_d.JPG,1,test,3663,notabilis x lativitta,3663_CAM016515_d.JPG,major
-CAM016514,https://zenodo.org/record/3082688/files/CAM016514_d.JPG,1,test,3661,notabilis x lativitta,3661_CAM016514_d.JPG,major
-CAM016410,https://zenodo.org/record/3082688/files/CAM016410_d.JPG,1,test,3531,notabilis x lativitta,3531_CAM016410_d.JPG,major
-CAM016415,https://zenodo.org/record/3082688/files/CAM016415_d.JPG,1,test,3541,notabilis x lativitta,3541_CAM016415_d.JPG,major
-CAM016463,https://zenodo.org/record/3082688/files/CAM016463_d.JPG,1,test,3623,notabilis x lativitta,3623_CAM016463_d.JPG,major
-CAM016464,https://zenodo.org/record/3082688/files/CAM016464_d.JPG,1,test,3625,notabilis x lativitta,3625_CAM016464_d.JPG,major
-CAM016465,https://zenodo.org/record/3082688/files/CAM016465_d.JPG,0,test-2,3627,malleti,3627_CAM016465_d.JPG,mimic
-CAM016466,https://zenodo.org/record/3082688/files/CAM016466_d.JPG,1,test,3629,notabilis x lativitta,3629_CAM016466_d.JPG,major
-CAM016462,https://zenodo.org/record/3082688/files/CAM016462_d.JPG,1,test,3621,notabilis x lativitta,3621_CAM016462_d.JPG,major
-CAM016506,https://zenodo.org/record/3082688/files/CAM016506_d.JPG,0,test-2,3645,malleti,3645_CAM016506_d.JPG,mimic
-CAM016507,https://zenodo.org/record/3082688/files/CAM016507_d.JPG,1,test,3647,notabilis x lativitta,3647_CAM016507_d.JPG,major
-CAM016512,https://zenodo.org/record/3082688/files/CAM016512_d.JPG,1,test,3657,notabilis x lativitta,3657_CAM016512_d.JPG,major
-CAM016513,https://zenodo.org/record/3082688/files/CAM016513_d.JPG,1,test,3659,notabilis x lativitta,3659_CAM016513_d.JPG,major
-CAM016461,https://zenodo.org/record/3082688/files/CAM016461_d.JPG,1,test,3619,notabilis x lativitta,3619_CAM016461_d.JPG,major
-CAM016459,https://zenodo.org/record/3082688/files/CAM016459_d.JPG,1,test,3617,notabilis x lativitta,3617_CAM016459_d.JPG,major
-CAM016423,https://zenodo.org/record/3082688/files/CAM016423_d.JPG,1,test,3557,notabilis x lativitta,3557_CAM016423_d.JPG,major
-CAM016426,https://zenodo.org/record/3082688/files/CAM016426_d.JPG,0,test-2,3563,malleti,3563_CAM016426_d.JPG,mimic
-CAM016447,https://zenodo.org/record/3082688/files/CAM016447_d.JPG,1,test,3599,notabilis x lativitta,3599_CAM016447_d.JPG,major
-CAM016448,https://zenodo.org/record/3082688/files/CAM016448_d.JPG,1,test,3601,notabilis x lativitta,3601_CAM016448_d.JPG,major
-CAM016079,https://zenodo.org/record/3082688/files/CAM016079_d.JPG,1,test,3066,notabilis x lativitta,3066_CAM016079_d.JPG,major
-CAM016452,https://zenodo.org/record/3082688/files/CAM016452_d.JPG,1,test,3607,notabilis x lativitta,3607_CAM016452_d.JPG,major
-CAM016453,https://zenodo.org/record/3082688/files/CAM016453_d.JPG,1,test,3609,notabilis x lativitta,3609_CAM016453_d.JPG,major
-CAM016455,https://zenodo.org/record/3082688/files/CAM016455_d.JPG,1,test,3611,notabilis x lativitta,3611_CAM016455_d.JPG,major
-CAM016456,https://zenodo.org/record/3082688/files/CAM016456_d.JPG,1,test,3613,notabilis x lativitta,3613_CAM016456_d.JPG,major
-CAM016458,https://zenodo.org/record/3082688/files/CAM016458_d.JPG,1,test,3615,notabilis x lativitta,3615_CAM016458_d.JPG,major
-CAM017051,https://zenodo.org/record/3082688/files/CAM017051_d.JPG,1,test,4451,notabilis x lativitta,4451_CAM017051_d.JPG,major
-CAM016026,https://zenodo.org/record/3082688/files/CAM016026_d.JPG,1,test,2961,notabilis x lativitta,2961_CAM016026_d.JPG,major
-CAM016025,https://zenodo.org/record/3082688/files/CAM016025_d.JPG,1,test,2959,notabilis x lativitta,2959_CAM016025_d.JPG,major
-CAM016024,https://zenodo.org/record/3082688/files/CAM016024_d.JPG,1,test,2957,notabilis x lativitta,2957_CAM016024_d.JPG,major
-CAM016023,https://zenodo.org/record/3082688/files/CAM016023_d.JPG,1,test,2955,notabilis x lativitta,2955_CAM016023_d.JPG,major
-CAM016022,https://zenodo.org/record/3082688/files/CAM016022_d.JPG,1,test,2953,notabilis x lativitta,2953_CAM016022_d.JPG,major
-CAM016027,https://zenodo.org/record/3082688/files/CAM016027_d.JPG,1,test,2963,notabilis x lativitta,2963_CAM016027_d.JPG,major
-CAM017341,https://zenodo.org/record/3082688/files/CAM017341_d.JPG,1,test,4960,notabilis x lativitta,4960_CAM017341_d.JPG,major
-CAM017343,https://zenodo.org/record/3082688/files/CAM017343_d.JPG,1,test,4964,notabilis x lativitta,4964_CAM017343_d.JPG,major
-CAM017344,https://zenodo.org/record/3082688/files/CAM017344_d.JPG,1,test,4966,notabilis x lativitta,4966_CAM017344_d.JPG,major
-CAM017346,https://zenodo.org/record/3082688/files/CAM017346_d.JPG,1,test,4970,notabilis x lativitta,4970_CAM017346_d.JPG,major
-CAM017347,https://zenodo.org/record/3082688/files/CAM017347_d.JPG,1,test,4972,notabilis x lativitta,4972_CAM017347_d.JPG,major
-CAM017348,https://zenodo.org/record/3082688/files/CAM017348_d.JPG,1,test,4974,notabilis x lativitta,4974_CAM017348_d.JPG,major
-CAM017349,https://zenodo.org/record/3082688/files/CAM017349_d.JPG,1,test,4976,notabilis x lativitta,4976_CAM017349_d.JPG,major
-CAM017350,https://zenodo.org/record/3082688/files/CAM017350_d.JPG,1,test,4978,notabilis x lativitta,4978_CAM017350_d.JPG,major
-CAM016021,https://zenodo.org/record/3082688/files/CAM016021_d.JPG,1,test,2951,notabilis x lativitta,2951_CAM016021_d.JPG,major
-CAM016020,https://zenodo.org/record/3082688/files/CAM016020_d.JPG,1,test,2949,notabilis x lativitta,2949_CAM016020_d.JPG,major
-CAM017610,https://zenodo.org/record/3082688/files/CAM017610_d.JPG,1,test,5382,notabilis x lativitta,5382_CAM017610_d.JPG,major
-CAM017375,https://zenodo.org/record/3082688/files/CAM017375_d.JPG,0,test,5002,notabilis,5002_CAM017375_d.JPG,major
-CAM016014,https://zenodo.org/record/3082688/files/CAM016014_d.JPG,0,test,2937,notabilis,2937_CAM016014_d.JPG,major
-CAM017272,https://zenodo.org/record/3082688/files/CAM017272_d.JPG,0,test-2,4856,malleti,4856_CAM017272_d.JPG,mimic
-CAM017283,https://zenodo.org/record/3082688/files/CAM017283_d.JPG,0,test-2,4878,malleti,4878_CAM017283_d.JPG,mimic
-CAM017324,https://zenodo.org/record/3082688/files/CAM017324_d.JPG,0,test,4932,notabilis,4932_CAM017324_d.JPG,major
-CAM017320,https://zenodo.org/record/3082688/files/CAM017320_d.JPG,0,test,4924,notabilis,4924_CAM017320_d.JPG,major
-CAM017321,https://zenodo.org/record/3082688/files/CAM017321_d.JPG,0,test,4926,notabilis,4926_CAM017321_d.JPG,major
-CAM017322,https://zenodo.org/record/3082688/files/CAM017322_d.JPG,0,test,4928,notabilis,4928_CAM017322_d.JPG,major
-CAM017323,https://zenodo.org/record/3082688/files/CAM017323_d.JPG,0,test,4930,notabilis,4930_CAM017323_d.JPG,major
-CAM017381,https://zenodo.org/record/3082688/files/CAM017381_d.JPG,0,test-2,5012,malleti,5012_CAM017381_d.JPG,mimic
-CAM017400,https://zenodo.org/record/3082688/files/CAM017400_d.JPG,0,test-2,5043,malleti,5043_CAM017400_d.JPG,mimic
-CAM017385,https://zenodo.org/record/3082688/files/CAM017385_d.JPG,0,test-2,5020,malleti,5020_CAM017385_d.JPG,mimic
-CAM017387,https://zenodo.org/record/3082688/files/CAM017387_d.JPG,0,test-2,5024,malleti,5024_CAM017387_d.JPG,mimic
-CAM017412,https://zenodo.org/record/3082688/files/CAM017412_d.JPG,0,test-2,5061,malleti,5061_CAM017412_d.JPG,mimic
-CAM017269,https://zenodo.org/record/3082688/files/CAM017269_d.JPG,0,test-2,4850,malleti,4850_CAM017269_d.JPG,mimic
-CAM017126,https://zenodo.org/record/3082688/files/CAM017126_d.JPG,0,test-2,4581,malleti,4581_CAM017126_d.JPG,mimic
-CAM017117,https://zenodo.org/record/3082688/files/CAM017117_d.JPG,0,test-2,4563,malleti,4563_CAM017117_d.JPG,mimic
-CAM017120,https://zenodo.org/record/3082688/files/CAM017120_d.JPG,0,test-2,4569,malleti,4569_CAM017120_d.JPG,mimic
-CAM017121,https://zenodo.org/record/3082688/files/CAM017121_d.JPG,0,test-2,4571,malleti,4571_CAM017121_d.JPG,mimic
-CAM017134,https://zenodo.org/record/3082688/files/CAM017134_d.JPG,0,test-2,4597,malleti,4597_CAM017134_d.JPG,mimic
-CAM017156,https://zenodo.org/record/3082688/files/CAM017156_d.JPG,0,test-2,4637,malleti,4637_CAM017156_d.JPG,mimic
-CAM017136,https://zenodo.org/record/3082688/files/CAM017136_d.JPG,0,test-2,4601,malleti,4601_CAM017136_d.JPG,mimic
-CAM017137,https://zenodo.org/record/3082688/files/CAM017137_d.JPG,0,test-2,4603,malleti,4603_CAM017137_d.JPG,mimic
-CAM017138,https://zenodo.org/record/3082688/files/CAM017138_d.JPG,0,test-2,4605,malleti,4605_CAM017138_d.JPG,mimic
-CAM017069,https://zenodo.org/record/3082688/files/CAM017069_d.JPG,0,test-2,4487,malleti,4487_CAM017069_d.JPG,mimic
-CAM017070,https://zenodo.org/record/3082688/files/CAM017070_d.JPG,0,test-2,4489,malleti,4489_CAM017070_d.JPG,mimic
-CAM017071,https://zenodo.org/record/3082688/files/CAM017071_d.JPG,0,test-2,4491,malleti,4491_CAM017071_d.JPG,mimic
-CAM017073,https://zenodo.org/record/3082688/files/CAM017073_d.JPG,0,test-2,4495,malleti,4495_CAM017073_d.JPG,mimic
-CAM017064,https://zenodo.org/record/3082688/files/CAM017064_d.JPG,0,test-2,4477,malleti,4477_CAM017064_d.JPG,mimic
-CAM017093,https://zenodo.org/record/3082688/files/CAM017093_d.JPG,0,test-2,4527,malleti,4527_CAM017093_d.JPG,mimic
-CAM017099,https://zenodo.org/record/3082688/files/CAM017099_d.JPG,0,test-2,4537,malleti,4537_CAM017099_d.JPG,mimic
-CAM017100,https://zenodo.org/record/3082688/files/CAM017100_d.JPG,0,test-2,4539,malleti,4539_CAM017100_d.JPG,mimic
-CAM017103,https://zenodo.org/record/3082688/files/CAM017103_d.JPG,0,test-2,4543,malleti,4543_CAM017103_d.JPG,mimic
-CAM017104,https://zenodo.org/record/3082688/files/CAM017104_d.JPG,0,test-2,4545,malleti,4545_CAM017104_d.JPG,mimic
-CAM017092,https://zenodo.org/record/3082688/files/CAM017092_d.JPG,0,test-2,4525,malleti,4525_CAM017092_d.JPG,mimic
-CAM017091,https://zenodo.org/record/3082688/files/CAM017091_d.JPG,0,test-2,4523,malleti,4523_CAM017091_d.JPG,mimic
-CAM017081,https://zenodo.org/record/3082688/files/CAM017081_d.JPG,0,test-2,4503,malleti,4503_CAM017081_d.JPG,mimic
-CAM017083,https://zenodo.org/record/3082688/files/CAM017083_d.JPG,0,test-2,4507,malleti,4507_CAM017083_d.JPG,mimic
-CAM017089,https://zenodo.org/record/3082688/files/CAM017089_d.JPG,0,test-2,4519,malleti,4519_CAM017089_d.JPG,mimic
-CAM017154,https://zenodo.org/record/3082688/files/CAM017154_d.JPG,0,test-2,4633,malleti,4633_CAM017154_d.JPG,mimic
-CAM017236,https://zenodo.org/record/3082688/files/CAM017236_d.JPG,0,test,4789,notabilis,4789_CAM017236_d.JPG,major
-CAM017237,https://zenodo.org/record/3082688/files/CAM017237_d.JPG,0,test,4791,notabilis,4791_CAM017237_d.JPG,major
-CAM017238,https://zenodo.org/record/3082688/files/CAM017238_d.JPG,0,test,4793,notabilis,4793_CAM017238_d.JPG,major
-CAM017239,https://zenodo.org/record/3082688/files/CAM017239_d.JPG,0,test,4795,notabilis,4795_CAM017239_d.JPG,major
-CAM017216,https://zenodo.org/record/3082688/files/CAM017216_d.JPG,0,test,4749,notabilis,4749_CAM017216_d.JPG,major
-CAM017217,https://zenodo.org/record/3082688/files/CAM017217_d.JPG,0,test,4751,notabilis,4751_CAM017217_d.JPG,major
-CAM017219,https://zenodo.org/record/3082688/files/CAM017219_d.JPG,0,test,4755,notabilis,4755_CAM017219_d.JPG,major
-CAM017228,https://zenodo.org/record/3082688/files/CAM017228_d.JPG,0,test,4773,notabilis,4773_CAM017228_d.JPG,major
-CAM017221,https://zenodo.org/record/3082688/files/CAM017221_d.JPG,0,test,4759,notabilis,4759_CAM017221_d.JPG,major
-CAM017223,https://zenodo.org/record/3082688/files/CAM017223_d.JPG,0,test,4763,notabilis,4763_CAM017223_d.JPG,major
-CAM017227,https://zenodo.org/record/3082688/files/CAM017227_d.JPG,0,test,4771,notabilis,4771_CAM017227_d.JPG,major
-CAM017240,https://zenodo.org/record/3082688/files/CAM017240_d.JPG,0,test,4797,notabilis,4797_CAM017240_d.JPG,major
-CAM017241,https://zenodo.org/record/3082688/files/CAM017241_d.JPG,0,test,4799,notabilis,4799_CAM017241_d.JPG,major
-CAM017259,https://zenodo.org/record/3082688/files/CAM017259_d.JPG,0,test,4830,notabilis,4830_CAM017259_d.JPG,major
-CAM017260,https://zenodo.org/record/3082688/files/CAM017260_d.JPG,0,test,4832,notabilis,4832_CAM017260_d.JPG,major
-CAM017261,https://zenodo.org/record/3082688/files/CAM017261_d.JPG,0,test,4834,notabilis,4834_CAM017261_d.JPG,major
-CAM017262,https://zenodo.org/record/3082688/files/CAM017262_d.JPG,0,test,4836,notabilis,4836_CAM017262_d.JPG,major
-CAM017268,https://zenodo.org/record/3082688/files/CAM017268_d.JPG,0,test-2,4848,malleti,4848_CAM017268_d.JPG,mimic
-CAM017263,https://zenodo.org/record/3082688/files/CAM017263_d.JPG,0,test,4838,notabilis,4838_CAM017263_d.JPG,major
-CAM017254,https://zenodo.org/record/3082688/files/CAM017254_d.JPG,0,test,4825,notabilis,4825_CAM017254_d.JPG,major
-CAM017253,https://zenodo.org/record/3082688/files/CAM017253_d.JPG,0,test,4823,notabilis,4823_CAM017253_d.JPG,major
-CAM017242,https://zenodo.org/record/3082688/files/CAM017242_d.JPG,0,test,4801,notabilis,4801_CAM017242_d.JPG,major
-CAM017243,https://zenodo.org/record/3082688/files/CAM017243_d.JPG,0,test,4803,notabilis,4803_CAM017243_d.JPG,major
-CAM017244,https://zenodo.org/record/3082688/files/CAM017244_d.JPG,0,test,4805,notabilis,4805_CAM017244_d.JPG,major
-CAM017245,https://zenodo.org/record/3082688/files/CAM017245_d.JPG,0,test,4807,notabilis,4807_CAM017245_d.JPG,major
-CAM017247,https://zenodo.org/record/3082688/files/CAM017247_d.JPG,0,test,4811,notabilis,4811_CAM017247_d.JPG,major
-CAM017248,https://zenodo.org/record/3082688/files/CAM017248_d.JPG,0,test,4813,notabilis,4813_CAM017248_d.JPG,major
-CAM017249,https://zenodo.org/record/3082688/files/CAM017249_d.JPG,0,test,4815,notabilis,4815_CAM017249_d.JPG,major
-CAM017250,https://zenodo.org/record/3082688/files/CAM017250_d.JPG,0,test,4817,notabilis,4817_CAM017250_d.JPG,major
-CAM017251,https://zenodo.org/record/3082688/files/CAM017251_d.JPG,0,test,4819,notabilis,4819_CAM017251_d.JPG,major
-CAM017252,https://zenodo.org/record/3082688/files/CAM017252_d.JPG,0,test,4821,notabilis,4821_CAM017252_d.JPG,major
-CAM017246,https://zenodo.org/record/3082688/files/CAM017246_d.JPG,0,test,4809,notabilis,4809_CAM017246_d.JPG,major
-CAM017214,https://zenodo.org/record/3082688/files/CAM017214_d.JPG,0,test,4745,notabilis,4745_CAM017214_d.JPG,major
-CAM017212,https://zenodo.org/record/3082688/files/CAM017212_d.JPG,0,test,4741,notabilis,4741_CAM017212_d.JPG,major
-CAM017176,https://zenodo.org/record/3082688/files/CAM017176_d.JPG,0,test,4672,notabilis,4672_CAM017176_d.JPG,major
-CAM017177,https://zenodo.org/record/3082688/files/CAM017177_d.JPG,0,test,4674,notabilis,4674_CAM017177_d.JPG,major
-CAM017178,https://zenodo.org/record/3082688/files/CAM017178_d.JPG,0,test,4676,notabilis,4676_CAM017178_d.JPG,major
-19N0638,https://zenodo.org/record/4288311/files/19N0638_d.JPG,0,test-2,19932,malleti,19932_19N0638_d.JPG,mimic
-19N0336,https://zenodo.org/record/4288311/files/19N0336_d.JPG,0,test-2,19778,malleti,19778_19N0336_d.JPG,mimic
-19N0341,https://zenodo.org/record/4288311/files/19N0341_d.JPG,0,test-2,19780,malleti,19780_19N0341_d.JPG,mimic
-19N0372,https://zenodo.org/record/4288311/files/19N0372_d.JPG,0,test-2,19786,malleti,19786_19N0372_d.JPG,mimic
-19N0416,https://zenodo.org/record/4288311/files/19N0416_d.JPG,0,test-2,19811,malleti,19811_19N0416_d.JPG,mimic
-19N0437,https://zenodo.org/record/4288311/files/19N0437_d.JPG,0,test-2,19820,malleti,19820_19N0437_d.JPG,mimic
-19N0438,https://zenodo.org/record/4288311/files/19N0438_d.JPG,0,test-2,19822,malleti,19822_19N0438_d.JPG,mimic
-19N0330,https://zenodo.org/record/4288311/files/19N0330_d.JPG,0,test-2,19770,malleti,19770_19N0330_d.JPG,mimic
-19N0325,https://zenodo.org/record/4288311/files/19N0325_d.JPG,0,test-2,19766,malleti,19766_19N0325_d.JPG,mimic
-19N0288,https://zenodo.org/record/4288311/files/19N0288_d.JPG,0,test-2,19720,malleti,19720_19N0288_d.JPG,mimic
-19N0291,https://zenodo.org/record/4288311/files/19N0291_d.JPG,0,test-2,19722,malleti,19722_19N0291_d.JPG,mimic
-19N0298,https://zenodo.org/record/4288311/files/19N0298_d.JPG,0,test-2,19730,malleti,19730_19N0298_d.JPG,mimic
-19N0299,https://zenodo.org/record/4288311/files/19N0299_d.JPG,0,test-2,19732,malleti,19732_19N0299_d.JPG,mimic
-19N0301,https://zenodo.org/record/4288311/files/19N0301_d.JPG,0,test-2,19734,malleti,19734_19N0301_d.JPG,mimic
-19N0302,https://zenodo.org/record/4288311/files/19N0302_d.JPG,0,test-2,19736,malleti,19736_19N0302_d.JPG,mimic
-19N0439,https://zenodo.org/record/4288311/files/19N0439_d.JPG,0,test-2,19824,malleti,19824_19N0439_d.JPG,mimic
-19N0306,https://zenodo.org/record/4288311/files/19N0306_d.JPG,0,test-2,19744,malleti,19744_19N0306_d.JPG,mimic
-19N0314,https://zenodo.org/record/4288311/files/19N0314_d.JPG,0,test-2,19750,malleti,19750_19N0314_d.JPG,mimic
-19N0315,https://zenodo.org/record/4288311/files/19N0315_d.JPG,0,test-2,19752,malleti,19752_19N0315_d.JPG,mimic
-19N0317,https://zenodo.org/record/4288311/files/19N0317_d.JPG,0,test-2,19754,malleti,19754_19N0317_d.JPG,mimic
-19N0323,https://zenodo.org/record/4288311/files/19N0323_d.JPG,0,test-2,19762,malleti,19762_19N0323_d.JPG,mimic
-19N0324,https://zenodo.org/record/4288311/files/19N0324_d.JPG,0,test-2,19764,malleti,19764_19N0324_d.JPG,mimic
-19N0304,https://zenodo.org/record/4288311/files/19N0304_d.JPG,0,test-2,19740,malleti,19740_19N0304_d.JPG,mimic
-19N0575,https://zenodo.org/record/4288311/files/19N0575_d.JPG,0,test-2,19896,malleti,19896_19N0575_d.JPG,mimic
-19N0582,https://zenodo.org/record/4288311/files/19N0582_d.JPG,0,test-2,19898,malleti,19898_19N0582_d.JPG,mimic
-19N0583,https://zenodo.org/record/4288311/files/19N0583_d.JPG,0,test-2,19900,malleti,19900_19N0583_d.JPG,mimic
-19N0584,https://zenodo.org/record/4288311/files/19N0584_d.JPG,0,test-2,19902,malleti,19902_19N0584_d.JPG,mimic
-19N0599,https://zenodo.org/record/4288311/files/19N0599_d.JPG,0,test-2,19906,malleti,19906_19N0599_d.JPG,mimic
-19N0608,https://zenodo.org/record/4288311/files/19N0608_d.JPG,0,test-2,19908,malleti,19908_19N0608_d.JPG,mimic
-19N0613,https://zenodo.org/record/4288311/files/19N0613_d.JPG,0,test-2,19910,malleti,19910_19N0613_d.JPG,mimic
-19N0614,https://zenodo.org/record/4288311/files/19N0614_d.JPG,0,test-2,19912,malleti,19912_19N0614_d.JPG,mimic
-19N0615,https://zenodo.org/record/4288311/files/19N0615_d.JPG,0,test-2,19914,malleti,19914_19N0615_d.JPG,mimic
-19N0624,https://zenodo.org/record/4288311/files/19N0624_d.JPG,0,test-2,19916,malleti,19916_19N0624_d.JPG,mimic
-19N0630,https://zenodo.org/record/4288311/files/19N0630_d.JPG,0,test-2,19920,malleti,19920_19N0630_d.JPG,mimic
-19N0660,https://zenodo.org/record/4288311/files/19N0660_d.JPG,0,test-2,19950,malleti,19950_19N0660_d.JPG,mimic
-19N0659,https://zenodo.org/record/4288311/files/19N0659_d.JPG,0,test-2,19948,malleti,19948_19N0659_d.JPG,mimic
-19N0658,https://zenodo.org/record/4288311/files/19N0658_d.JPG,0,test-2,19946,malleti,19946_19N0658_d.JPG,mimic
-19N0657,https://zenodo.org/record/4288311/files/19N0657_d.JPG,0,test-2,19944,malleti,19944_19N0657_d.JPG,mimic
-19N0648,https://zenodo.org/record/4288311/files/19N0648_d.JPG,0,test-2,19942,malleti,19942_19N0648_d.JPG,mimic
-19N0646,https://zenodo.org/record/4288311/files/19N0646_d.JPG,0,test-2,19938,malleti,19938_19N0646_d.JPG,mimic
-19N0640,https://zenodo.org/record/4288311/files/19N0640_d.JPG,0,test-2,19936,malleti,19936_19N0640_d.JPG,mimic
-19N0639,https://zenodo.org/record/4288311/files/19N0639_d.JPG,0,test-2,19934,malleti,19934_19N0639_d.JPG,mimic
-19N0564,https://zenodo.org/record/4288311/files/19N0564_d.JPG,0,test-2,19890,malleti,19890_19N0564_d.JPG,mimic
-19N0635,https://zenodo.org/record/4288311/files/19N0635_d.JPG,0,test-2,19930,malleti,19930_19N0635_d.JPG,mimic
-19N0528,https://zenodo.org/record/4288311/files/19N0528_d.JPG,0,test-2,19882,malleti,19882_19N0528_d.JPG,mimic
-19N0647,https://zenodo.org/record/4288311/files/19N0647_d.JPG,0,test-2,19940,malleti,19940_19N0647_d.JPG,mimic
-19N0144,https://zenodo.org/record/4288311/files/19N0144_d.JPG,0,test-2,19433,malleti,19433_19N0144_d.JPG,mimic
-19N1063,https://zenodo.org/record/4288311/files/19N1063_d.JPG,0,test-2,20170,malleti,20170_19N1063_d.JPG,mimic
-19N1037,https://zenodo.org/record/4288311/files/19N1037_d.JPG,0,test-2,20166,malleti,20166_19N1037_d.JPG,mimic
-19N1034,https://zenodo.org/record/4288311/files/19N1034_d.JPG,0,test-2,20159,malleti,20159_19N1034_d.JPG,mimic
-19N1020,https://zenodo.org/record/4288311/files/19N1020_d.JPG,0,test-2,20155,malleti,20155_19N1020_d.JPG,mimic
-19N1018,https://zenodo.org/record/4288311/files/19N1018_d.JPG,0,test-2,20151,malleti,20151_19N1018_d.JPG,mimic
-19N1065,https://zenodo.org/record/4288311/files/19N1065_d.JPG,0,test-2,20174,malleti,20174_19N1065_d.JPG,mimic
-19N0982,https://zenodo.org/record/4288311/files/19N0982_d.JPG,0,test-2,20137,malleti,20137_19N0982_d.JPG,mimic
-19N0981,https://zenodo.org/record/4288311/files/19N0981_d.JPG,0,test-2,20135,malleti,20135_19N0981_d.JPG,mimic
-19N0957,https://zenodo.org/record/4288311/files/19N0957_d.JPG,0,test-2,20126,malleti,20126_19N0957_d.JPG,mimic
-19N0956,https://zenodo.org/record/4288311/files/19N0956_d.JPG,0,test-2,20124,malleti,20124_19N0956_d.JPG,mimic
-19N0955,https://zenodo.org/record/4288311/files/19N0955_d.JPG,0,test-2,20122,malleti,20122_19N0955_d.JPG,mimic
-19N0954,https://zenodo.org/record/4288311/files/19N0954_d.JPG,0,test-2,20120,malleti,20120_19N0954_d.JPG,mimic
-19N0953,https://zenodo.org/record/4288311/files/19N0953_d.JPG,0,test-2,20118,malleti,20118_19N0953_d.JPG,mimic
-19N0948,https://zenodo.org/record/4288311/files/19N0948_d.JPG,0,test-2,20116,malleti,20116_19N0948_d.JPG,mimic
-19N0946,https://zenodo.org/record/4288311/files/19N0946_d.JPG,0,test-2,20112,malleti,20112_19N0946_d.JPG,mimic
-19N0983,https://zenodo.org/record/4288311/files/19N0983_d.JPG,0,test-2,20139,malleti,20139_19N0983_d.JPG,mimic
-19N1095,https://zenodo.org/record/4288311/files/19N1095_d.JPG,0,test-2,20180,malleti,20180_19N1095_d.JPG,mimic
-19N1237,https://zenodo.org/record/4288311/files/19N1237_d.JPG,0,test-2,20247,malleti,20247_19N1237_d.JPG,mimic
-19N1236,https://zenodo.org/record/4288311/files/19N1236_d.JPG,0,test-2,20245,malleti,20245_19N1236_d.JPG,mimic
-15N309,https://zenodo.org/record/4289223/files/15N309_d.JPG,0,test,15228,venus,15228_15N309_d.JPG,minor
-15N323,https://zenodo.org/record/4289223/files/15N323_d.JPG,0,test,15232,venus,15232_15N323_d.JPG,minor
-15N320,https://zenodo.org/record/4289223/files/15N320_d.JPG,0,test,15230,venus,15230_15N320_d.JPG,minor
-15N104,https://zenodo.org/record/4289223/files/15N104_d.JPG,1,test,15165,venus x chestertonii,15165_15N104_d.JPG,minor
-CAM041538,https://zenodo.org/record/4291095/files/CAM041538_d.JPG,0,test,39124,lativitta,39124_CAM041538_d.JPG,major
-CAM041537,https://zenodo.org/record/4291095/files/CAM041537_d.JPG,0,test,39120,lativitta,39120_CAM041537_d.JPG,major
-CAM041536,https://zenodo.org/record/4291095/files/CAM041536_d.JPG,0,test,39116,lativitta,39116_CAM041536_d.JPG,major
-CAM041491,https://zenodo.org/record/4291095/files/CAM041491_d.JPG,0,test,38936,lativitta,38936_CAM041491_d.JPG,major
-CAM041479,https://zenodo.org/record/4291095/files/CAM041479_d.JPG,0,test,38888,lativitta,38888_CAM041479_d.JPG,major
-CAM041478,https://zenodo.org/record/4291095/files/CAM041478_d.JPG,0,test,38880,lativitta,38880_CAM041478_d.JPG,major
-CAM041476,https://zenodo.org/record/4291095/files/CAM041476_d.JPG,0,test,38872,lativitta,38872_CAM041476_d.JPG,major
-CAM041386,https://zenodo.org/record/4291095/files/CAM041386_d.JPG,0,test,38524,lativitta,38524_CAM041386_d.JPG,major
-CAM041385,https://zenodo.org/record/4291095/files/CAM041385_d.JPG,0,test,38520,lativitta,38520_CAM041385_d.JPG,major
-CAM041384,https://zenodo.org/record/4291095/files/CAM041384_d.JPG,0,test,38516,lativitta,38516_CAM041384_d.JPG,major
-CAM041383,https://zenodo.org/record/4291095/files/CAM041383_d.JPG,0,test,38512,lativitta,38512_CAM041383_d.JPG,major
-CAM041382,https://zenodo.org/record/4291095/files/CAM041382_d.JPG,0,test,38508,lativitta,38508_CAM041382_d.JPG,major
-CAM041381,https://zenodo.org/record/4291095/files/CAM041381_d.JPG,0,test,38504,lativitta,38504_CAM041381_d.JPG,major
-CAM041380,https://zenodo.org/record/4291095/files/CAM041380_d.JPG,0,test,38500,lativitta,38500_CAM041380_d.JPG,major
-CAM041379,https://zenodo.org/record/4291095/files/CAM041379_d.JPG,0,test,38496,lativitta,38496_CAM041379_d.JPG,major
-CAM041378,https://zenodo.org/record/4291095/files/CAM041378_d.JPG,0,test,38492,lativitta,38492_CAM041378_d.JPG,major
-CAM041698,https://zenodo.org/record/4291095/files/CAM041698_d.JPG,0,test,39759,lativitta,39759_CAM041698_d.JPG,major
-CAM041366,https://zenodo.org/record/4291095/files/CAM041366_d.JPG,0,test,38444,lativitta,38444_CAM041366_d.JPG,major
-CAM041365,https://zenodo.org/record/4291095/files/CAM041365_d.JPG,0,test,38440,lativitta,38440_CAM041365_d.JPG,major
-CAM041364,https://zenodo.org/record/4291095/files/CAM041364_d.JPG,0,test,38436,lativitta,38436_CAM041364_d.JPG,major
-CAM041363,https://zenodo.org/record/4291095/files/CAM041363_d.JPG,0,test,38432,lativitta,38432_CAM041363_d.JPG,major
-CAM041362,https://zenodo.org/record/4291095/files/CAM041362_d.JPG,0,test,38428,lativitta,38428_CAM041362_d.JPG,major
-CAM041361,https://zenodo.org/record/4291095/files/CAM041361_d.JPG,0,test,38424,lativitta,38424_CAM041361_d.JPG,major
-CAM041360,https://zenodo.org/record/4291095/files/CAM041360_d.JPG,0,test,38420,lativitta,38420_CAM041360_d.JPG,major
-CAM041359,https://zenodo.org/record/4291095/files/CAM041359_d.JPG,0,test,38416,lativitta,38416_CAM041359_d.JPG,major
-CAM041387,https://zenodo.org/record/4291095/files/CAM041387_d.JPG,0,test,38528,lativitta,38528_CAM041387_d.JPG,major
-CAM041586,https://zenodo.org/record/4291095/files/CAM041586_d.JPG,0,test,39311,lativitta,39311_CAM041586_d.JPG,major
-CAM041388,https://zenodo.org/record/4291095/files/CAM041388_d.JPG,0,test,38532,lativitta,38532_CAM041388_d.JPG,major
-CAM041393,https://zenodo.org/record/4291095/files/CAM041393_d.JPG,0,test,38544,lativitta,38544_CAM041393_d.JPG,major
-CAM041473,https://zenodo.org/record/4291095/files/CAM041473_d.JPG,0,test,38864,lativitta,38864_CAM041473_d.JPG,major
-CAM041472,https://zenodo.org/record/4291095/files/CAM041472_d.JPG,0,test,38860,lativitta,38860_CAM041472_d.JPG,major
-CAM041467,https://zenodo.org/record/4291095/files/CAM041467_d.JPG,0,test,38840,lativitta,38840_CAM041467_d.JPG,major
-CAM041442,https://zenodo.org/record/4291095/files/CAM041442_d.JPG,0,test,38740,lativitta,38740_CAM041442_d.JPG,major
-CAM041441,https://zenodo.org/record/4291095/files/CAM041441_d.JPG,0,test,38736,lativitta,38736_CAM041441_d.JPG,major
-CAM041440,https://zenodo.org/record/4291095/files/CAM041440_d.JPG,0,test,38732,lativitta,38732_CAM041440_d.JPG,major
-CAM041439,https://zenodo.org/record/4291095/files/CAM041439_d.JPG,0,test,38728,lativitta,38728_CAM041439_d.JPG,major
-CAM041438,https://zenodo.org/record/4291095/files/CAM041438_d.JPG,0,test,38724,lativitta,38724_CAM041438_d.JPG,major
-CAM041437,https://zenodo.org/record/4291095/files/CAM041437_d.JPG,0,test,38720,lativitta,38720_CAM041437_d.JPG,major
-CAM041436,https://zenodo.org/record/4291095/files/CAM041436_d.JPG,0,test,38716,lativitta,38716_CAM041436_d.JPG,major
-CAM041435,https://zenodo.org/record/4291095/files/CAM041435_d.JPG,0,test,38712,lativitta,38712_CAM041435_d.JPG,major
-CAM041434,https://zenodo.org/record/4291095/files/CAM041434_d.JPG,0,test,38708,lativitta,38708_CAM041434_d.JPG,major
-CAM041433,https://zenodo.org/record/4291095/files/CAM041433_d.JPG,0,test,38704,lativitta,38704_CAM041433_d.JPG,major
-CAM041432,https://zenodo.org/record/4291095/files/CAM041432_d.JPG,0,test,38700,lativitta,38700_CAM041432_d.JPG,major
-CAM041431,https://zenodo.org/record/4291095/files/CAM041431_d.JPG,0,test,38696,lativitta,38696_CAM041431_d.JPG,major
-CAM041430,https://zenodo.org/record/4291095/files/CAM041430_d.JPG,0,test,38692,lativitta,38692_CAM041430_d.JPG,major
-CAM041429,https://zenodo.org/record/4291095/files/CAM041429_d.JPG,0,test,38688,lativitta,38688_CAM041429_d.JPG,major
-CAM041428,https://zenodo.org/record/4291095/files/CAM041428_d.JPG,0,test,38684,lativitta,38684_CAM041428_d.JPG,major
-CAM041390,https://zenodo.org/record/4291095/files/CAM041390_d.JPG,0,test,38540,lativitta,38540_CAM041390_d.JPG,major
-CAM041358,https://zenodo.org/record/4291095/files/CAM041358_d.JPG,0,test,38412,lativitta,38412_CAM041358_d.JPG,major
-CAM041591,https://zenodo.org/record/4291095/files/CAM041591_d.JPG,0,test,39331,lativitta,39331_CAM041591_d.JPG,major
-CAM041667,https://zenodo.org/record/4291095/files/CAM041667_d.JPG,0,test,39635,lativitta,39635_CAM041667_d.JPG,major
-CAM041666,https://zenodo.org/record/4291095/files/CAM041666_d.JPG,0,test,39631,lativitta,39631_CAM041666_d.JPG,major
-CAM041665,https://zenodo.org/record/4291095/files/CAM041665_d.JPG,0,test,39627,lativitta,39627_CAM041665_d.JPG,major
-CAM041664,https://zenodo.org/record/4291095/files/CAM041664_d.JPG,0,test,39623,lativitta,39623_CAM041664_d.JPG,major
-CAM041663,https://zenodo.org/record/4291095/files/CAM041663_d.JPG,0,test,39619,lativitta,39619_CAM041663_d.JPG,major
-CAM041662,https://zenodo.org/record/4291095/files/CAM041662_d.JPG,0,test,39615,lativitta,39615_CAM041662_d.JPG,major
-CAM041661,https://zenodo.org/record/4291095/files/CAM041661_d.JPG,0,test,39611,lativitta,39611_CAM041661_d.JPG,major
-CAM041660,https://zenodo.org/record/4291095/files/CAM041660_d.JPG,0,test,39607,lativitta,39607_CAM041660_d.JPG,major
-CAM041659,https://zenodo.org/record/4291095/files/CAM041659_d.JPG,0,test,39603,lativitta,39603_CAM041659_d.JPG,major
-CAM041658,https://zenodo.org/record/4291095/files/CAM041658_d.JPG,0,test,39599,lativitta,39599_CAM041658_d.JPG,major
-CAM041668,https://zenodo.org/record/4291095/files/CAM041668_d.JPG,0,test,39639,lativitta,39639_CAM041668_d.JPG,major
-CAM041657,https://zenodo.org/record/4291095/files/CAM041657_d.JPG,0,test,39595,lativitta,39595_CAM041657_d.JPG,major
-CAM041655,https://zenodo.org/record/4291095/files/CAM041655_d.JPG,0,test,39587,lativitta,39587_CAM041655_d.JPG,major
-CAM041654,https://zenodo.org/record/4291095/files/CAM041654_d.JPG,0,test,39583,lativitta,39583_CAM041654_d.JPG,major
-CAM041653,https://zenodo.org/record/4291095/files/CAM041653_d.JPG,0,test,39579,lativitta,39579_CAM041653_d.JPG,major
-CAM041652,https://zenodo.org/record/4291095/files/CAM041652_d.JPG,0,test,39575,lativitta,39575_CAM041652_d.JPG,major
-CAM041651,https://zenodo.org/record/4291095/files/CAM041651_d.JPG,0,test,39571,lativitta,39571_CAM041651_d.JPG,major
-CAM041650,https://zenodo.org/record/4291095/files/CAM041650_d.JPG,0,test,39567,lativitta,39567_CAM041650_d.JPG,major
-CAM041649,https://zenodo.org/record/4291095/files/CAM041649_d.JPG,0,test,39563,lativitta,39563_CAM041649_d.JPG,major
-CAM041648,https://zenodo.org/record/4291095/files/CAM041648_d.JPG,0,test,39559,lativitta,39559_CAM041648_d.JPG,major
-CAM041647,https://zenodo.org/record/4291095/files/CAM041647_d.JPG,0,test,39555,lativitta,39555_CAM041647_d.JPG,major
-CAM041646,https://zenodo.org/record/4291095/files/CAM041646_d.JPG,0,test,39551,lativitta,39551_CAM041646_d.JPG,major
-CAM041656,https://zenodo.org/record/4291095/files/CAM041656_d.JPG,0,test,39591,lativitta,39591_CAM041656_d.JPG,major
-CAM041669,https://zenodo.org/record/4291095/files/CAM041669_d.JPG,0,test,39643,lativitta,39643_CAM041669_d.JPG,major
-CAM041670,https://zenodo.org/record/4291095/files/CAM041670_d.JPG,0,test,39647,lativitta,39647_CAM041670_d.JPG,major
-CAM041671,https://zenodo.org/record/4291095/files/CAM041671_d.JPG,0,test,39651,lativitta,39651_CAM041671_d.JPG,major
-CAM041699,https://zenodo.org/record/4291095/files/CAM041699_d.JPG,0,test,39763,lativitta,39763_CAM041699_d.JPG,major
-CAM041697,https://zenodo.org/record/4291095/files/CAM041697_d.JPG,0,test,39755,lativitta,39755_CAM041697_d.JPG,major
-CAM041696,https://zenodo.org/record/4291095/files/CAM041696_d.JPG,0,test,39751,lativitta,39751_CAM041696_d.JPG,major
-CAM041695,https://zenodo.org/record/4291095/files/CAM041695_d.JPG,0,test,39747,lativitta,39747_CAM041695_d.JPG,major
-CAM041694,https://zenodo.org/record/4291095/files/CAM041694_d.JPG,0,test,39743,lativitta,39743_CAM041694_d.JPG,major
-CAM041693,https://zenodo.org/record/4291095/files/CAM041693_d.JPG,0,test,39739,lativitta,39739_CAM041693_d.JPG,major
-CAM041692,https://zenodo.org/record/4291095/files/CAM041692_d.JPG,0,test,39735,lativitta,39735_CAM041692_d.JPG,major
-CAM041691,https://zenodo.org/record/4291095/files/CAM041691_d.JPG,0,test,39731,lativitta,39731_CAM041691_d.JPG,major
-CAM041690,https://zenodo.org/record/4291095/files/CAM041690_d.JPG,0,test,39727,lativitta,39727_CAM041690_d.JPG,major
-CAM041689,https://zenodo.org/record/4291095/files/CAM041689_d.JPG,0,test,39723,lativitta,39723_CAM041689_d.JPG,major
-CAM041685,https://zenodo.org/record/4291095/files/CAM041685_d.JPG,0,test,39707,lativitta,39707_CAM041685_d.JPG,major
-CAM041684,https://zenodo.org/record/4291095/files/CAM041684_d.JPG,0,test,39703,lativitta,39703_CAM041684_d.JPG,major
-CAM041683,https://zenodo.org/record/4291095/files/CAM041683_d.JPG,0,test,39699,lativitta,39699_CAM041683_d.JPG,major
-CAM041682,https://zenodo.org/record/4291095/files/CAM041682_d.JPG,0,test,39695,lativitta,39695_CAM041682_d.JPG,major
-CAM041680,https://zenodo.org/record/4291095/files/CAM041680_d.JPG,0,test,39687,lativitta,39687_CAM041680_d.JPG,major
-CAM041679,https://zenodo.org/record/4291095/files/CAM041679_d.JPG,0,test,39683,lativitta,39683_CAM041679_d.JPG,major
-CAM041678,https://zenodo.org/record/4291095/files/CAM041678_d.JPG,0,test,39679,lativitta,39679_CAM041678_d.JPG,major
-CAM041677,https://zenodo.org/record/4291095/files/CAM041677_d.JPG,0,test,39675,lativitta,39675_CAM041677_d.JPG,major
-CAM041676,https://zenodo.org/record/4291095/files/CAM041676_d.JPG,0,test,39671,lativitta,39671_CAM041676_d.JPG,major
-CAM041675,https://zenodo.org/record/4291095/files/CAM041675_d.JPG,0,test,39667,lativitta,39667_CAM041675_d.JPG,major
-CAM041674,https://zenodo.org/record/4291095/files/CAM041674_d.JPG,0,test,39663,lativitta,39663_CAM041674_d.JPG,major
-CAM041673,https://zenodo.org/record/4291095/files/CAM041673_d.JPG,0,test,39659,lativitta,39659_CAM041673_d.JPG,major
-CAM041672,https://zenodo.org/record/4291095/files/CAM041672_d.JPG,0,test,39655,lativitta,39655_CAM041672_d.JPG,major
-CAM041645,https://zenodo.org/record/4291095/files/CAM041645_d.JPG,0,test,39547,lativitta,39547_CAM041645_d.JPG,major
-CAM041644,https://zenodo.org/record/4291095/files/CAM041644_d.JPG,0,test,39543,lativitta,39543_CAM041644_d.JPG,major
-CAM041643,https://zenodo.org/record/4291095/files/CAM041643_d.JPG,0,test,39539,lativitta,39539_CAM041643_d.JPG,major
-CAM041642,https://zenodo.org/record/4291095/files/CAM041642_d.JPG,0,test,39535,lativitta,39535_CAM041642_d.JPG,major
-CAM041614,https://zenodo.org/record/4291095/files/CAM041614_d.JPG,0,test,39423,lativitta,39423_CAM041614_d.JPG,major
-CAM041613,https://zenodo.org/record/4291095/files/CAM041613_d.JPG,0,test,39419,lativitta,39419_CAM041613_d.JPG,major
-CAM041612,https://zenodo.org/record/4291095/files/CAM041612_d.JPG,0,test,39415,lativitta,39415_CAM041612_d.JPG,major
-CAM041611,https://zenodo.org/record/4291095/files/CAM041611_d.JPG,0,test,39411,lativitta,39411_CAM041611_d.JPG,major
-CAM041610,https://zenodo.org/record/4291095/files/CAM041610_d.JPG,0,test,39407,lativitta,39407_CAM041610_d.JPG,major
-CAM041609,https://zenodo.org/record/4291095/files/CAM041609_d.JPG,0,test,39403,lativitta,39403_CAM041609_d.JPG,major
-CAM041608,https://zenodo.org/record/4291095/files/CAM041608_d.JPG,0,test,39399,lativitta,39399_CAM041608_d.JPG,major
-CAM041607,https://zenodo.org/record/4291095/files/CAM041607_d.JPG,0,test,39395,lativitta,39395_CAM041607_d.JPG,major
-CAM041606,https://zenodo.org/record/4291095/files/CAM041606_d.JPG,0,test,39391,lativitta,39391_CAM041606_d.JPG,major
-CAM041605,https://zenodo.org/record/4291095/files/CAM041605_d.JPG,0,test,39387,lativitta,39387_CAM041605_d.JPG,major
-CAM041604,https://zenodo.org/record/4291095/files/CAM041604_d.JPG,0,test,39383,lativitta,39383_CAM041604_d.JPG,major
-CAM041603,https://zenodo.org/record/4291095/files/CAM041603_d.JPG,0,test,39379,lativitta,39379_CAM041603_d.JPG,major
-CAM041602,https://zenodo.org/record/4291095/files/CAM041602_d.JPG,0,test,39375,lativitta,39375_CAM041602_d.JPG,major
-CAM041601,https://zenodo.org/record/4291095/files/CAM041601_d.JPG,0,test,39371,lativitta,39371_CAM041601_d.JPG,major
-CAM041600,https://zenodo.org/record/4291095/files/CAM041600_d.JPG,0,test,39367,lativitta,39367_CAM041600_d.JPG,major
-CAM041599,https://zenodo.org/record/4291095/files/CAM041599_d.JPG,0,test,39363,lativitta,39363_CAM041599_d.JPG,major
-CAM041598,https://zenodo.org/record/4291095/files/CAM041598_d.JPG,0,test,39359,lativitta,39359_CAM041598_d.JPG,major
-CAM041597,https://zenodo.org/record/4291095/files/CAM041597_d.JPG,0,test,39355,lativitta,39355_CAM041597_d.JPG,major
-CAM041596,https://zenodo.org/record/4291095/files/CAM041596_d.JPG,0,test,39351,lativitta,39351_CAM041596_d.JPG,major
-CAM041595,https://zenodo.org/record/4291095/files/CAM041595_d.JPG,0,test,39347,lativitta,39347_CAM041595_d.JPG,major
-CAM041594,https://zenodo.org/record/4291095/files/CAM041594_d.JPG,0,test,39343,lativitta,39343_CAM041594_d.JPG,major
-CAM041593,https://zenodo.org/record/4291095/files/CAM041593_d.JPG,0,test,39339,lativitta,39339_CAM041593_d.JPG,major
-CAM041592,https://zenodo.org/record/4291095/files/CAM041592_d.JPG,0,test,39335,lativitta,39335_CAM041592_d.JPG,major
-CAM041615,https://zenodo.org/record/4291095/files/CAM041615_d.JPG,0,test,39427,lativitta,39427_CAM041615_d.JPG,major
-CAM041616,https://zenodo.org/record/4291095/files/CAM041616_d.JPG,0,test,39431,lativitta,39431_CAM041616_d.JPG,major
-CAM041618,https://zenodo.org/record/4291095/files/CAM041618_d.JPG,0,test,39439,lativitta,39439_CAM041618_d.JPG,major
-CAM041641,https://zenodo.org/record/4291095/files/CAM041641_d.JPG,0,test,39531,lativitta,39531_CAM041641_d.JPG,major
-CAM041640,https://zenodo.org/record/4291095/files/CAM041640_d.JPG,0,test,39527,lativitta,39527_CAM041640_d.JPG,major
-CAM041639,https://zenodo.org/record/4291095/files/CAM041639_d.JPG,0,test,39523,lativitta,39523_CAM041639_d.JPG,major
-CAM041638,https://zenodo.org/record/4291095/files/CAM041638_d.JPG,0,test,39519,lativitta,39519_CAM041638_d.JPG,major
-CAM041637,https://zenodo.org/record/4291095/files/CAM041637_d.JPG,0,test,39515,lativitta,39515_CAM041637_d.JPG,major
-CAM041636,https://zenodo.org/record/4291095/files/CAM041636_d.JPG,0,test,39511,lativitta,39511_CAM041636_d.JPG,major
-CAM041635,https://zenodo.org/record/4291095/files/CAM041635_d.JPG,0,test,39507,lativitta,39507_CAM041635_d.JPG,major
-CAM041634,https://zenodo.org/record/4291095/files/CAM041634_d.JPG,0,test,39503,lativitta,39503_CAM041634_d.JPG,major
-CAM041633,https://zenodo.org/record/4291095/files/CAM041633_d.JPG,0,test,39499,lativitta,39499_CAM041633_d.JPG,major
-CAM041632,https://zenodo.org/record/4291095/files/CAM041632_d.JPG,0,test,39495,lativitta,39495_CAM041632_d.JPG,major
-CAM041631,https://zenodo.org/record/4291095/files/CAM041631_d.JPG,0,test,39491,lativitta,39491_CAM041631_d.JPG,major
-CAM041630,https://zenodo.org/record/4291095/files/CAM041630_d.JPG,0,test,39487,lativitta,39487_CAM041630_d.JPG,major
-CAM041629,https://zenodo.org/record/4291095/files/CAM041629_d.JPG,0,test,39483,lativitta,39483_CAM041629_d.JPG,major
-CAM041628,https://zenodo.org/record/4291095/files/CAM041628_d.JPG,0,test,39479,lativitta,39479_CAM041628_d.JPG,major
-CAM041627,https://zenodo.org/record/4291095/files/CAM041627_d.JPG,0,test,39475,lativitta,39475_CAM041627_d.JPG,major
-CAM041626,https://zenodo.org/record/4291095/files/CAM041626_d.JPG,0,test,39471,lativitta,39471_CAM041626_d.JPG,major
-CAM041625,https://zenodo.org/record/4291095/files/CAM041625_d.JPG,0,test,39467,lativitta,39467_CAM041625_d.JPG,major
-CAM041624,https://zenodo.org/record/4291095/files/CAM041624_d.JPG,0,test,39463,lativitta,39463_CAM041624_d.JPG,major
-CAM041623,https://zenodo.org/record/4291095/files/CAM041623_d.JPG,0,test,39459,lativitta,39459_CAM041623_d.JPG,major
-CAM041622,https://zenodo.org/record/4291095/files/CAM041622_d.JPG,0,test,39455,lativitta,39455_CAM041622_d.JPG,major
-CAM041621,https://zenodo.org/record/4291095/files/CAM041621_d.JPG,0,test,39451,lativitta,39451_CAM041621_d.JPG,major
-CAM041620,https://zenodo.org/record/4291095/files/CAM041620_d.JPG,0,test,39447,lativitta,39447_CAM041620_d.JPG,major
-CAM041619,https://zenodo.org/record/4291095/files/CAM041619_d.JPG,0,test,39443,lativitta,39443_CAM041619_d.JPG,major
-CAM041617,https://zenodo.org/record/4291095/files/CAM041617_d.JPG,0,test,39435,lativitta,39435_CAM041617_d.JPG,major
-CAM041357,https://zenodo.org/record/4291095/files/CAM041357_d.JPG,0,test,38408,lativitta,38408_CAM041357_d.JPG,major
-CAM041389,https://zenodo.org/record/4291095/files/CAM041389_d.JPG,0,test,38536,lativitta,38536_CAM041389_d.JPG,major
-CAM041355,https://zenodo.org/record/4291095/files/CAM041355_d.JPG,0,test,38400,lativitta,38400_CAM041355_d.JPG,major
-CAM041777,https://zenodo.org/record/4291095/files/CAM041777_d.JPG,0,test,40075,lativitta,40075_CAM041777_d.JPG,major
-CAM041776,https://zenodo.org/record/4291095/files/CAM041776_d.JPG,0,test,40071,lativitta,40071_CAM041776_d.JPG,major
-CAM041775,https://zenodo.org/record/4291095/files/CAM041775_d.JPG,0,test,40067,lativitta,40067_CAM041775_d.JPG,major
-CAM041774,https://zenodo.org/record/4291095/files/CAM041774_d.JPG,0,test,40063,lativitta,40063_CAM041774_d.JPG,major
-CAM041773,https://zenodo.org/record/4291095/files/CAM041773_d.JPG,0,test,40059,lativitta,40059_CAM041773_d.JPG,major
-CAM041772,https://zenodo.org/record/4291095/files/CAM041772_d.JPG,0,test,40055,lativitta,40055_CAM041772_d.JPG,major
-CAM041771,https://zenodo.org/record/4291095/files/CAM041771_d.JPG,0,test,40051,lativitta,40051_CAM041771_d.JPG,major
-CAM041770,https://zenodo.org/record/4291095/files/CAM041770_d.JPG,0,test,40047,lativitta,40047_CAM041770_d.JPG,major
-CAM041769,https://zenodo.org/record/4291095/files/CAM041769_d.JPG,0,test,40043,lativitta,40043_CAM041769_d.JPG,major
-CAM041768,https://zenodo.org/record/4291095/files/CAM041768_d.JPG,0,test,40039,lativitta,40039_CAM041768_d.JPG,major
-CAM041767,https://zenodo.org/record/4291095/files/CAM041767_d.JPG,0,test,40035,lativitta,40035_CAM041767_d.JPG,major
-CAM041766,https://zenodo.org/record/4291095/files/CAM041766_d.JPG,0,test,40031,lativitta,40031_CAM041766_d.JPG,major
-CAM041765,https://zenodo.org/record/4291095/files/CAM041765_d.JPG,0,test,40027,lativitta,40027_CAM041765_d.JPG,major
-CAM041764,https://zenodo.org/record/4291095/files/CAM041764_d.JPG,0,test,40023,lativitta,40023_CAM041764_d.JPG,major
-CAM041763,https://zenodo.org/record/4291095/files/CAM041763_d.JPG,0,test,40019,lativitta,40019_CAM041763_d.JPG,major
-CAM041762,https://zenodo.org/record/4291095/files/CAM041762_d.JPG,0,test,40015,lativitta,40015_CAM041762_d.JPG,major
-CAM041761,https://zenodo.org/record/4291095/files/CAM041761_d.JPG,0,test,40011,lativitta,40011_CAM041761_d.JPG,major
-CAM041760,https://zenodo.org/record/4291095/files/CAM041760_d.JPG,0,test,40007,lativitta,40007_CAM041760_d.JPG,major
-CAM041759,https://zenodo.org/record/4291095/files/CAM041759_d.JPG,0,test,40003,lativitta,40003_CAM041759_d.JPG,major
-CAM041758,https://zenodo.org/record/4291095/files/CAM041758_d.JPG,0,test,39999,lativitta,39999_CAM041758_d.JPG,major
-CAM041757,https://zenodo.org/record/4291095/files/CAM041757_d.JPG,0,test,39995,lativitta,39995_CAM041757_d.JPG,major
-CAM041756,https://zenodo.org/record/4291095/files/CAM041756_d.JPG,0,test,39991,lativitta,39991_CAM041756_d.JPG,major
-CAM041755,https://zenodo.org/record/4291095/files/CAM041755_d.JPG,0,test,39987,lativitta,39987_CAM041755_d.JPG,major
-CAM041778,https://zenodo.org/record/4291095/files/CAM041778_d.JPG,0,test,40079,lativitta,40079_CAM041778_d.JPG,major
-CAM041754,https://zenodo.org/record/4291095/files/CAM041754_d.JPG,0,test,39983,lativitta,39983_CAM041754_d.JPG,major
-CAM041356,https://zenodo.org/record/4291095/files/CAM041356_d.JPG,0,test,38404,lativitta,38404_CAM041356_d.JPG,major
-CAM041781,https://zenodo.org/record/4291095/files/CAM041781_d.JPG,0,test,40091,lativitta,40091_CAM041781_d.JPG,major
-CAM041804,https://zenodo.org/record/4291095/files/CAM041804_d.JPG,0,test,40183,lativitta,40183_CAM041804_d.JPG,major
-CAM045107,https://zenodo.org/record/5526257/files/CAM045107_d.JPG,0,test,42993,cyrbia,42993_CAM045107_d.JPG,minor
-CAM045106,https://zenodo.org/record/5526257/files/CAM045106_d.JPG,0,test,42989,cyrbia,42989_CAM045106_d.JPG,minor
-CAM045105,https://zenodo.org/record/5526257/files/CAM045105_d.JPG,0,test,42985,cyrbia,42985_CAM045105_d.JPG,minor
-CAM045104,https://zenodo.org/record/5526257/files/CAM045104_d.JPG,0,test,42981,cyrbia,42981_CAM045104_d.JPG,minor
-CAM045118,https://zenodo.org/record/5526257/files/CAM045118_d.JPG,0,test,43039,cyrbia,43039_CAM045118_d.JPG,minor
-CAM045069,https://zenodo.org/record/5526257/files/CAM045069_d.JPG,0,test,42841,cyrbia,42841_CAM045069_d.JPG,minor
-CAM045068,https://zenodo.org/record/5526257/files/CAM045068_d.JPG,0,test,42837,cyrbia,42837_CAM045068_d.JPG,minor
-CAM045067,https://zenodo.org/record/5526257/files/CAM045067_d.JPG,0,test,42833,cyrbia,42833_CAM045067_d.JPG,minor
-CAM045031,https://zenodo.org/record/5526257/files/CAM045031_d.JPG,0,test,42689,cyrbia,42689_CAM045031_d.JPG,minor
-CAM045030,https://zenodo.org/record/5526257/files/CAM045030_d.JPG,0,test,42685,cyrbia,42685_CAM045030_d.JPG,minor
-CAM045029,https://zenodo.org/record/5526257/files/CAM045029_d.JPG,0,test,42681,cyrbia,42681_CAM045029_d.JPG,minor
-CAM045028,https://zenodo.org/record/5526257/files/CAM045028_d.JPG,0,test,42677,cyrbia,42677_CAM045028_d.JPG,minor
-CAM045027,https://zenodo.org/record/5526257/files/CAM045027_d.JPG,0,test,42673,cyrbia,42673_CAM045027_d.JPG,minor
-CAM045026,https://zenodo.org/record/5526257/files/CAM045026_d.JPG,0,test,42669,cyrbia,42669_CAM045026_d.JPG,minor
-CAM045025,https://zenodo.org/record/5526257/files/CAM045025_d.JPG,0,test,42665,cyrbia,42665_CAM045025_d.JPG,minor
-CAM045024,https://zenodo.org/record/5526257/files/CAM045024_d.JPG,0,test,42661,cyrbia,42661_CAM045024_d.JPG,minor
-CAM045023,https://zenodo.org/record/5526257/files/CAM045023_d.JPG,0,test,42657,cyrbia,42657_CAM045023_d.JPG,minor
-CAM045022,https://zenodo.org/record/5526257/files/CAM045022_d.JPG,0,test,42653,cyrbia,42653_CAM045022_d.JPG,minor
-CAM045021,https://zenodo.org/record/5526257/files/CAM045021_d.JPG,0,test,42649,cyrbia,42649_CAM045021_d.JPG,minor
-CAM045020,https://zenodo.org/record/5526257/files/CAM045020_d.JPG,0,test,42645,cyrbia,42645_CAM045020_d.JPG,minor
-CAM045018,https://zenodo.org/record/5526257/files/CAM045018_d.JPG,0,test,42637,cyrbia,42637_CAM045018_d.JPG,minor
-CAM045017,https://zenodo.org/record/5526257/files/CAM045017_d.JPG,0,test,42633,cyrbia,42633_CAM045017_d.JPG,minor
-CAM045032,https://zenodo.org/record/5526257/files/CAM045032_d.JPG,0,test,42693,cyrbia,42693_CAM045032_d.JPG,minor
-CAM045016,https://zenodo.org/record/5526257/files/CAM045016_d.JPG,0,test,42629,cyrbia,42629_CAM045016_d.JPG,minor
-CAM045014,https://zenodo.org/record/5526257/files/CAM045014_d.JPG,0,test,42621,cyrbia,42621_CAM045014_d.JPG,minor
-CAM045013,https://zenodo.org/record/5526257/files/CAM045013_d.JPG,0,test,42617,cyrbia,42617_CAM045013_d.JPG,minor
-CAM045012,https://zenodo.org/record/5526257/files/CAM045012_d.JPG,0,test,42613,cyrbia,42613_CAM045012_d.JPG,minor
-CAM045011,https://zenodo.org/record/5526257/files/CAM045011_d.JPG,0,test,42609,cyrbia,42609_CAM045011_d.JPG,minor
-CAM045010,https://zenodo.org/record/5526257/files/CAM045010_d.JPG,0,test,42605,cyrbia,42605_CAM045010_d.JPG,minor
-CAM045009,https://zenodo.org/record/5526257/files/CAM045009_d.JPG,0,test,42598,cyrbia,42598_CAM045009_d.JPG,minor
-CAM045008,https://zenodo.org/record/5526257/files/CAM045008_d.JPG,0,test,42595,cyrbia,42595_CAM045008_d.JPG,minor
-CAM045007,https://zenodo.org/record/5526257/files/CAM045007_d.JPG,0,test,42591,cyrbia,42591_CAM045007_d.JPG,minor
-CAM045006,https://zenodo.org/record/5526257/files/CAM045006_d.JPG,0,test,42584,cyrbia,42584_CAM045006_d.JPG,minor
-CAM045005,https://zenodo.org/record/5526257/files/CAM045005_d.JPG,0,test,42579,cyrbia,42579_CAM045005_d.JPG,minor
-CAM045004,https://zenodo.org/record/5526257/files/CAM045004_d.JPG,0,test,42575,cyrbia,42575_CAM045004_d.JPG,minor
-CAM045003,https://zenodo.org/record/5526257/files/CAM045003_d.JPG,0,test,42571,cyrbia,42571_CAM045003_d.JPG,minor
-CAM045002,https://zenodo.org/record/5526257/files/CAM045002_d.JPG,0,test,42567,cyrbia,42567_CAM045002_d.JPG,minor
-CAM045001,https://zenodo.org/record/5526257/files/CAM045001_d.JPG,0,test,42563,cyrbia,42563_CAM045001_d.JPG,minor
-CAM045015,https://zenodo.org/record/5526257/files/CAM045015_d.JPG,0,test,42625,cyrbia,42625_CAM045015_d.JPG,minor
-CAM045033,https://zenodo.org/record/5526257/files/CAM045033_d.JPG,0,test,42697,cyrbia,42697_CAM045033_d.JPG,minor
-CAM045034,https://zenodo.org/record/5526257/files/CAM045034_d.JPG,0,test,42701,cyrbia,42701_CAM045034_d.JPG,minor
-CAM045035,https://zenodo.org/record/5526257/files/CAM045035_d.JPG,0,test,42705,cyrbia,42705_CAM045035_d.JPG,minor
-CAM045066,https://zenodo.org/record/5526257/files/CAM045066_d.JPG,0,test,42829,cyrbia,42829_CAM045066_d.JPG,minor
-CAM045065,https://zenodo.org/record/5526257/files/CAM045065_d.JPG,0,test,42825,cyrbia,42825_CAM045065_d.JPG,minor
-CAM045064,https://zenodo.org/record/5526257/files/CAM045064_d.JPG,0,test,42821,cyrbia,42821_CAM045064_d.JPG,minor
-CAM045063,https://zenodo.org/record/5526257/files/CAM045063_d.JPG,0,test,42817,cyrbia,42817_CAM045063_d.JPG,minor
-CAM045062,https://zenodo.org/record/5526257/files/CAM045062_d.JPG,0,test,42813,cyrbia,42813_CAM045062_d.JPG,minor
-CAM045061,https://zenodo.org/record/5526257/files/CAM045061_d.JPG,0,test,42809,cyrbia,42809_CAM045061_d.JPG,minor
-CAM045060,https://zenodo.org/record/5526257/files/CAM045060_d.JPG,0,test,42805,cyrbia,42805_CAM045060_d.JPG,minor
-CAM045059,https://zenodo.org/record/5526257/files/CAM045059_d.JPG,0,test,42801,cyrbia,42801_CAM045059_d.JPG,minor
-CAM045058,https://zenodo.org/record/5526257/files/CAM045058_d.JPG,0,test,42797,cyrbia,42797_CAM045058_d.JPG,minor
-CAM045057,https://zenodo.org/record/5526257/files/CAM045057_d.JPG,0,test,42793,cyrbia,42793_CAM045057_d.JPG,minor
-CAM045056,https://zenodo.org/record/5526257/files/CAM045056_d.JPG,0,test,42789,cyrbia,42789_CAM045056_d.JPG,minor
-CAM045055,https://zenodo.org/record/5526257/files/CAM045055_d.JPG,0,test,42785,cyrbia,42785_CAM045055_d.JPG,minor
-CAM045054,https://zenodo.org/record/5526257/files/CAM045054_d.JPG,0,test,42781,cyrbia,42781_CAM045054_d.JPG,minor
-CAM045053,https://zenodo.org/record/5526257/files/CAM045053_d.JPG,0,test,42777,cyrbia,42777_CAM045053_d.JPG,minor
-CAM045052,https://zenodo.org/record/5526257/files/CAM045052_d.JPG,0,test,42773,cyrbia,42773_CAM045052_d.JPG,minor
-CAM045051,https://zenodo.org/record/5526257/files/CAM045051_d.JPG,0,test,42769,cyrbia,42769_CAM045051_d.JPG,minor
-CAM045050,https://zenodo.org/record/5526257/files/CAM045050_d.JPG,0,test,42765,cyrbia,42765_CAM045050_d.JPG,minor
-CAM045036,https://zenodo.org/record/5526257/files/CAM045036_d.JPG,0,test,42709,cyrbia,42709_CAM045036_d.JPG,minor
-CAM045037,https://zenodo.org/record/5526257/files/CAM045037_d.JPG,0,test,42713,cyrbia,42713_CAM045037_d.JPG,minor
-CAM045038,https://zenodo.org/record/5526257/files/CAM045038_d.JPG,0,test,42717,cyrbia,42717_CAM045038_d.JPG,minor
-CAM045039,https://zenodo.org/record/5526257/files/CAM045039_d.JPG,0,test,42721,cyrbia,42721_CAM045039_d.JPG,minor
-CAM045040,https://zenodo.org/record/5526257/files/CAM045040_d.JPG,0,test,42725,cyrbia,42725_CAM045040_d.JPG,minor
-CAM045041,https://zenodo.org/record/5526257/files/CAM045041_d.JPG,0,test,42729,cyrbia,42729_CAM045041_d.JPG,minor
-CAM045134,https://zenodo.org/record/5526257/files/CAM045134_d.JPG,0,test,43103,cyrbia,43103_CAM045134_d.JPG,minor
-CAM045042,https://zenodo.org/record/5526257/files/CAM045042_d.JPG,0,test,42733,cyrbia,42733_CAM045042_d.JPG,minor
-CAM045044,https://zenodo.org/record/5526257/files/CAM045044_d.JPG,0,test,42741,cyrbia,42741_CAM045044_d.JPG,minor
-CAM045045,https://zenodo.org/record/5526257/files/CAM045045_d.JPG,0,test,42745,cyrbia,42745_CAM045045_d.JPG,minor
-CAM045046,https://zenodo.org/record/5526257/files/CAM045046_d.JPG,0,test,42749,cyrbia,42749_CAM045046_d.JPG,minor
-CAM045047,https://zenodo.org/record/5526257/files/CAM045047_d.JPG,0,test,42753,cyrbia,42753_CAM045047_d.JPG,minor
-CAM045048,https://zenodo.org/record/5526257/files/CAM045048_d.JPG,0,test,42757,cyrbia,42757_CAM045048_d.JPG,minor
-CAM045049,https://zenodo.org/record/5526257/files/CAM045049_d.JPG,0,test,42761,cyrbia,42761_CAM045049_d.JPG,minor
-CAM045043,https://zenodo.org/record/5526257/files/CAM045043_d.JPG,0,test,42737,cyrbia,42737_CAM045043_d.JPG,minor
-CAM045135,https://zenodo.org/record/5526257/files/CAM045135_d.JPG,0,test,43107,cyrbia,43107_CAM045135_d.JPG,minor
-CAM045019,https://zenodo.org/record/5526257/files/CAM045019_d.JPG,0,test,42641,cyrbia,42641_CAM045019_d.JPG,minor
-CAM045137,https://zenodo.org/record/5526257/files/CAM045137_d.JPG,0,test,43115,cyrbia,43115_CAM045137_d.JPG,minor
-CAM045232,https://zenodo.org/record/5526257/files/CAM045232_d.JPG,0,test,43491,cyrbia,43491_CAM045232_d.JPG,minor
-CAM045233,https://zenodo.org/record/5526257/files/CAM045233_d.JPG,0,test,43495,cyrbia,43495_CAM045233_d.JPG,minor
-CAM045234,https://zenodo.org/record/5526257/files/CAM045234_d.JPG,0,test,43499,cyrbia,43499_CAM045234_d.JPG,minor
-CAM045236,https://zenodo.org/record/5526257/files/CAM045236_d.JPG,0,test,43507,cyrbia,43507_CAM045236_d.JPG,minor
-CAM045237,https://zenodo.org/record/5526257/files/CAM045237_d.JPG,0,test,43511,cyrbia,43511_CAM045237_d.JPG,minor
-CAM045238,https://zenodo.org/record/5526257/files/CAM045238_d.JPG,0,test,43515,cyrbia,43515_CAM045238_d.JPG,minor
-CAM045239,https://zenodo.org/record/5526257/files/CAM045239_d.JPG,0,test,43519,cyrbia,43519_CAM045239_d.JPG,minor
-CAM045240,https://zenodo.org/record/5526257/files/CAM045240_d.JPG,0,test,43523,cyrbia,43523_CAM045240_d.JPG,minor
-CAM045241,https://zenodo.org/record/5526257/files/CAM045241_d.JPG,0,test,43527,cyrbia,43527_CAM045241_d.JPG,minor
-CAM045242,https://zenodo.org/record/5526257/files/CAM045242_d.JPG,0,test,43531,cyrbia,43531_CAM045242_d.JPG,minor
-CAM045243,https://zenodo.org/record/5526257/files/CAM045243_d.JPG,0,test,43535,cyrbia,43535_CAM045243_d.JPG,minor
-CAM045244,https://zenodo.org/record/5526257/files/CAM045244_d.JPG,0,test,43539,cyrbia,43539_CAM045244_d.JPG,minor
-CAM045245,https://zenodo.org/record/5526257/files/CAM045245_d.JPG,0,test,43543,cyrbia,43543_CAM045245_d.JPG,minor
-CAM045246,https://zenodo.org/record/5526257/files/CAM045246_d.JPG,0,test,43547,cyrbia,43547_CAM045246_d.JPG,minor
-CAM045231,https://zenodo.org/record/5526257/files/CAM045231_d.JPG,0,test,43487,cyrbia,43487_CAM045231_d.JPG,minor
-CAM045247,https://zenodo.org/record/5526257/files/CAM045247_d.JPG,0,test,43551,cyrbia,43551_CAM045247_d.JPG,minor
-CAM045249,https://zenodo.org/record/5526257/files/CAM045249_d.JPG,0,test,43559,cyrbia,43559_CAM045249_d.JPG,minor
-CAM045250,https://zenodo.org/record/5526257/files/CAM045250_d.JPG,0,test,43563,cyrbia,43563_CAM045250_d.JPG,minor
-CAM045252,https://zenodo.org/record/5526257/files/CAM045252_d.JPG,0,test,43571,cyrbia,43571_CAM045252_d.JPG,minor
-CAM045253,https://zenodo.org/record/5526257/files/CAM045253_d.JPG,0,test,43575,cyrbia,43575_CAM045253_d.JPG,minor
-CAM045254,https://zenodo.org/record/5526257/files/CAM045254_d.JPG,0,test,43579,cyrbia,43579_CAM045254_d.JPG,minor
-CAM045255,https://zenodo.org/record/5526257/files/CAM045255_d.JPG,0,test,43583,cyrbia,43583_CAM045255_d.JPG,minor
-CAM045256,https://zenodo.org/record/5526257/files/CAM045256_d.JPG,0,test,43587,cyrbia,43587_CAM045256_d.JPG,minor
-CAM045257,https://zenodo.org/record/5526257/files/CAM045257_d.JPG,0,test,43591,cyrbia,43591_CAM045257_d.JPG,minor
-CAM045258,https://zenodo.org/record/5526257/files/CAM045258_d.JPG,0,test,43595,cyrbia,43595_CAM045258_d.JPG,minor
-CAM045259,https://zenodo.org/record/5526257/files/CAM045259_d.JPG,0,test,43599,cyrbia,43599_CAM045259_d.JPG,minor
-CAM045260,https://zenodo.org/record/5526257/files/CAM045260_d.JPG,0,test,43603,cyrbia,43603_CAM045260_d.JPG,minor
-CAM045261,https://zenodo.org/record/5526257/files/CAM045261_d.JPG,0,test,43607,cyrbia,43607_CAM045261_d.JPG,minor
-CAM036188,https://zenodo.org/record/5561246/files/CAM036188_d.JPG,0,test,41483,phyllis,41483_CAM036188_d.JPG,minor
-CAM036184,https://zenodo.org/record/5561246/files/CAM036184_d.JPG,0,test,41471,phyllis,41471_CAM036184_d.JPG,minor
-CAM036172,https://zenodo.org/record/5561246/files/CAM036172_d.JPG,0,test,41459,phyllis,41459_CAM036172_d.JPG,minor
-CAM036168,https://zenodo.org/record/5561246/files/CAM036168_d.JPG,0,test,41443,phyllis,41443_CAM036168_d.JPG,minor
-CAM036165,https://zenodo.org/record/5561246/files/CAM036165_d.JPG,0,test,41431,phyllis,41431_CAM036165_d.JPG,minor
-CAM036164,https://zenodo.org/record/5561246/files/CAM036164_d.JPG,0,test,41427,phyllis,41427_CAM036164_d.JPG,minor
-CAM036214,https://zenodo.org/record/5561246/files/CAM036214_d.JPG,0,test,41571,phyllis,41571_CAM036214_d.JPG,minor
-CAM036215,https://zenodo.org/record/5561246/files/CAM036215_d.JPG,0,test,41575,phyllis,41575_CAM036215_d.JPG,minor
-CAM036216,https://zenodo.org/record/5561246/files/CAM036216_d.JPG,0,test,41579,phyllis,41579_CAM036216_d.JPG,minor
-CAM036293,https://zenodo.org/record/5561246/files/CAM036293_d.JPG,0,test,41827,phyllis,41827_CAM036293_d.JPG,minor
-CAM036292,https://zenodo.org/record/5561246/files/CAM036292_d.JPG,0,test,41823,phyllis,41823_CAM036292_d.JPG,minor
-CAM036291,https://zenodo.org/record/5561246/files/CAM036291_d.JPG,0,test,41819,phyllis,41819_CAM036291_d.JPG,minor
-CAM036290,https://zenodo.org/record/5561246/files/CAM036290_d.JPG,0,test,41815,phyllis,41815_CAM036290_d.JPG,minor
-CAM036277,https://zenodo.org/record/5561246/files/CAM036277_d.JPG,0,test,41763,phyllis,41763_CAM036277_d.JPG,minor
-CAM036276,https://zenodo.org/record/5561246/files/CAM036276_d.JPG,0,test,41759,phyllis,41759_CAM036276_d.JPG,minor
+CAMID,file_url,hybrid_stat,X,subspecies_ref,filename,ssp_indicator
+F809,https://zenodo.org/record/2555086/files/F809_d.JPG,0,38048,demophoon,38048_F809_d.JPG,minor
+F866,https://zenodo.org/record/2555086/files/F866_d.JPG,0,38112,demophoon,38112_F866_d.JPG,minor
+F824,https://zenodo.org/record/2555086/files/F824_d.JPG,0,38052,demophoon,38052_F824_d.JPG,minor
+F844,https://zenodo.org/record/2555086/files/F844_d.JPG,0,38064,demophoon,38064_F844_d.JPG,minor
+F846,https://zenodo.org/record/2555086/files/F846_d.JPG,0,38068,demophoon,38068_F846_d.JPG,minor
+F848,https://zenodo.org/record/2555086/files/F848_d.JPG,0,38072,demophoon,38072_F848_d.JPG,minor
+F849,https://zenodo.org/record/2555086/files/F849_d.JPG,0,38076,demophoon,38076_F849_d.JPG,minor
+F837,https://zenodo.org/record/2555086/files/F837_d.JPG,0,38060,demophoon,38060_F837_d.JPG,minor
+F852,https://zenodo.org/record/2555086/files/F852_d.JPG,0,38084,demophoon,38084_F852_d.JPG,minor
+F853,https://zenodo.org/record/2555086/files/F853_d.JPG,0,38088,demophoon,38088_F853_d.JPG,minor
+F854,https://zenodo.org/record/2555086/files/F854_d.JPG,0,38092,demophoon,38092_F854_d.JPG,minor
+F858,https://zenodo.org/record/2555086/files/F858_d.JPG,0,38096,demophoon,38096_F858_d.JPG,minor
+F864,https://zenodo.org/record/2555086/files/F864_d.JPG,0,38104,demophoon,38104_F864_d.JPG,minor
+F862,https://zenodo.org/record/2555086/files/F862_d.JPG,0,38100,demophoon,38100_F862_d.JPG,minor
+F851,https://zenodo.org/record/2555086/files/F851_d.JPG,0,38080,demophoon,38080_F851_d.JPG,minor
+F8621,https://zenodo.org/record/2555086/files/F8621_d.JPG,0,38392,demophoon,38392_F8621_d.JPG,minor
+CAM000255,https://zenodo.org/record/2677821/files/CAM000255_d.JPG,0,6336,demophoon,6336_CAM000255_d.JPG,minor
+CAM000242,https://zenodo.org/record/2677821/files/CAM000242_d.JPG,0,6310,chestertonii,6310_CAM000242_d.JPG,minor
+CAM000241,https://zenodo.org/record/2677821/files/CAM000241_d.JPG,0,6308,chestertonii,6308_CAM000241_d.JPG,minor
+CAM000240,https://zenodo.org/record/2677821/files/CAM000240_d.JPG,0,6306,chestertonii,6306_CAM000240_d.JPG,minor
+CAM000239,https://zenodo.org/record/2677821/files/CAM000239_d.JPG,0,6304,chestertonii,6304_CAM000239_d.JPG,minor
+CAM000238,https://zenodo.org/record/2677821/files/CAM000238_d.JPG,0,6302,chestertonii,6302_CAM000238_d.JPG,minor
+CAM000237,https://zenodo.org/record/2677821/files/CAM000237_d.JPG,0,6300,chestertonii,6300_CAM000237_d.JPG,minor
+CAM000236,https://zenodo.org/record/2677821/files/CAM000236_d.JPG,0,6298,chestertonii,6298_CAM000236_d.JPG,minor
+CAM000235,https://zenodo.org/record/2677821/files/CAM000235_d.JPG,0,6296,chestertonii,6296_CAM000235_d.JPG,minor
+CAM000234,https://zenodo.org/record/2677821/files/CAM000234_d.JPG,0,6294,chestertonii,6294_CAM000234_d.JPG,minor
+CAM009553,https://zenodo.org/record/2686762/files/CAM009553_d.JPG,1,10848,hydara x petiverana,10848_CAM009553_d.JPG,minor
+CAM009568,https://zenodo.org/record/2686762/files/CAM009568_d.JPG,1,10878,hydara x petiverana,10878_CAM009568_d.JPG,minor
+CAM009574,https://zenodo.org/record/2686762/files/CAM009574_d.JPG,1,10890,hydara x petiverana,10890_CAM009574_d.JPG,minor
+CAM009510,https://zenodo.org/record/2686762/files/CAM009510_d.JPG,1,10762,hydara x petiverana,10762_CAM009510_d.JPG,minor
+CAM009513,https://zenodo.org/record/2686762/files/CAM009513_d.JPG,1,10768,hydara x petiverana,10768_CAM009513_d.JPG,minor
+CAM009518,https://zenodo.org/record/2686762/files/CAM009518_d.JPG,1,10778,hydara x petiverana,10778_CAM009518_d.JPG,minor
+CAM009520,https://zenodo.org/record/2686762/files/CAM009520_d.JPG,1,10782,hydara x petiverana,10782_CAM009520_d.JPG,minor
+CAM009523,https://zenodo.org/record/2686762/files/CAM009523_d.JPG,1,10788,hydara x petiverana,10788_CAM009523_d.JPG,minor
+CAM009526,https://zenodo.org/record/2686762/files/CAM009526_d.JPG,1,10794,hydara x petiverana,10794_CAM009526_d.JPG,minor
+CAM009534,https://zenodo.org/record/2686762/files/CAM009534_d.JPG,0,10810,petiverana,10810_CAM009534_d.JPG,minor
+CAM009503,https://zenodo.org/record/2686762/files/CAM009503_d.JPG,0,10748,petiverana,10748_CAM009503_d.JPG,minor
+CAM009304,https://zenodo.org/record/2686762/files/CAM009304_d.JPG,0,10460,hydara,10460_CAM009304_d.JPG,minor
+CAM009305,https://zenodo.org/record/2686762/files/CAM009305_d.JPG,0,10462,hydara,10462_CAM009305_d.JPG,minor
+CAM009306,https://zenodo.org/record/2686762/files/CAM009306_d.JPG,0,10464,hydara,10464_CAM009306_d.JPG,minor
+CAM009307,https://zenodo.org/record/2686762/files/CAM009307_d.JPG,0,10466,hydara,10466_CAM009307_d.JPG,minor
+CAM009328,https://zenodo.org/record/2686762/files/CAM009328_d.JPG,0,10508,hydara,10508_CAM009328_d.JPG,minor
+CAM009327,https://zenodo.org/record/2686762/files/CAM009327_d.JPG,0,10506,hydara,10506_CAM009327_d.JPG,minor
+CAM009326,https://zenodo.org/record/2686762/files/CAM009326_d.JPG,0,10504,hydara,10504_CAM009326_d.JPG,minor
+CAM009322,https://zenodo.org/record/2686762/files/CAM009322_d.JPG,0,10496,hydara,10496_CAM009322_d.JPG,minor
+CAM009321,https://zenodo.org/record/2686762/files/CAM009321_d.JPG,0,10494,hydara,10494_CAM009321_d.JPG,minor
+CAM009320,https://zenodo.org/record/2686762/files/CAM009320_d.JPG,0,10492,hydara,10492_CAM009320_d.JPG,minor
+CAM009313,https://zenodo.org/record/2686762/files/CAM009313_d.JPG,0,10478,hydara,10478_CAM009313_d.JPG,minor
+CAM009312,https://zenodo.org/record/2686762/files/CAM009312_d.JPG,0,10476,hydara,10476_CAM009312_d.JPG,minor
+CAM009311,https://zenodo.org/record/2686762/files/CAM009311_d.JPG,0,10474,hydara,10474_CAM009311_d.JPG,minor
+CAM009310,https://zenodo.org/record/2686762/files/CAM009310_d.JPG,0,10472,hydara,10472_CAM009310_d.JPG,minor
+CAM009309,https://zenodo.org/record/2686762/files/CAM009309_d.JPG,0,10470,hydara,10470_CAM009309_d.JPG,minor
+CAM009308,https://zenodo.org/record/2686762/files/CAM009308_d.JPG,0,10468,hydara,10468_CAM009308_d.JPG,minor
+CAM009014,https://zenodo.org/record/2686762/files/CAM009014_d.JPG,0,10133,hydara,10133_CAM009014_d.JPG,minor
+CAM009018,https://zenodo.org/record/2686762/files/CAM009018_d.JPG,0,10141,hydara,10141_CAM009018_d.JPG,minor
+CAM009017,https://zenodo.org/record/2686762/files/CAM009017_d.JPG,0,10139,hydara,10139_CAM009017_d.JPG,minor
+CAM021240,https://zenodo.org/record/2702457/files/CAM021240_d.JPG,0,11690,hydara,11690_CAM021240_d.JPG,minor
+CAM021239,https://zenodo.org/record/2702457/files/CAM021239_d.JPG,0,11688,hydara,11688_CAM021239_d.JPG,minor
+CAM021053,https://zenodo.org/record/2702457/files/CAM021053_d.JPG,0,11538,erato,11538_CAM021053_d.JPG,minor
+CAM021033,https://zenodo.org/record/2702457/files/CAM021033_d.JPG,1,11500,hydara x amalfreda,11500_CAM021033_d.JPG,minor
+CAM021034,https://zenodo.org/record/2702457/files/CAM021034_d.JPG,1,11502,hydara x amalfreda,11502_CAM021034_d.JPG,minor
+CAM021035,https://zenodo.org/record/2702457/files/CAM021035_d.JPG,1,11504,hydara x amalfreda,11504_CAM021035_d.JPG,minor
+CAM021038,https://zenodo.org/record/2702457/files/CAM021038_d.JPG,0,11508,amalfreda,11508_CAM021038_d.JPG,minor
+CAM021039,https://zenodo.org/record/2702457/files/CAM021039_d.JPG,0,11510,amalfreda,11510_CAM021039_d.JPG,minor
+CAM021040,https://zenodo.org/record/2702457/files/CAM021040_d.JPG,0,11512,amalfreda,11512_CAM021040_d.JPG,minor
+CAM021041,https://zenodo.org/record/2702457/files/CAM021041_d.JPG,0,11514,amalfreda,11514_CAM021041_d.JPG,minor
+CAM021042,https://zenodo.org/record/2702457/files/CAM021042_d.JPG,0,11516,amalfreda,11516_CAM021042_d.JPG,minor
+CAM021032,https://zenodo.org/record/2702457/files/CAM021032_d.JPG,1,11498,hydara x amalfreda,11498_CAM021032_d.JPG,minor
+CAM021067,https://zenodo.org/record/2702457/files/CAM021067_d.JPG,0,11563,erato,11563_CAM021067_d.JPG,minor
+CAM021063,https://zenodo.org/record/2702457/files/CAM021063_d.JPG,0,11555,erato,11555_CAM021063_d.JPG,minor
+CAM040078,https://zenodo.org/record/2707828/files/CAM040078_d.JPG,0,11820,dignus,11820_CAM040078_d.JPG,minor
+CAM040077,https://zenodo.org/record/2707828/files/CAM040077_d.JPG,0,11818,dignus,11818_CAM040077_d.JPG,minor
+CAM040066,https://zenodo.org/record/2707828/files/CAM040066_d.JPG,0,11812,dignus,11812_CAM040066_d.JPG,minor
+CAM040039,https://zenodo.org/record/2707828/files/CAM040039_d.JPG,0,11758,dignus,11758_CAM040039_d.JPG,minor
+CS004059,https://zenodo.org/record/2813153/files/CS004059_d.JPG,0,14384,reductimacula,14384_CS004059_d.JPG,minor
+CAM016323,https://zenodo.org/record/3082688/files/CAM016323_d.JPG,0,3420,plesseni,3420_CAM016323_d.JPG,mimic
+CAM016324,https://zenodo.org/record/3082688/files/CAM016324_d.JPG,0,3422,plesseni,3422_CAM016324_d.JPG,mimic
+CAM016341,https://zenodo.org/record/3082688/files/CAM016341_d.JPG,1,3430,plesseni x malleti,3430_CAM016341_d.JPG,mimic
+CAM016092,https://zenodo.org/record/3082688/files/CAM016092_d.JPG,1,3092,plesseni x malleti,3092_CAM016092_d.JPG,mimic
+CAM016141,https://zenodo.org/record/3082688/files/CAM016141_d.JPG,1,3190,plesseni x malleti,3190_CAM016141_d.JPG,mimic
+CAM016142,https://zenodo.org/record/3082688/files/CAM016142_d.JPG,1,3192,plesseni x malleti,3192_CAM016142_d.JPG,mimic
+CAM016143,https://zenodo.org/record/3082688/files/CAM016143_d.JPG,1,3194,plesseni x malleti,3194_CAM016143_d.JPG,mimic
+CAM016235,https://zenodo.org/record/3082688/files/CAM016235_d.JPG,1,3346,plesseni x malleti,3346_CAM016235_d.JPG,mimic
+CAM016230,https://zenodo.org/record/3082688/files/CAM016230_d.JPG,1,3342,plesseni x malleti,3342_CAM016230_d.JPG,mimic
+CAM016228,https://zenodo.org/record/3082688/files/CAM016228_d.JPG,1,3340,plesseni x malleti,3340_CAM016228_d.JPG,mimic
+CAM016227,https://zenodo.org/record/3082688/files/CAM016227_d.JPG,1,3338,plesseni x malleti,3338_CAM016227_d.JPG,mimic
+CAM016225,https://zenodo.org/record/3082688/files/CAM016225_d.JPG,1,3336,plesseni x malleti,3336_CAM016225_d.JPG,mimic
+CAM016196,https://zenodo.org/record/3082688/files/CAM016196_d.JPG,1,3300,plesseni x malleti,3300_CAM016196_d.JPG,mimic
+CAM016195,https://zenodo.org/record/3082688/files/CAM016195_d.JPG,1,3298,plesseni x malleti,3298_CAM016195_d.JPG,mimic
+CAM016191,https://zenodo.org/record/3082688/files/CAM016191_d.JPG,1,3290,plesseni x malleti,3290_CAM016191_d.JPG,mimic
+CAM016237,https://zenodo.org/record/3082688/files/CAM016237_d.JPG,1,3348,plesseni x malleti,3348_CAM016237_d.JPG,mimic
+CAM016239,https://zenodo.org/record/3082688/files/CAM016239_d.JPG,1,3350,plesseni x malleti,3350_CAM016239_d.JPG,mimic
+CAM016242,https://zenodo.org/record/3082688/files/CAM016242_d.JPG,1,3352,plesseni x malleti,3352_CAM016242_d.JPG,mimic
+CAM016244,https://zenodo.org/record/3082688/files/CAM016244_d.JPG,1,3354,plesseni x malleti,3354_CAM016244_d.JPG,mimic
+CAM016285,https://zenodo.org/record/3082688/files/CAM016285_d.JPG,0,3398,plesseni,3398_CAM016285_d.JPG,mimic
+CAM016287,https://zenodo.org/record/3082688/files/CAM016287_d.JPG,0,3400,plesseni,3400_CAM016287_d.JPG,mimic
+CAM016290,https://zenodo.org/record/3082688/files/CAM016290_d.JPG,0,3402,plesseni,3402_CAM016290_d.JPG,mimic
+CAM016294,https://zenodo.org/record/3082688/files/CAM016294_d.JPG,0,3404,plesseni,3404_CAM016294_d.JPG,mimic
+CAM016295,https://zenodo.org/record/3082688/files/CAM016295_d.JPG,0,3406,plesseni,3406_CAM016295_d.JPG,mimic
+CAM016272,https://zenodo.org/record/3082688/files/CAM016272_d.JPG,1,3388,plesseni x malleti,3388_CAM016272_d.JPG,mimic
+CAM016189,https://zenodo.org/record/3082688/files/CAM016189_d.JPG,1,3286,plesseni x malleti,3286_CAM016189_d.JPG,mimic
+CAM016270,https://zenodo.org/record/3082688/files/CAM016270_d.JPG,1,3386,plesseni x malleti,3386_CAM016270_d.JPG,mimic
+CAM016254,https://zenodo.org/record/3082688/files/CAM016254_d.JPG,1,3368,plesseni x malleti,3368_CAM016254_d.JPG,mimic
+CAM016253,https://zenodo.org/record/3082688/files/CAM016253_d.JPG,1,3366,plesseni x malleti,3366_CAM016253_d.JPG,mimic
+CAM016251,https://zenodo.org/record/3082688/files/CAM016251_d.JPG,1,3362,plesseni x malleti,3362_CAM016251_d.JPG,mimic
+CAM016250,https://zenodo.org/record/3082688/files/CAM016250_d.JPG,1,3360,plesseni x malleti,3360_CAM016250_d.JPG,mimic
+CAM016249,https://zenodo.org/record/3082688/files/CAM016249_d.JPG,1,3358,plesseni x malleti,3358_CAM016249_d.JPG,mimic
+CAM016247,https://zenodo.org/record/3082688/files/CAM016247_d.JPG,0,3356,plesseni,3356_CAM016247_d.JPG,mimic
+CAM016161,https://zenodo.org/record/3082688/files/CAM016161_d.JPG,1,3230,plesseni x malleti,3230_CAM016161_d.JPG,mimic
+CAM016160,https://zenodo.org/record/3082688/files/CAM016160_d.JPG,1,3228,plesseni x malleti,3228_CAM016160_d.JPG,mimic
+CAM016159,https://zenodo.org/record/3082688/files/CAM016159_d.JPG,1,3226,plesseni x malleti,3226_CAM016159_d.JPG,mimic
+CAM016158,https://zenodo.org/record/3082688/files/CAM016158_d.JPG,1,3224,plesseni x malleti,3224_CAM016158_d.JPG,mimic
+CAM016374,https://zenodo.org/record/3082688/files/CAM016374_d.JPG,0,3462,plesseni,3462_CAM016374_d.JPG,mimic
+CAM016165,https://zenodo.org/record/3082688/files/CAM016165_d.JPG,1,3238,plesseni x malleti,3238_CAM016165_d.JPG,mimic
+CAM016166,https://zenodo.org/record/3082688/files/CAM016166_d.JPG,1,3240,plesseni x malleti,3240_CAM016166_d.JPG,mimic
+CAM016073,https://zenodo.org/record/3082688/files/CAM016073_d.JPG,0,3054,plesseni,3054_CAM016073_d.JPG,mimic
+CAM016602,https://zenodo.org/record/3082688/files/CAM016602_d.JPG,1,3791,plesseni x malleti,3791_CAM016602_d.JPG,mimic
+CAM016608,https://zenodo.org/record/3082688/files/CAM016608_d.JPG,1,3801,plesseni x malleti,3801_CAM016608_d.JPG,mimic
+CAM016404,https://zenodo.org/record/3082688/files/CAM016404_d.JPG,0,3519,plesseni,3519_CAM016404_d.JPG,mimic
+CAM016406,https://zenodo.org/record/3082688/files/CAM016406_d.JPG,1,3523,plesseni x malleti,3523_CAM016406_d.JPG,mimic
+CAM016407,https://zenodo.org/record/3082688/files/CAM016407_d.JPG,1,3525,plesseni x malleti,3525_CAM016407_d.JPG,mimic
+CAM016408,https://zenodo.org/record/3082688/files/CAM016408_d.JPG,1,3527,plesseni x malleti,3527_CAM016408_d.JPG,mimic
+CAM016409,https://zenodo.org/record/3082688/files/CAM016409_d.JPG,1,3529,plesseni x malleti,3529_CAM016409_d.JPG,mimic
+CAM016378,https://zenodo.org/record/3082688/files/CAM016378_d.JPG,0,3470,plesseni,3470_CAM016378_d.JPG,mimic
+CAM016393,https://zenodo.org/record/3082688/files/CAM016393_d.JPG,1,3499,plesseni x malleti,3499_CAM016393_d.JPG,mimic
+CAM016394,https://zenodo.org/record/3082688/files/CAM016394_d.JPG,1,3501,plesseni x malleti,3501_CAM016394_d.JPG,mimic
+CAM016500,https://zenodo.org/record/3082688/files/CAM016500_d.JPG,1,3633,plesseni x malleti,3633_CAM016500_d.JPG,mimic
+CAM016503,https://zenodo.org/record/3082688/files/CAM016503_d.JPG,1,3639,plesseni x malleti,3639_CAM016503_d.JPG,mimic
+CAM016504,https://zenodo.org/record/3082688/files/CAM016504_d.JPG,1,3641,plesseni x malleti,3641_CAM016504_d.JPG,mimic
+CAM016508,https://zenodo.org/record/3082688/files/CAM016508_d.JPG,1,3649,plesseni x malleti,3649_CAM016508_d.JPG,mimic
+CAM016509,https://zenodo.org/record/3082688/files/CAM016509_d.JPG,1,3651,plesseni x malleti,3651_CAM016509_d.JPG,mimic
+CAM016510,https://zenodo.org/record/3082688/files/CAM016510_d.JPG,1,3653,plesseni x malleti,3653_CAM016510_d.JPG,mimic
+CAM016511,https://zenodo.org/record/3082688/files/CAM016511_d.JPG,1,3655,plesseni x malleti,3655_CAM016511_d.JPG,mimic
+CAM016505,https://zenodo.org/record/3082688/files/CAM016505_d.JPG,1,3643,plesseni x malleti,3643_CAM016505_d.JPG,mimic
+CAM016422,https://zenodo.org/record/3082688/files/CAM016422_d.JPG,1,3555,plesseni x malleti,3555_CAM016422_d.JPG,mimic
+CAM016424,https://zenodo.org/record/3082688/files/CAM016424_d.JPG,1,3559,plesseni x malleti,3559_CAM016424_d.JPG,mimic
+CAM016428,https://zenodo.org/record/3082688/files/CAM016428_d.JPG,1,3567,plesseni x malleti,3567_CAM016428_d.JPG,mimic
+CAM016082,https://zenodo.org/record/3082688/files/CAM016082_d.JPG,0,3072,plesseni,3072_CAM016082_d.JPG,mimic
+CAM017668,https://zenodo.org/record/3082688/files/CAM017668_d.JPG,1,5414,malleti x plesseni,5414_CAM017668_d.JPG,mimic
+CAM017351,https://zenodo.org/record/3082688/files/CAM017351_d.JPG,1,4980,plesseni x malleti,4980_CAM017351_d.JPG,mimic
+CAM017345,https://zenodo.org/record/3082688/files/CAM017345_d.JPG,1,4968,plesseni x malleti,4968_CAM017345_d.JPG,mimic
+CAM017614,https://zenodo.org/record/3082688/files/CAM017614_d.JPG,0,5388,plesseni,5388_CAM017614_d.JPG,mimic
+CAM017612,https://zenodo.org/record/3082688/files/CAM017612_d.JPG,1,5386,plesseni x malleti,5386_CAM017612_d.JPG,mimic
+CAM017611,https://zenodo.org/record/3082688/files/CAM017611_d.JPG,1,5384,plesseni x malleti,5384_CAM017611_d.JPG,mimic
+CAM017609,https://zenodo.org/record/3082688/files/CAM017609_d.JPG,1,5380,notabilis x lativitta,5380_CAM017609_d.JPG,major
+CAM017608,https://zenodo.org/record/3082688/files/CAM017608_d.JPG,1,5378,notabilis x lativitta,5378_CAM017608_d.JPG,major
+CAM017607,https://zenodo.org/record/3082688/files/CAM017607_d.JPG,1,5376,notabilis x lativitta,5376_CAM017607_d.JPG,major
+CAM017606,https://zenodo.org/record/3082688/files/CAM017606_d.JPG,1,5374,notabilis x lativitta,5374_CAM017606_d.JPG,major
+CAM017605,https://zenodo.org/record/3082688/files/CAM017605_d.JPG,1,5372,plesseni x malleti,5372_CAM017605_d.JPG,mimic
+CAM017604,https://zenodo.org/record/3082688/files/CAM017604_d.JPG,1,5370,notabilis x lativitta,5370_CAM017604_d.JPG,major
+CAM017603,https://zenodo.org/record/3082688/files/CAM017603_d.JPG,1,5368,notabilis x lativitta,5368_CAM017603_d.JPG,major
+CAM017602,https://zenodo.org/record/3082688/files/CAM017602_d.JPG,1,5366,notabilis x lativitta,5366_CAM017602_d.JPG,major
+CAM017601,https://zenodo.org/record/3082688/files/CAM017601_d.JPG,1,5364,notabilis x lativitta,5364_CAM017601_d.JPG,major
+CAM016009,https://zenodo.org/record/3082688/files/CAM016009_d.JPG,0,2927,plesseni,2927_CAM016009_d.JPG,mimic
+CAM016012,https://zenodo.org/record/3082688/files/CAM016012_d.JPG,1,2933,plesseni x malleti,2933_CAM016012_d.JPG,mimic
+CAM016019,https://zenodo.org/record/3082688/files/CAM016019_d.JPG,1,2947,notabilis x lativitta,2947_CAM016019_d.JPG,major
+CAM017658,https://zenodo.org/record/3082688/files/CAM017658_d.JPG,1,5396,malleti x plesseni,5396_CAM017658_d.JPG,mimic
+CAM016016,https://zenodo.org/record/3082688/files/CAM016016_d.JPG,1,2941,notabilis x lativitta,2941_CAM016016_d.JPG,major
+CAM016015,https://zenodo.org/record/3082688/files/CAM016015_d.JPG,1,2939,plesseni x malleti,2939_CAM016015_d.JPG,mimic
+CAM016017,https://zenodo.org/record/3082688/files/CAM016017_d.JPG,1,2943,notabilis x lativitta,2943_CAM016017_d.JPG,major
+CAM017340,https://zenodo.org/record/3082688/files/CAM017340_d.JPG,1,4958,notabilis x lativitta,4958_CAM017340_d.JPG,major
+CAM017339,https://zenodo.org/record/3082688/files/CAM017339_d.JPG,1,4956,notabilis x lativitta,4956_CAM017339_d.JPG,major
+CAM017298,https://zenodo.org/record/3082688/files/CAM017298_d.JPG,1,4888,notabilis x lativitta,4888_CAM017298_d.JPG,major
+CAM017300,https://zenodo.org/record/3082688/files/CAM017300_d.JPG,1,4890,notabilis x lativitta,4890_CAM017300_d.JPG,major
+CAM017301,https://zenodo.org/record/3082688/files/CAM017301_d.JPG,1,4892,notabilis x lativitta,4892_CAM017301_d.JPG,major
+CAM017302,https://zenodo.org/record/3082688/files/CAM017302_d.JPG,1,4894,notabilis x lativitta,4894_CAM017302_d.JPG,major
+CAM017303,https://zenodo.org/record/3082688/files/CAM017303_d.JPG,1,4896,notabilis x lativitta,4896_CAM017303_d.JPG,major
+CAM017306,https://zenodo.org/record/3082688/files/CAM017306_d.JPG,1,4898,notabilis x lativitta,4898_CAM017306_d.JPG,major
+CAM017307,https://zenodo.org/record/3082688/files/CAM017307_d.JPG,1,4900,notabilis x lativitta,4900_CAM017307_d.JPG,major
+CAM017308,https://zenodo.org/record/3082688/files/CAM017308_d.JPG,1,4902,notabilis x lativitta,4902_CAM017308_d.JPG,major
+CAM017297,https://zenodo.org/record/3082688/files/CAM017297_d.JPG,1,4886,notabilis x lativitta,4886_CAM017297_d.JPG,major
+CAM017296,https://zenodo.org/record/3082688/files/CAM017296_d.JPG,1,4884,notabilis x lativitta,4884_CAM017296_d.JPG,major
+CAM017287,https://zenodo.org/record/3082688/files/CAM017287_d.JPG,1,4882,notabilis x lativitta,4882_CAM017287_d.JPG,major
+CAM017274,https://zenodo.org/record/3082688/files/CAM017274_d.JPG,1,4860,notabilis x lativitta,4860_CAM017274_d.JPG,major
+CAM017275,https://zenodo.org/record/3082688/files/CAM017275_d.JPG,1,4862,notabilis x lativitta,4862_CAM017275_d.JPG,major
+CAM017276,https://zenodo.org/record/3082688/files/CAM017276_d.JPG,1,4864,notabilis x lativitta,4864_CAM017276_d.JPG,major
+CAM017309,https://zenodo.org/record/3082688/files/CAM017309_d.JPG,1,4904,notabilis x lativitta,4904_CAM017309_d.JPG,major
+CAM017277,https://zenodo.org/record/3082688/files/CAM017277_d.JPG,1,4866,notabilis x lativitta,4866_CAM017277_d.JPG,major
+CAM017280,https://zenodo.org/record/3082688/files/CAM017280_d.JPG,1,4872,notabilis x lativitta,4872_CAM017280_d.JPG,major
+CAM017732,https://zenodo.org/record/3082688/files/CAM017732_d.JPG,1,5494,plesseni x malleti,5494_CAM017732_d.JPG,mimic
+CAM017281,https://zenodo.org/record/3082688/files/CAM017281_d.JPG,1,4874,notabilis x lativitta,4874_CAM017281_d.JPG,major
+CAM017282,https://zenodo.org/record/3082688/files/CAM017282_d.JPG,1,4876,plesseni x malleti,4876_CAM017282_d.JPG,mimic
+CAM017050,https://zenodo.org/record/3082688/files/CAM017050_d.JPG,1,4449,notabilis x lativitta,4449_CAM017050_d.JPG,major
+CAM016028,https://zenodo.org/record/3082688/files/CAM016028_d.JPG,1,2965,notabilis x lativitta,2965_CAM016028_d.JPG,major
+CAM017328,https://zenodo.org/record/3082688/files/CAM017328_d.JPG,1,4934,notabilis x lativitta,4934_CAM017328_d.JPG,major
+CAM017329,https://zenodo.org/record/3082688/files/CAM017329_d.JPG,1,4936,plesseni x malleti,4936_CAM017329_d.JPG,mimic
+CAM017330,https://zenodo.org/record/3082688/files/CAM017330_d.JPG,1,4938,notabilis x lativitta,4938_CAM017330_d.JPG,major
+CAM017331,https://zenodo.org/record/3082688/files/CAM017331_d.JPG,1,4940,notabilis x lativitta,4940_CAM017331_d.JPG,major
+CAM017332,https://zenodo.org/record/3082688/files/CAM017332_d.JPG,1,4942,notabilis x lativitta,4942_CAM017332_d.JPG,major
+CAM017333,https://zenodo.org/record/3082688/files/CAM017333_d.JPG,1,4944,notabilis x lativitta,4944_CAM017333_d.JPG,major
+CAM017334,https://zenodo.org/record/3082688/files/CAM017334_d.JPG,1,4946,notabilis x lativitta,4946_CAM017334_d.JPG,major
+CAM017692,https://zenodo.org/record/3082688/files/CAM017692_d.JPG,1,5448,malleti x plesseni,5448_CAM017692_d.JPG,mimic
+CAM017335,https://zenodo.org/record/3082688/files/CAM017335_d.JPG,1,4948,plesseni x malleti,4948_CAM017335_d.JPG,mimic
+CAM017336,https://zenodo.org/record/3082688/files/CAM017336_d.JPG,1,4950,plesseni x malleti,4950_CAM017336_d.JPG,mimic
+CAM017337,https://zenodo.org/record/3082688/files/CAM017337_d.JPG,1,4952,notabilis x lativitta,4952_CAM017337_d.JPG,major
+CAM017338,https://zenodo.org/record/3082688/files/CAM017338_d.JPG,1,4954,notabilis x lativitta,4954_CAM017338_d.JPG,major
+CAM016029,https://zenodo.org/record/3082688/files/CAM016029_d.JPG,1,2967,notabilis x lativitta,2967_CAM016029_d.JPG,major
+CAM017311,https://zenodo.org/record/3082688/files/CAM017311_d.JPG,1,4908,notabilis x lativitta,4908_CAM017311_d.JPG,major
+CAM017312,https://zenodo.org/record/3082688/files/CAM017312_d.JPG,1,4910,notabilis x lativitta,4910_CAM017312_d.JPG,major
+CAM017713,https://zenodo.org/record/3082688/files/CAM017713_d.JPG,1,5466,lativitta x notabilis,5466_CAM017713_d.JPG,major
+CAM016030,https://zenodo.org/record/3082688/files/CAM016030_d.JPG,1,2969,notabilis x lativitta,2969_CAM016030_d.JPG,major
+CAM017314,https://zenodo.org/record/3082688/files/CAM017314_d.JPG,1,4912,notabilis x lativitta,4912_CAM017314_d.JPG,major
+CAM017315,https://zenodo.org/record/3082688/files/CAM017315_d.JPG,1,4914,notabilis x lativitta,4914_CAM017315_d.JPG,major
+CAM017316,https://zenodo.org/record/3082688/files/CAM017316_d.JPG,1,4916,notabilis x lativitta,4916_CAM017316_d.JPG,major
+CAM017310,https://zenodo.org/record/3082688/files/CAM017310_d.JPG,1,4906,notabilis x lativitta,4906_CAM017310_d.JPG,major
+CAM017317,https://zenodo.org/record/3082688/files/CAM017317_d.JPG,1,4918,notabilis x lativitta,4918_CAM017317_d.JPG,major
+CAM017318,https://zenodo.org/record/3082688/files/CAM017318_d.JPG,1,4920,notabilis x lativitta,4920_CAM017318_d.JPG,major
+CAM017319,https://zenodo.org/record/3082688/files/CAM017319_d.JPG,1,4922,notabilis x lativitta,4922_CAM017319_d.JPG,major
+CAM017703,https://zenodo.org/record/3082688/files/CAM017703_d.JPG,1,5458,lativitta x notabilis,5458_CAM017703_d.JPG,major
+CAM017456,https://zenodo.org/record/3082688/files/CAM017456_d.JPG,1,5140,malleti x plesseni,5140_CAM017456_d.JPG,mimic
+CAM017459,https://zenodo.org/record/3082688/files/CAM017459_d.JPG,1,5142,malleti x plesseni,5142_CAM017459_d.JPG,mimic
+CAM017440,https://zenodo.org/record/3082688/files/CAM017440_d.JPG,1,5115,plesseni x malleti,5115_CAM017440_d.JPG,mimic
+CAM017441,https://zenodo.org/record/3082688/files/CAM017441_d.JPG,1,5117,notabilis x lativitta,5117_CAM017441_d.JPG,major
+CAM017442,https://zenodo.org/record/3082688/files/CAM017442_d.JPG,1,5119,notabilis x lativitta,5119_CAM017442_d.JPG,major
+CAM017443,https://zenodo.org/record/3082688/files/CAM017443_d.JPG,1,5121,notabilis x lativitta,5121_CAM017443_d.JPG,major
+CAM017444,https://zenodo.org/record/3082688/files/CAM017444_d.JPG,1,5122,notabilis x lativitta,5122_CAM017444_d.JPG,major
+CAM017445,https://zenodo.org/record/3082688/files/CAM017445_d.JPG,1,5124,notabilis x lativitta,5124_CAM017445_d.JPG,major
+CAM017446,https://zenodo.org/record/3082688/files/CAM017446_d.JPG,1,5126,notabilis x lativitta,5126_CAM017446_d.JPG,major
+CAM017447,https://zenodo.org/record/3082688/files/CAM017447_d.JPG,1,5128,notabilis x lativitta,5128_CAM017447_d.JPG,major
+CAM017450,https://zenodo.org/record/3082688/files/CAM017450_d.JPG,1,5132,malleti x plesseni,5132_CAM017450_d.JPG,mimic
+CAM017451,https://zenodo.org/record/3082688/files/CAM017451_d.JPG,1,5134,malleti x plesseni,5134_CAM017451_d.JPG,mimic
+CAM017452,https://zenodo.org/record/3082688/files/CAM017452_d.JPG,1,5136,malleti x plesseni,5136_CAM017452_d.JPG,mimic
+CAM017454,https://zenodo.org/record/3082688/files/CAM017454_d.JPG,1,5138,plesseni x malleti,5138_CAM017454_d.JPG,mimic
+CAM017508,https://zenodo.org/record/3082688/files/CAM017508_d.JPG,1,5218,plesseni x malleti,5218_CAM017508_d.JPG,mimic
+CAM017507,https://zenodo.org/record/3082688/files/CAM017507_d.JPG,1,5216,malleti x plesseni,5216_CAM017507_d.JPG,mimic
+CAM017439,https://zenodo.org/record/3082688/files/CAM017439_d.JPG,1,5113,notabilis x lativitta,5113_CAM017439_d.JPG,major
+CAM017438,https://zenodo.org/record/3082688/files/CAM017438_d.JPG,1,5111,notabilis x lativitta,5111_CAM017438_d.JPG,major
+CAM017398,https://zenodo.org/record/3082688/files/CAM017398_d.JPG,1,5039,notabilis x lativitta,5039_CAM017398_d.JPG,major
+CAM017578,https://zenodo.org/record/3082688/files/CAM017578_d.JPG,1,5330,plesseni x malleti,5330_CAM017578_d.JPG,mimic
+CAM017407,https://zenodo.org/record/3082688/files/CAM017407_d.JPG,1,5055,notabilis x lativitta,5055_CAM017407_d.JPG,major
+CAM017408,https://zenodo.org/record/3082688/files/CAM017408_d.JPG,1,5057,notabilis x lativitta,5057_CAM017408_d.JPG,major
+CAM017574,https://zenodo.org/record/3082688/files/CAM017574_d.JPG,1,5322,malleti x plesseni,5322_CAM017574_d.JPG,mimic
+CAM017384,https://zenodo.org/record/3082688/files/CAM017384_d.JPG,1,5018,plesseni x malleti,5018_CAM017384_d.JPG,mimic
+CAM017393,https://zenodo.org/record/3082688/files/CAM017393_d.JPG,1,5035,notabilis x lativitta,5035_CAM017393_d.JPG,major
+CAM017410,https://zenodo.org/record/3082688/files/CAM017410_d.JPG,1,5059,notabilis x lativitta,5059_CAM017410_d.JPG,major
+CAM017426,https://zenodo.org/record/3082688/files/CAM017426_d.JPG,1,5089,notabilis x lativitta,5089_CAM017426_d.JPG,major
+CAM017427,https://zenodo.org/record/3082688/files/CAM017427_d.JPG,1,5091,notabilis x lativitta,5091_CAM017427_d.JPG,major
+CAM017429,https://zenodo.org/record/3082688/files/CAM017429_d.JPG,1,5095,notabilis x lativitta,5095_CAM017429_d.JPG,major
+CAM017431,https://zenodo.org/record/3082688/files/CAM017431_d.JPG,1,5099,plesseni x malleti,5099_CAM017431_d.JPG,mimic
+CAM017432,https://zenodo.org/record/3082688/files/CAM017432_d.JPG,1,5101,notabilis x lativitta,5101_CAM017432_d.JPG,major
+CAM017552,https://zenodo.org/record/3082688/files/CAM017552_d.JPG,1,5294,malleti x plesseni,5294_CAM017552_d.JPG,mimic
+CAM017433,https://zenodo.org/record/3082688/files/CAM017433_d.JPG,1,5103,notabilis x lativitta,5103_CAM017433_d.JPG,major
+CAM017551,https://zenodo.org/record/3082688/files/CAM017551_d.JPG,1,5292,malleti x plesseni,5292_CAM017551_d.JPG,mimic
+CAM017435,https://zenodo.org/record/3082688/files/CAM017435_d.JPG,1,5105,notabilis x lativitta,5105_CAM017435_d.JPG,major
+CAM017550,https://zenodo.org/record/3082688/files/CAM017550_d.JPG,1,5290,malleti x plesseni,5290_CAM017550_d.JPG,mimic
+CAM017436,https://zenodo.org/record/3082688/files/CAM017436_d.JPG,1,5107,notabilis x lativitta,5107_CAM017436_d.JPG,major
+CAM017549,https://zenodo.org/record/3082688/files/CAM017549_d.JPG,1,5288,malleti x plesseni,5288_CAM017549_d.JPG,mimic
+CAM017437,https://zenodo.org/record/3082688/files/CAM017437_d.JPG,1,5109,plesseni x malleti,5109_CAM017437_d.JPG,mimic
+CAM017425,https://zenodo.org/record/3082688/files/CAM017425_d.JPG,1,5087,notabilis x lativitta,5087_CAM017425_d.JPG,major
+CAM017424,https://zenodo.org/record/3082688/files/CAM017424_d.JPG,1,5085,notabilis x lativitta,5085_CAM017424_d.JPG,major
+CAM017417,https://zenodo.org/record/3082688/files/CAM017417_d.JPG,1,5071,plesseni x malleti,5071_CAM017417_d.JPG,mimic
+CAM017564,https://zenodo.org/record/3082688/files/CAM017564_d.JPG,1,5308,malleti x plesseni,5308_CAM017564_d.JPG,mimic
+CAM017419,https://zenodo.org/record/3082688/files/CAM017419_d.JPG,1,5075,notabilis x lativitta,5075_CAM017419_d.JPG,major
+CAM017420,https://zenodo.org/record/3082688/files/CAM017420_d.JPG,1,5077,notabilis x lativitta,5077_CAM017420_d.JPG,major
+CAM017421,https://zenodo.org/record/3082688/files/CAM017421_d.JPG,1,5079,notabilis x lativitta,5079_CAM017421_d.JPG,major
+CAM017422,https://zenodo.org/record/3082688/files/CAM017422_d.JPG,1,5081,notabilis x lativitta,5081_CAM017422_d.JPG,major
+CAM017423,https://zenodo.org/record/3082688/files/CAM017423_d.JPG,1,5083,plesseni x malleti,5083_CAM017423_d.JPG,mimic
+CAM017418,https://zenodo.org/record/3082688/files/CAM017418_d.JPG,1,5073,notabilis x lativitta,5073_CAM017418_d.JPG,major
+CAM017125,https://zenodo.org/record/3082688/files/CAM017125_d.JPG,1,4579,plesseni x malleti,4579_CAM017125_d.JPG,mimic
+CAM017127,https://zenodo.org/record/3082688/files/CAM017127_d.JPG,1,4583,notabilis x lativitta,4583_CAM017127_d.JPG,major
+CAM017128,https://zenodo.org/record/3082688/files/CAM017128_d.JPG,1,4585,plesseni x malleti,4585_CAM017128_d.JPG,mimic
+CAM017129,https://zenodo.org/record/3082688/files/CAM017129_d.JPG,1,4587,notabilis x lativitta,4587_CAM017129_d.JPG,major
+CAM017130,https://zenodo.org/record/3082688/files/CAM017130_d.JPG,1,4589,notabilis x lativitta,4589_CAM017130_d.JPG,major
+CAM017131,https://zenodo.org/record/3082688/files/CAM017131_d.JPG,1,4591,plesseni x malleti,4591_CAM017131_d.JPG,mimic
+CAM017132,https://zenodo.org/record/3082688/files/CAM017132_d.JPG,1,4593,notabilis x lativitta,4593_CAM017132_d.JPG,major
+CAM017133,https://zenodo.org/record/3082688/files/CAM017133_d.JPG,1,4595,notabilis x lativitta,4595_CAM017133_d.JPG,major
+CAM017123,https://zenodo.org/record/3082688/files/CAM017123_d.JPG,1,4575,plesseni x malleti,4575_CAM017123_d.JPG,mimic
+CAM017114,https://zenodo.org/record/3082688/files/CAM017114_d.JPG,1,4557,notabilis x lativitta,4557_CAM017114_d.JPG,major
+CAM017116,https://zenodo.org/record/3082688/files/CAM017116_d.JPG,1,4561,notabilis x lativitta,4561_CAM017116_d.JPG,major
+CAM017118,https://zenodo.org/record/3082688/files/CAM017118_d.JPG,1,4565,notabilis x lativitta,4565_CAM017118_d.JPG,major
+CAM017119,https://zenodo.org/record/3082688/files/CAM017119_d.JPG,1,4567,notabilis x lativitta,4567_CAM017119_d.JPG,major
+CAM017122,https://zenodo.org/record/3082688/files/CAM017122_d.JPG,1,4573,notabilis x lativitta,4573_CAM017122_d.JPG,major
+CAM017150,https://zenodo.org/record/3082688/files/CAM017150_d.JPG,1,4625,notabilis x lativitta,4625_CAM017150_d.JPG,major
+CAM017151,https://zenodo.org/record/3082688/files/CAM017151_d.JPG,1,4627,notabilis x lativitta,4627_CAM017151_d.JPG,major
+CAM017152,https://zenodo.org/record/3082688/files/CAM017152_d.JPG,1,4629,plesseni x malleti,4629_CAM017152_d.JPG,mimic
+CAM017153,https://zenodo.org/record/3082688/files/CAM017153_d.JPG,1,4631,plesseni x malleti,4631_CAM017153_d.JPG,mimic
+CAM017270,https://zenodo.org/record/3082688/files/CAM017270_d.JPG,1,4852,notabilis x lativitta,4852_CAM017270_d.JPG,major
+CAM017155,https://zenodo.org/record/3082688/files/CAM017155_d.JPG,1,4635,plesseni x malleti,4635_CAM017155_d.JPG,mimic
+CAM017157,https://zenodo.org/record/3082688/files/CAM017157_d.JPG,1,4639,notabilis x lativitta,4639_CAM017157_d.JPG,major
+CAM017158,https://zenodo.org/record/3082688/files/CAM017158_d.JPG,1,4641,notabilis x lativitta,4641_CAM017158_d.JPG,major
+CAM017159,https://zenodo.org/record/3082688/files/CAM017159_d.JPG,1,4643,notabilis x lativitta,4643_CAM017159_d.JPG,major
+CAM017149,https://zenodo.org/record/3082688/files/CAM017149_d.JPG,1,4623,notabilis x lativitta,4623_CAM017149_d.JPG,major
+CAM017148,https://zenodo.org/record/3082688/files/CAM017148_d.JPG,1,4621,notabilis x lativitta,4621_CAM017148_d.JPG,major
+CAM017141,https://zenodo.org/record/3082688/files/CAM017141_d.JPG,1,4607,notabilis x lativitta,4607_CAM017141_d.JPG,major
+CAM017142,https://zenodo.org/record/3082688/files/CAM017142_d.JPG,1,4609,notabilis x lativitta,4609_CAM017142_d.JPG,major
+CAM017144,https://zenodo.org/record/3082688/files/CAM017144_d.JPG,1,4613,notabilis x lativitta,4613_CAM017144_d.JPG,major
+CAM017145,https://zenodo.org/record/3082688/files/CAM017145_d.JPG,1,4615,notabilis x lativitta,4615_CAM017145_d.JPG,major
+CAM017146,https://zenodo.org/record/3082688/files/CAM017146_d.JPG,1,4617,notabilis x lativitta,4617_CAM017146_d.JPG,major
+CAM017867,https://zenodo.org/record/3082688/files/CAM017867_d.JPG,1,5661,malleti x plesseni,5661_CAM017867_d.JPG,mimic
+CAM017147,https://zenodo.org/record/3082688/files/CAM017147_d.JPG,1,4619,notabilis x lativitta,4619_CAM017147_d.JPG,major
+CAM017143,https://zenodo.org/record/3082688/files/CAM017143_d.JPG,1,4611,notabilis x lativitta,4611_CAM017143_d.JPG,major
+CAM017066,https://zenodo.org/record/3082688/files/CAM017066_d.JPG,1,4481,plesseni x malleti,4481_CAM017066_d.JPG,mimic
+CAM017067,https://zenodo.org/record/3082688/files/CAM017067_d.JPG,1,4483,plesseni x malleti,4483_CAM017067_d.JPG,mimic
+CAM017068,https://zenodo.org/record/3082688/files/CAM017068_d.JPG,1,4485,plesseni x malleti,4485_CAM017068_d.JPG,mimic
+CAM017072,https://zenodo.org/record/3082688/files/CAM017072_d.JPG,1,4493,plesseni x malleti,4493_CAM017072_d.JPG,mimic
+CAM017074,https://zenodo.org/record/3082688/files/CAM017074_d.JPG,1,4497,notabilis x lativitta,4497_CAM017074_d.JPG,major
+CAM017065,https://zenodo.org/record/3082688/files/CAM017065_d.JPG,1,4479,notabilis x lativitta,4479_CAM017065_d.JPG,major
+CAM017063,https://zenodo.org/record/3082688/files/CAM017063_d.JPG,1,4475,notabilis x lativitta,4475_CAM017063_d.JPG,major
+CAM017052,https://zenodo.org/record/3082688/files/CAM017052_d.JPG,1,4453,notabilis x lativitta,4453_CAM017052_d.JPG,major
+CAM017053,https://zenodo.org/record/3082688/files/CAM017053_d.JPG,1,4455,plesseni x malleti,4455_CAM017053_d.JPG,mimic
+CAM017054,https://zenodo.org/record/3082688/files/CAM017054_d.JPG,1,4457,notabilis x lativitta,4457_CAM017054_d.JPG,major
+CAM017055,https://zenodo.org/record/3082688/files/CAM017055_d.JPG,1,4459,notabilis x lativitta,4459_CAM017055_d.JPG,major
+CAM017056,https://zenodo.org/record/3082688/files/CAM017056_d.JPG,1,4461,notabilis x lativitta,4461_CAM017056_d.JPG,major
+CAM017057,https://zenodo.org/record/3082688/files/CAM017057_d.JPG,1,4463,notabilis x lativitta,4463_CAM017057_d.JPG,major
+CAM017059,https://zenodo.org/record/3082688/files/CAM017059_d.JPG,1,4467,notabilis x lativitta,4467_CAM017059_d.JPG,major
+CAM017062,https://zenodo.org/record/3082688/files/CAM017062_d.JPG,1,4473,notabilis x lativitta,4473_CAM017062_d.JPG,major
+CAM017058,https://zenodo.org/record/3082688/files/CAM017058_d.JPG,1,4465,notabilis x lativitta,4465_CAM017058_d.JPG,major
+CAM017094,https://zenodo.org/record/3082688/files/CAM017094_d.JPG,1,4529,plesseni x malleti,4529_CAM017094_d.JPG,mimic
+CAM017095,https://zenodo.org/record/3082688/files/CAM017095_d.JPG,1,4531,plesseni x malleti,4531_CAM017095_d.JPG,mimic
+CAM017096,https://zenodo.org/record/3082688/files/CAM017096_d.JPG,1,4533,plesseni x malleti,4533_CAM017096_d.JPG,mimic
+CAM017102,https://zenodo.org/record/3082688/files/CAM017102_d.JPG,1,4541,plesseni x malleti,4541_CAM017102_d.JPG,mimic
+CAM017109,https://zenodo.org/record/3082688/files/CAM017109_d.JPG,1,4547,notabilis x lativitta,4547_CAM017109_d.JPG,major
+CAM017110,https://zenodo.org/record/3082688/files/CAM017110_d.JPG,1,4549,notabilis x lativitta,4549_CAM017110_d.JPG,major
+CAM017080,https://zenodo.org/record/3082688/files/CAM017080_d.JPG,1,4501,plesseni x malleti,4501_CAM017080_d.JPG,mimic
+CAM017084,https://zenodo.org/record/3082688/files/CAM017084_d.JPG,1,4509,plesseni x malleti,4509_CAM017084_d.JPG,mimic
+CAM017085,https://zenodo.org/record/3082688/files/CAM017085_d.JPG,1,4511,notabilis x lativitta,4511_CAM017085_d.JPG,major
+CAM017087,https://zenodo.org/record/3082688/files/CAM017087_d.JPG,1,4515,notabilis x lativitta,4515_CAM017087_d.JPG,major
+CAM017088,https://zenodo.org/record/3082688/files/CAM017088_d.JPG,1,4517,notabilis x lativitta,4517_CAM017088_d.JPG,major
+CAM017090,https://zenodo.org/record/3082688/files/CAM017090_d.JPG,1,4521,plesseni x malleti,4521_CAM017090_d.JPG,mimic
+CAM017160,https://zenodo.org/record/3082688/files/CAM017160_d.JPG,1,4645,notabilis x lativitta,4645_CAM017160_d.JPG,major
+CAM017230,https://zenodo.org/record/3082688/files/CAM017230_d.JPG,1,4777,notabilis x lativitta,4777_CAM017230_d.JPG,major
+CAM017231,https://zenodo.org/record/3082688/files/CAM017231_d.JPG,1,4779,plesseni x malleti,4779_CAM017231_d.JPG,mimic
+CAM017232,https://zenodo.org/record/3082688/files/CAM017232_d.JPG,1,4781,plesseni x malleti,4781_CAM017232_d.JPG,mimic
+CAM017233,https://zenodo.org/record/3082688/files/CAM017233_d.JPG,1,4783,plesseni x malleti,4783_CAM017233_d.JPG,mimic
+CAM017234,https://zenodo.org/record/3082688/files/CAM017234_d.JPG,1,4785,notabilis x lativitta,4785_CAM017234_d.JPG,major
+CAM017778,https://zenodo.org/record/3082688/files/CAM017778_d.JPG,1,5544,plesseni x malleti,5544_CAM017778_d.JPG,mimic
+CAM017776,https://zenodo.org/record/3082688/files/CAM017776_d.JPG,1,5540,malleti x plesseni,5540_CAM017776_d.JPG,mimic
+CAM017235,https://zenodo.org/record/3082688/files/CAM017235_d.JPG,1,4787,notabilis x lativitta,4787_CAM017235_d.JPG,major
+CAM017773,https://zenodo.org/record/3082688/files/CAM017773_d.JPG,1,5534,lativitta x notabilis,5534_CAM017773_d.JPG,major
+CAM017229,https://zenodo.org/record/3082688/files/CAM017229_d.JPG,1,4775,notabilis x lativitta,4775_CAM017229_d.JPG,major
+CAM017218,https://zenodo.org/record/3082688/files/CAM017218_d.JPG,1,4753,notabilis x lativitta,4753_CAM017218_d.JPG,major
+CAM017161,https://zenodo.org/record/3082688/files/CAM017161_d.JPG,1,4647,notabilis x lativitta,4647_CAM017161_d.JPG,major
+CAM017224,https://zenodo.org/record/3082688/files/CAM017224_d.JPG,1,4765,notabilis x lativitta,4765_CAM017224_d.JPG,major
+CAM017225,https://zenodo.org/record/3082688/files/CAM017225_d.JPG,1,4767,notabilis x lativitta,4767_CAM017225_d.JPG,major
+CAM017226,https://zenodo.org/record/3082688/files/CAM017226_d.JPG,1,4769,notabilis x lativitta,4769_CAM017226_d.JPG,major
+CAM017222,https://zenodo.org/record/3082688/files/CAM017222_d.JPG,1,4761,notabilis x lativitta,4761_CAM017222_d.JPG,major
+CAM017215,https://zenodo.org/record/3082688/files/CAM017215_d.JPG,1,4747,notabilis x lativitta,4747_CAM017215_d.JPG,major
+CAM017257,https://zenodo.org/record/3082688/files/CAM017257_d.JPG,1,4828,plesseni x malleti,4828_CAM017257_d.JPG,mimic
+CAM016031,https://zenodo.org/record/3082688/files/CAM016031_d.JPG,1,2971,notabilis x lativitta,2971_CAM016031_d.JPG,major
+CAM017754,https://zenodo.org/record/3082688/files/CAM017754_d.JPG,1,5514,lativitta x notabilis,5514_CAM017754_d.JPG,major
+CAM017753,https://zenodo.org/record/3082688/files/CAM017753_d.JPG,1,5512,plesseni x malleti,5512_CAM017753_d.JPG,mimic
+CAM017752,https://zenodo.org/record/3082688/files/CAM017752_d.JPG,1,5510,plesseni x malleti,5510_CAM017752_d.JPG,mimic
+CAM016032,https://zenodo.org/record/3082688/files/CAM016032_d.JPG,1,2973,notabilis x lativitta,2973_CAM016032_d.JPG,major
+CAM017264,https://zenodo.org/record/3082688/files/CAM017264_d.JPG,1,4840,plesseni x malleti,4840_CAM017264_d.JPG,mimic
+CAM017748,https://zenodo.org/record/3082688/files/CAM017748_d.JPG,1,5506,lativitta x notabilis,5506_CAM017748_d.JPG,major
+CAM017265,https://zenodo.org/record/3082688/files/CAM017265_d.JPG,1,4842,notabilis x lativitta,4842_CAM017265_d.JPG,major
+CAM017266,https://zenodo.org/record/3082688/files/CAM017266_d.JPG,1,4844,notabilis x lativitta,4844_CAM017266_d.JPG,major
+CAM017747,https://zenodo.org/record/3082688/files/CAM017747_d.JPG,1,5504,malleti x plesseni,5504_CAM017747_d.JPG,mimic
+CAM017267,https://zenodo.org/record/3082688/files/CAM017267_d.JPG,1,4846,plesseni x malleti,4846_CAM017267_d.JPG,mimic
+CAM017758,https://zenodo.org/record/3082688/files/CAM017758_d.JPG,1,5516,plesseni x malleti,5516_CAM017758_d.JPG,mimic
+CAM017760,https://zenodo.org/record/3082688/files/CAM017760_d.JPG,1,5520,plesseni x malleti,5520_CAM017760_d.JPG,mimic
+CAM017759,https://zenodo.org/record/3082688/files/CAM017759_d.JPG,1,5518,lativitta x notabilis,5518_CAM017759_d.JPG,major
+CAM017220,https://zenodo.org/record/3082688/files/CAM017220_d.JPG,1,4757,notabilis x lativitta,4757_CAM017220_d.JPG,major
+CAM017835,https://zenodo.org/record/3082688/files/CAM017835_d.JPG,1,5615,plesseni x malleti,5615_CAM017835_d.JPG,mimic
+CAM017179,https://zenodo.org/record/3082688/files/CAM017179_d.JPG,0,4678,notabilis,4678_CAM017179_d.JPG,major
+CAM017175,https://zenodo.org/record/3082688/files/CAM017175_d.JPG,0,4670,notabilis,4670_CAM017175_d.JPG,major
+CAM017213,https://zenodo.org/record/3082688/files/CAM017213_d.JPG,0,4743,notabilis,4743_CAM017213_d.JPG,major
+CAM017181,https://zenodo.org/record/3082688/files/CAM017181_d.JPG,0,4682,notabilis,4682_CAM017181_d.JPG,major
+CAM017182,https://zenodo.org/record/3082688/files/CAM017182_d.JPG,0,4684,notabilis,4684_CAM017182_d.JPG,major
+CAM017183,https://zenodo.org/record/3082688/files/CAM017183_d.JPG,0,4686,notabilis,4686_CAM017183_d.JPG,major
+CAM017180,https://zenodo.org/record/3082688/files/CAM017180_d.JPG,0,4680,notabilis,4680_CAM017180_d.JPG,major
+CAM017174,https://zenodo.org/record/3082688/files/CAM017174_d.JPG,0,4669,notabilis,4669_CAM017174_d.JPG,major
+CAM017163,https://zenodo.org/record/3082688/files/CAM017163_d.JPG,1,4649,notabilis x lativitta,4649_CAM017163_d.JPG,major
+CAM017165,https://zenodo.org/record/3082688/files/CAM017165_d.JPG,1,4651,notabilis x lativitta,4651_CAM017165_d.JPG,major
+CAM017172,https://zenodo.org/record/3082688/files/CAM017172_d.JPG,0,4665,notabilis,4665_CAM017172_d.JPG,major
+CAM017173,https://zenodo.org/record/3082688/files/CAM017173_d.JPG,0,4667,notabilis,4667_CAM017173_d.JPG,major
+CAM017826,https://zenodo.org/record/3082688/files/CAM017826_d.JPG,1,5599,lativitta x notabilis,5599_CAM017826_d.JPG,major
+CAM017184,https://zenodo.org/record/3082688/files/CAM017184_d.JPG,1,4688,plesseni x malleti,4688_CAM017184_d.JPG,mimic
+CAM017185,https://zenodo.org/record/3082688/files/CAM017185_d.JPG,0,4690,plesseni,4690_CAM017185_d.JPG,mimic
+CAM017198,https://zenodo.org/record/3082688/files/CAM017198_d.JPG,0,4715,notabilis,4715_CAM017198_d.JPG,major
+CAM017199,https://zenodo.org/record/3082688/files/CAM017199_d.JPG,0,4717,notabilis,4717_CAM017199_d.JPG,major
+CAM017200,https://zenodo.org/record/3082688/files/CAM017200_d.JPG,0,4719,notabilis,4719_CAM017200_d.JPG,major
+CAM017201,https://zenodo.org/record/3082688/files/CAM017201_d.JPG,1,4721,notabilis x lativitta,4721_CAM017201_d.JPG,major
+CAM017202,https://zenodo.org/record/3082688/files/CAM017202_d.JPG,0,4723,notabilis,4723_CAM017202_d.JPG,major
+CAM017196,https://zenodo.org/record/3082688/files/CAM017196_d.JPG,0,4711,notabilis,4711_CAM017196_d.JPG,major
+CAM017203,https://zenodo.org/record/3082688/files/CAM017203_d.JPG,0,4725,notabilis,4725_CAM017203_d.JPG,major
+CAM017206,https://zenodo.org/record/3082688/files/CAM017206_d.JPG,1,4729,notabilis x lativitta,4729_CAM017206_d.JPG,major
+CAM017207,https://zenodo.org/record/3082688/files/CAM017207_d.JPG,0,4731,notabilis,4731_CAM017207_d.JPG,major
+CAM017208,https://zenodo.org/record/3082688/files/CAM017208_d.JPG,1,4733,plesseni x malleti,4733_CAM017208_d.JPG,mimic
+CAM017209,https://zenodo.org/record/3082688/files/CAM017209_d.JPG,1,4735,plesseni x malleti,4735_CAM017209_d.JPG,mimic
+CAM017211,https://zenodo.org/record/3082688/files/CAM017211_d.JPG,0,4739,notabilis,4739_CAM017211_d.JPG,major
+CAM017204,https://zenodo.org/record/3082688/files/CAM017204_d.JPG,0,4727,notabilis,4727_CAM017204_d.JPG,major
+CAM017197,https://zenodo.org/record/3082688/files/CAM017197_d.JPG,0,4713,notabilis,4713_CAM017197_d.JPG,major
+CAM017195,https://zenodo.org/record/3082688/files/CAM017195_d.JPG,0,4710,notabilis,4710_CAM017195_d.JPG,major
+CAM017186,https://zenodo.org/record/3082688/files/CAM017186_d.JPG,0,4692,plesseni,4692_CAM017186_d.JPG,mimic
+CAM017187,https://zenodo.org/record/3082688/files/CAM017187_d.JPG,0,4694,plesseni,4694_CAM017187_d.JPG,mimic
+CAM017188,https://zenodo.org/record/3082688/files/CAM017188_d.JPG,0,4696,notabilis,4696_CAM017188_d.JPG,major
+CAM017189,https://zenodo.org/record/3082688/files/CAM017189_d.JPG,0,4698,notabilis,4698_CAM017189_d.JPG,major
+CAM017190,https://zenodo.org/record/3082688/files/CAM017190_d.JPG,0,4700,notabilis,4700_CAM017190_d.JPG,major
+CAM017191,https://zenodo.org/record/3082688/files/CAM017191_d.JPG,1,4702,notabilis x lativitta,4702_CAM017191_d.JPG,major
+CAM017192,https://zenodo.org/record/3082688/files/CAM017192_d.JPG,1,4704,notabilis x lativitta,4704_CAM017192_d.JPG,major
+CAM017193,https://zenodo.org/record/3082688/files/CAM017193_d.JPG,0,4706,notabilis,4706_CAM017193_d.JPG,major
+CAM016280,https://zenodo.org/record/3082688/files/CAM016280_d.JPG,0,3394,plesseni,3394_CAM016280_d.JPG,mimic
+CAM017194,https://zenodo.org/record/3082688/files/CAM017194_d.JPG,0,4708,notabilis,4708_CAM017194_d.JPG,major
+CAM016208,https://zenodo.org/record/4153502/files/CAM016208_D.JPG,1,19072,notabilis x lativitta,19072_CAM016208_D.JPG,major
+CAM016004,https://zenodo.org/record/4153502/files/CAM016004_d.JPG,0,18849,plesseni,18849_CAM016004_d.JPG,mimic
+CAM016229,https://zenodo.org/record/4153502/files/CAM016229_D.JPG,1,19082,notabilis x lativitta,19082_CAM016229_D.JPG,major
+CAM016002,https://zenodo.org/record/4153502/files/CAM016002_d.JPG,0,18845,plesseni,18845_CAM016002_d.JPG,mimic
+CAM016231,https://zenodo.org/record/4153502/files/CAM016231_D.JPG,1,19084,notabilis x lativitta,19084_CAM016231_D.JPG,major
+CAM016232,https://zenodo.org/record/4153502/files/CAM016232_D.JPG,1,19086,notabilis x lativitta,19086_CAM016232_D.JPG,major
+CAM016000,https://zenodo.org/record/4153502/files/CAM016000_d.JPG,0,18841,plesseni,18841_CAM016000_d.JPG,mimic
+CAM016233,https://zenodo.org/record/4153502/files/CAM016233_D.JPG,1,19088,notabilis x lativitta,19088_CAM016233_D.JPG,major
+CAM016271,https://zenodo.org/record/4153502/files/CAM016271_D.JPG,1,19104,notabilis x lativitta,19104_CAM016271_D.JPG,major
+CAM016221,https://zenodo.org/record/4153502/files/CAM016221_D.JPG,1,19080,notabilis x lativitta,19080_CAM016221_D.JPG,major
+CAM016236,https://zenodo.org/record/4153502/files/CAM016236_D.JPG,1,19090,notabilis x lativitta,19090_CAM016236_D.JPG,major
+CAM016003,https://zenodo.org/record/4153502/files/CAM016003_d.JPG,0,18847,plesseni,18847_CAM016003_d.JPG,mimic
+CAM016265,https://zenodo.org/record/4153502/files/CAM016265_D.JPG,1,19102,notabilis x lativitta,19102_CAM016265_D.JPG,major
+CAM016262,https://zenodo.org/record/4153502/files/CAM016262_D.JPG,1,19100,notabilis x lativitta,19100_CAM016262_D.JPG,major
+CAM016261,https://zenodo.org/record/4153502/files/CAM016261_D.JPG,1,19098,notabilis x lativitta,19098_CAM016261_D.JPG,major
+CAM016258,https://zenodo.org/record/4153502/files/CAM016258_D.JPG,1,19094,notabilis x lativitta,19094_CAM016258_D.JPG,major
+CAM016001,https://zenodo.org/record/4153502/files/CAM016001_d.JPG,0,18843,plesseni,18843_CAM016001_d.JPG,mimic
+CAM016213,https://zenodo.org/record/4153502/files/CAM016213_D.JPG,1,19076,notabilis x lativitta,19076_CAM016213_D.JPG,major
+CAM016005,https://zenodo.org/record/4153502/files/CAM016005_d.JPG,0,18851,plesseni,18851_CAM016005_d.JPG,mimic
+CAM016212,https://zenodo.org/record/4153502/files/CAM016212_D.JPG,1,19074,notabilis x lativitta,19074_CAM016212_D.JPG,major
+CAM016215,https://zenodo.org/record/4153502/files/CAM016215_D.JPG,1,19078,notabilis x lativitta,19078_CAM016215_D.JPG,major
+CAM016256,https://zenodo.org/record/4153502/files/CAM016256_D.JPG,1,19092,notabilis x lativitta,19092_CAM016256_D.JPG,major
+CAM016698,https://zenodo.org/record/4153502/files/CAM016698_d.JPG,0,18940,plesseni,18940_CAM016698_d.JPG,mimic
+CAM016690,https://zenodo.org/record/4153502/files/CAM016690_d.JPG,0,18924,plesseni,18924_CAM016690_d.JPG,mimic
+CAM016303,https://zenodo.org/record/4153502/files/CAM016303_D.JPG,1,19108,notabilis x lativitta,19108_CAM016303_D.JPG,major
+CAM016305,https://zenodo.org/record/4153502/files/CAM016305_d.JPG,0,18864,notabilis,18864_CAM016305_d.JPG,major
+CAM016307,https://zenodo.org/record/4153502/files/CAM016307_d.JPG,1,18866,notabilis x lativitta,18866_CAM016307_d.JPG,major
+CAM016308,https://zenodo.org/record/4153502/files/CAM016308_D.JPG,1,19110,notabilis x lativitta,19110_CAM016308_D.JPG,major
+CAM016310,https://zenodo.org/record/4153502/files/CAM016310_D.JPG,1,19112,notabilis x lativitta,19112_CAM016310_D.JPG,major
+CAM016311,https://zenodo.org/record/4153502/files/CAM016311_D.JPG,1,19114,notabilis x lativitta,19114_CAM016311_D.JPG,major
+CAM016314,https://zenodo.org/record/4153502/files/CAM016314_d.JPG,1,18868,notabilis x lativitta,18868_CAM016314_d.JPG,major
+CAM016315,https://zenodo.org/record/4153502/files/CAM016315_D.JPG,0,19116,notabilis,19116_CAM016315_D.JPG,major
+CAM016316,https://zenodo.org/record/4153502/files/CAM016316_D.JPG,1,19118,notabilis x lativitta,19118_CAM016316_D.JPG,major
+CAM016317,https://zenodo.org/record/4153502/files/CAM016317_D.JPG,1,19120,notabilis x lativitta,19120_CAM016317_D.JPG,major
+CAM016322,https://zenodo.org/record/4153502/files/CAM016322_d.JPG,0,18870,notabilis,18870_CAM016322_d.JPG,major
+CAM016352,https://zenodo.org/record/4153502/files/CAM016352_D.JPG,0,19122,notabilis,19122_CAM016352_D.JPG,major
+CAM016353,https://zenodo.org/record/4153502/files/CAM016353_D.JPG,0,19124,notabilis,19124_CAM016353_D.JPG,major
+CAM016356,https://zenodo.org/record/4153502/files/CAM016356_D.JPG,0,19126,notabilis,19126_CAM016356_D.JPG,major
+CAM016361,https://zenodo.org/record/4153502/files/CAM016361_D.JPG,0,19128,notabilis,19128_CAM016361_D.JPG,major
+CAM016362,https://zenodo.org/record/4153502/files/CAM016362_D.JPG,0,19130,notabilis,19130_CAM016362_D.JPG,major
+CAM016363,https://zenodo.org/record/4153502/files/CAM016363_D.JPG,0,19132,notabilis,19132_CAM016363_D.JPG,major
+CAM016451,https://zenodo.org/record/4153502/files/CAM016451_d.JPG,1,18878,notabilis x lativitta,18878_CAM016451_d.JPG,major
+CAM016457,https://zenodo.org/record/4153502/files/CAM016457_d.JPG,1,18882,notabilis x lativitta,18882_CAM016457_d.JPG,major
+CAM016302,https://zenodo.org/record/4153502/files/CAM016302_d.JPG,1,18862,notabilis x lativitta,18862_CAM016302_d.JPG,major
+CAM016460,https://zenodo.org/record/4153502/files/CAM016460_d.JPG,1,18884,notabilis x lativitta,18884_CAM016460_d.JPG,major
+CAM016301,https://zenodo.org/record/4153502/files/CAM016301_d.JPG,0,18860,notabilis,18860_CAM016301_d.JPG,major
+CAM017357,https://zenodo.org/record/4153502/files/CAM017357_d.JPG,0,19020,plesseni,19020_CAM017357_d.JPG,mimic
+CAM017376,https://zenodo.org/record/4153502/files/CAM017376_d.JPG,0,19038,plesseni,19038_CAM017376_d.JPG,mimic
+CAM017613,https://zenodo.org/record/4153502/files/CAM017613_d.JPG,0,19054,plesseni,19054_CAM017613_d.JPG,mimic
+CAM017615,https://zenodo.org/record/4153502/files/CAM017615_d.JPG,0,19056,plesseni,19056_CAM017615_d.JPG,mimic
+CAM017616,https://zenodo.org/record/4153502/files/CAM017616_d.JPG,0,19058,plesseni,19058_CAM017616_d.JPG,mimic
+CAM017617,https://zenodo.org/record/4153502/files/CAM017617_d.JPG,0,19060,plesseni,19060_CAM017617_d.JPG,mimic
+CAM017618,https://zenodo.org/record/4153502/files/CAM017618_d.JPG,0,19062,plesseni,19062_CAM017618_d.JPG,mimic
+CAM017619,https://zenodo.org/record/4153502/files/CAM017619_d.JPG,0,19064,plesseni,19064_CAM017619_d.JPG,mimic
+CAM017620,https://zenodo.org/record/4153502/files/CAM017620_d.JPG,0,19066,plesseni,19066_CAM017620_d.JPG,mimic
+CAM017621,https://zenodo.org/record/4153502/files/CAM017621_d.JPG,0,19068,plesseni,19068_CAM017621_d.JPG,mimic
+CAM017622,https://zenodo.org/record/4153502/files/CAM017622_d.JPG,0,19070,plesseni,19070_CAM017622_d.JPG,mimic
+CAM017373,https://zenodo.org/record/4153502/files/CAM017373_d.JPG,0,19036,plesseni,19036_CAM017373_d.JPG,mimic
+CAM017372,https://zenodo.org/record/4153502/files/CAM017372_d.JPG,0,19034,plesseni,19034_CAM017372_d.JPG,mimic
+CAM017371,https://zenodo.org/record/4153502/files/CAM017371_d.JPG,0,19032,plesseni,19032_CAM017371_d.JPG,mimic
+CAM017368,https://zenodo.org/record/4153502/files/CAM017368_d.JPG,0,19030,plesseni,19030_CAM017368_d.JPG,mimic
+CAM017367,https://zenodo.org/record/4153502/files/CAM017367_d.JPG,0,19028,plesseni,19028_CAM017367_d.JPG,mimic
+CAM017365,https://zenodo.org/record/4153502/files/CAM017365_d.JPG,0,19026,plesseni,19026_CAM017365_d.JPG,mimic
+CAM017364,https://zenodo.org/record/4153502/files/CAM017364_d.JPG,0,19024,plesseni,19024_CAM017364_d.JPG,mimic
+CAM017363,https://zenodo.org/record/4153502/files/CAM017363_d.JPG,0,19022,plesseni,19022_CAM017363_d.JPG,mimic
+CAM016297,https://zenodo.org/record/4153502/files/CAM016297_D.JPG,0,19106,notabilis,19106_CAM016297_D.JPG,major
+CAM016705,https://zenodo.org/record/4153502/files/CAM016705_d.JPG,0,18954,notabilis,18954_CAM016705_d.JPG,major
+CAM016707,https://zenodo.org/record/4153502/files/CAM016707_d.JPG,0,18956,notabilis,18956_CAM016707_d.JPG,major
+CAM016709,https://zenodo.org/record/4153502/files/CAM016709_d.JPG,0,18958,notabilis,18958_CAM016709_d.JPG,major
+CAM016712,https://zenodo.org/record/4153502/files/CAM016712_d.JPG,0,18960,notabilis,18960_CAM016712_d.JPG,major
+CAM016734,https://zenodo.org/record/4153502/files/CAM016734_d.JPG,0,18962,plesseni,18962_CAM016734_d.JPG,mimic
+CAM016737,https://zenodo.org/record/4153502/files/CAM016737_d.JPG,0,18964,plesseni,18964_CAM016737_d.JPG,mimic
+CAM016738,https://zenodo.org/record/4153502/files/CAM016738_d.JPG,0,18966,plesseni,18966_CAM016738_d.JPG,mimic
+CAM016739,https://zenodo.org/record/4153502/files/CAM016739_d.JPG,0,18968,plesseni,18968_CAM016739_d.JPG,mimic
+CAM016905,https://zenodo.org/record/4153502/files/CAM016905_d.JPG,0,18974,plesseni,18974_CAM016905_d.JPG,mimic
+CAM016906,https://zenodo.org/record/4153502/files/CAM016906_d.JPG,0,18976,plesseni,18976_CAM016906_d.JPG,mimic
+CAM016907,https://zenodo.org/record/4153502/files/CAM016907_d.JPG,0,18978,plesseni,18978_CAM016907_d.JPG,mimic
+CAM016908,https://zenodo.org/record/4153502/files/CAM016908_d.JPG,0,18980,plesseni,18980_CAM016908_d.JPG,mimic
+CAM016909,https://zenodo.org/record/4153502/files/CAM016909_d.JPG,0,18982,plesseni,18982_CAM016909_d.JPG,mimic
+CAM016910,https://zenodo.org/record/4153502/files/CAM016910_d.JPG,0,18984,plesseni,18984_CAM016910_d.JPG,mimic
+CAM016911,https://zenodo.org/record/4153502/files/CAM016911_d.JPG,0,18986,plesseni,18986_CAM016911_d.JPG,mimic
+CAM016913,https://zenodo.org/record/4153502/files/CAM016913_d.JPG,0,18988,plesseni,18988_CAM016913_d.JPG,mimic
+CAM017256,https://zenodo.org/record/4153502/files/CAM017256_d.JPG,0,19002,plesseni,19002_CAM017256_d.JPG,mimic
+CAM017258,https://zenodo.org/record/4153502/files/CAM017258_d.JPG,0,19004,plesseni,19004_CAM017258_d.JPG,mimic
+CAM017313,https://zenodo.org/record/4153502/files/CAM017313_d.JPG,1,19006,plesseni x malleti,19006_CAM017313_d.JPG,mimic
+CAM017325,https://zenodo.org/record/4153502/files/CAM017325_d.JPG,0,19008,plesseni,19008_CAM017325_d.JPG,mimic
+CAM017327,https://zenodo.org/record/4153502/files/CAM017327_d.JPG,0,19010,plesseni,19010_CAM017327_d.JPG,mimic
+CAM016704,https://zenodo.org/record/4153502/files/CAM016704_d.JPG,0,18952,notabilis,18952_CAM016704_d.JPG,major
+CAM016703,https://zenodo.org/record/4153502/files/CAM016703_d.JPG,0,18950,notabilis,18950_CAM016703_d.JPG,major
+CAM016702,https://zenodo.org/record/4153502/files/CAM016702_d.JPG,0,18948,notabilis,18948_CAM016702_d.JPG,major
+CAM016701,https://zenodo.org/record/4153502/files/CAM016701_d.JPG,0,18946,plesseni,18946_CAM016701_d.JPG,mimic
+CAM016634,https://zenodo.org/record/4153502/files/CAM016634_d.JPG,1,18902,notabilis x lativitta,18902_CAM016634_d.JPG,major
+CAM016638,https://zenodo.org/record/4153502/files/CAM016638_d.JPG,1,18904,notabilis x lativitta,18904_CAM016638_d.JPG,major
+CAM016640,https://zenodo.org/record/4153502/files/CAM016640_d.JPG,1,18906,notabilis x lativitta,18906_CAM016640_d.JPG,major
+CAM016642,https://zenodo.org/record/4153502/files/CAM016642_d.JPG,1,18908,notabilis x lativitta,18908_CAM016642_d.JPG,major
+CAM016683,https://zenodo.org/record/4153502/files/CAM016683_d.JPG,0,18910,plesseni,18910_CAM016683_d.JPG,mimic
+CAM016684,https://zenodo.org/record/4153502/files/CAM016684_d.JPG,0,18912,plesseni,18912_CAM016684_d.JPG,mimic
+CAM016685,https://zenodo.org/record/4153502/files/CAM016685_d.JPG,0,18914,plesseni,18914_CAM016685_d.JPG,mimic
+CAM016686,https://zenodo.org/record/4153502/files/CAM016686_d.JPG,0,18916,plesseni,18916_CAM016686_d.JPG,mimic
+CAM016687,https://zenodo.org/record/4153502/files/CAM016687_d.JPG,0,18918,plesseni,18918_CAM016687_d.JPG,mimic
+CAM016688,https://zenodo.org/record/4153502/files/CAM016688_d.JPG,0,18920,plesseni,18920_CAM016688_d.JPG,mimic
+CAM016689,https://zenodo.org/record/4153502/files/CAM016689_d.JPG,0,18922,plesseni,18922_CAM016689_d.JPG,mimic
+CAM016691,https://zenodo.org/record/4153502/files/CAM016691_d.JPG,0,18926,plesseni,18926_CAM016691_d.JPG,mimic
+CAM016692,https://zenodo.org/record/4153502/files/CAM016692_d.JPG,0,18928,plesseni,18928_CAM016692_d.JPG,mimic
+CAM016693,https://zenodo.org/record/4153502/files/CAM016693_d.JPG,0,18930,plesseni,18930_CAM016693_d.JPG,mimic
+CAM016694,https://zenodo.org/record/4153502/files/CAM016694_d.JPG,0,18932,plesseni,18932_CAM016694_d.JPG,mimic
+CAM016695,https://zenodo.org/record/4153502/files/CAM016695_d.JPG,0,18934,plesseni,18934_CAM016695_d.JPG,mimic
+CAM016696,https://zenodo.org/record/4153502/files/CAM016696_d.JPG,0,18936,plesseni,18936_CAM016696_d.JPG,mimic
+CAM016697,https://zenodo.org/record/4153502/files/CAM016697_d.JPG,0,18938,plesseni,18938_CAM016697_d.JPG,mimic
+CAM017355,https://zenodo.org/record/4153502/files/CAM017355_d.JPG,0,19016,plesseni,19016_CAM017355_d.JPG,mimic
+CAM016699,https://zenodo.org/record/4153502/files/CAM016699_d.JPG,0,18942,plesseni,18942_CAM016699_d.JPG,mimic
+CAM016700,https://zenodo.org/record/4153502/files/CAM016700_d.JPG,0,18944,plesseni,18944_CAM016700_d.JPG,mimic
+CAM017356,https://zenodo.org/record/4153502/files/CAM017356_d.JPG,0,19018,plesseni,19018_CAM017356_d.JPG,mimic
+CAM017352,https://zenodo.org/record/4153502/files/CAM017352_d.JPG,0,19012,plesseni,19012_CAM017352_d.JPG,mimic
+CAM017353,https://zenodo.org/record/4153502/files/CAM017353_d.JPG,0,19014,plesseni,19014_CAM017353_d.JPG,mimic
+19N0332,https://zenodo.org/record/4288311/files/19N0332_d.JPG,0,19774,erato,19774_19N0332_d.JPG,minor
+19N1223,https://zenodo.org/record/4288311/files/19N1223_d.JPG,0,20235,malleti,20235_19N1223_d.JPG,mimic
+19N1212,https://zenodo.org/record/4288311/files/19N1212_d.JPG,0,20231,malleti,20231_19N1212_d.JPG,mimic
+19N1196,https://zenodo.org/record/4288311/files/19N1196_d.JPG,0,20225,malleti,20225_19N1196_d.JPG,mimic
+19N1195,https://zenodo.org/record/4288311/files/19N1195_d.JPG,0,20223,malleti,20223_19N1195_d.JPG,mimic
+19N1194,https://zenodo.org/record/4288311/files/19N1194_d.JPG,0,20221,malleti,20221_19N1194_d.JPG,mimic
+19N1158,https://zenodo.org/record/4288311/files/19N1158_d.JPG,0,20204,malleti,20204_19N1158_d.JPG,mimic
+19N1124,https://zenodo.org/record/4288311/files/19N1124_d.JPG,0,20198,malleti,20198_19N1124_d.JPG,mimic
+19N1112,https://zenodo.org/record/4288311/files/19N1112_d.JPG,0,20190,malleti,20190_19N1112_d.JPG,mimic
+19N1111,https://zenodo.org/record/4288311/files/19N1111_d.JPG,0,20188,malleti,20188_19N1111_d.JPG,mimic
+19N1110,https://zenodo.org/record/4288311/files/19N1110_d.JPG,0,20186,malleti,20186_19N1110_d.JPG,mimic
+19N1109,https://zenodo.org/record/4288311/files/19N1109_d.JPG,0,20184,malleti,20184_19N1109_d.JPG,mimic
+19N1179,https://zenodo.org/record/4288311/files/19N1179_d.JPG,0,20213,malleti,20213_19N1179_d.JPG,mimic
+19N0901,https://zenodo.org/record/4288311/files/19N0901_d.JPG,0,20098,malleti,20098_19N0901_d.JPG,mimic
+19N0746,https://zenodo.org/record/4288311/files/19N0746_d.JPG,0,20022,malleti,20022_19N0746_d.JPG,mimic
+19N0745,https://zenodo.org/record/4288311/files/19N0745_d.JPG,0,20020,malleti,20020_19N0745_d.JPG,mimic
+19N0738,https://zenodo.org/record/4288311/files/19N0738_d.JPG,0,20016,malleti,20016_19N0738_d.JPG,mimic
+19N0727,https://zenodo.org/record/4288311/files/19N0727_d.JPG,0,20012,malleti,20012_19N0727_d.JPG,mimic
+19N0715,https://zenodo.org/record/4288311/files/19N0715_d.JPG,0,20008,malleti,20008_19N0715_d.JPG,mimic
+19N0713,https://zenodo.org/record/4288311/files/19N0713_d.JPG,0,20004,malleti,20004_19N0713_d.JPG,mimic
+19N0712,https://zenodo.org/record/4288311/files/19N0712_d.JPG,0,20002,malleti,20002_19N0712_d.JPG,mimic
+19N0708,https://zenodo.org/record/4288311/files/19N0708_d.JPG,0,20000,malleti,20000_19N0708_d.JPG,mimic
+19N0700,https://zenodo.org/record/4288311/files/19N0700_d.JPG,0,19996,malleti,19996_19N0700_d.JPG,mimic
+19N0698,https://zenodo.org/record/4288311/files/19N0698_d.JPG,0,19992,malleti,19992_19N0698_d.JPG,mimic
+19N0759,https://zenodo.org/record/4288311/files/19N0759_d.JPG,0,20024,malleti,20024_19N0759_d.JPG,mimic
+19N0691,https://zenodo.org/record/4288311/files/19N0691_d.JPG,0,19984,malleti,19984_19N0691_d.JPG,mimic
+19N0690,https://zenodo.org/record/4288311/files/19N0690_d.JPG,0,19982,malleti,19982_19N0690_d.JPG,mimic
+19N0683,https://zenodo.org/record/4288311/files/19N0683_d.JPG,0,19976,malleti,19976_19N0683_d.JPG,mimic
+19N0682,https://zenodo.org/record/4288311/files/19N0682_d.JPG,0,19974,malleti,19974_19N0682_d.JPG,mimic
+19N0680,https://zenodo.org/record/4288311/files/19N0680_d.JPG,0,19972,malleti,19972_19N0680_d.JPG,mimic
+19N0674,https://zenodo.org/record/4288311/files/19N0674_d.JPG,0,19970,malleti,19970_19N0674_d.JPG,mimic
+19N0673,https://zenodo.org/record/4288311/files/19N0673_d.JPG,0,19968,malleti,19968_19N0673_d.JPG,mimic
+19N0672,https://zenodo.org/record/4288311/files/19N0672_d.JPG,0,19966,malleti,19966_19N0672_d.JPG,mimic
+19N0671,https://zenodo.org/record/4288311/files/19N0671_d.JPG,0,19964,malleti,19964_19N0671_d.JPG,mimic
+19N0667,https://zenodo.org/record/4288311/files/19N0667_d.JPG,0,19958,malleti,19958_19N0667_d.JPG,mimic
+19N0666,https://zenodo.org/record/4288311/files/19N0666_d.JPG,0,19956,malleti,19956_19N0666_d.JPG,mimic
+19N0899,https://zenodo.org/record/4288311/files/19N0899_d.JPG,0,20094,malleti,20094_19N0899_d.JPG,mimic
+19N0897,https://zenodo.org/record/4288311/files/19N0897_d.JPG,0,20090,malleti,20090_19N0897_d.JPG,mimic
+19N0868,https://zenodo.org/record/4288311/files/19N0868_d.JPG,0,20076,malleti,20076_19N0868_d.JPG,mimic
+19N0867,https://zenodo.org/record/4288311/files/19N0867_d.JPG,0,20074,malleti,20074_19N0867_d.JPG,mimic
+19N0866,https://zenodo.org/record/4288311/files/19N0866_d.JPG,0,20072,malleti,20072_19N0866_d.JPG,mimic
+19N0864,https://zenodo.org/record/4288311/files/19N0864_d.JPG,0,20068,malleti,20068_19N0864_d.JPG,mimic
+19N0863,https://zenodo.org/record/4288311/files/19N0863_d.JPG,0,20066,malleti,20066_19N0863_d.JPG,mimic
+19N0809,https://zenodo.org/record/4288311/files/19N0809_d.JPG,0,20034,malleti,20034_19N0809_d.JPG,mimic
+19N0812,https://zenodo.org/record/4288311/files/19N0812_d.JPG,0,20040,malleti,20040_19N0812_d.JPG,mimic
+19N0813,https://zenodo.org/record/4288311/files/19N0813_d.JPG,0,20042,malleti,20042_19N0813_d.JPG,mimic
+19N0833,https://zenodo.org/record/4288311/files/19N0833_d.JPG,0,20048,malleti,20048_19N0833_d.JPG,mimic
+19N0281,https://zenodo.org/record/4288311/files/19N0281_d.JPG,0,19708,malleti,19708_19N0281_d.JPG,mimic
+19N0056,https://zenodo.org/record/4288311/files/19N0056_d.JPG,0,19254,malleti,19254_19N0056_d.JPG,mimic
+19N0058,https://zenodo.org/record/4288311/files/19N0058_d.JPG,0,19260,malleti,19260_19N0058_d.JPG,mimic
+19N0061,https://zenodo.org/record/4288311/files/19N0061_d.JPG,0,19267,malleti,19267_19N0061_d.JPG,mimic
+19N0063,https://zenodo.org/record/4288311/files/19N0063_d.JPG,0,19271,malleti,19271_19N0063_d.JPG,mimic
+19N0068,https://zenodo.org/record/4288311/files/19N0068_d.JPG,0,19281,malleti,19281_19N0068_d.JPG,mimic
+19N0073,https://zenodo.org/record/4288311/files/19N0073_d.JPG,0,19291,malleti,19291_19N0073_d.JPG,mimic
+19N0074,https://zenodo.org/record/4288311/files/19N0074_d.JPG,0,19293,malleti,19293_19N0074_d.JPG,mimic
+19N0075,https://zenodo.org/record/4288311/files/19N0075_d.JPG,0,19295,malleti,19295_19N0075_d.JPG,mimic
+19N0076,https://zenodo.org/record/4288311/files/19N0076_d.JPG,0,19297,malleti,19297_19N0076_d.JPG,mimic
+19N0013,https://zenodo.org/record/4288311/files/19N0013_d.JPG,0,19165,malleti,19165_19N0013_d.JPG,mimic
+19N0014,https://zenodo.org/record/4288311/files/19N0014_d.JPG,0,19167,malleti,19167_19N0014_d.JPG,mimic
+19N0015,https://zenodo.org/record/4288311/files/19N0015_d.JPG,0,19169,malleti,19169_19N0015_d.JPG,mimic
+19N0026,https://zenodo.org/record/4288311/files/19N0026_d.JPG,0,19191,malleti,19191_19N0026_d.JPG,mimic
+19N0027,https://zenodo.org/record/4288311/files/19N0027_d.JPG,0,19194,malleti,19194_19N0027_d.JPG,mimic
+19N0029,https://zenodo.org/record/4288311/files/19N0029_d.JPG,0,19198,malleti,19198_19N0029_d.JPG,mimic
+19N0031,https://zenodo.org/record/4288311/files/19N0031_d.JPG,0,19202,malleti,19202_19N0031_d.JPG,mimic
+19N0033,https://zenodo.org/record/4288311/files/19N0033_d.JPG,0,19206,malleti,19206_19N0033_d.JPG,mimic
+19N0034,https://zenodo.org/record/4288311/files/19N0034_d.JPG,0,19208,malleti,19208_19N0034_d.JPG,mimic
+19N0035,https://zenodo.org/record/4288311/files/19N0035_d.JPG,0,19210,malleti,19210_19N0035_d.JPG,mimic
+19N0012,https://zenodo.org/record/4288311/files/19N0012_d.JPG,0,19163,malleti,19163_19N0012_d.JPG,mimic
+19N0114,https://zenodo.org/record/4288311/files/19N0114_d.JPG,0,19373,malleti,19373_19N0114_d.JPG,mimic
+19N0115,https://zenodo.org/record/4288311/files/19N0115_d.JPG,0,19375,malleti,19375_19N0115_d.JPG,mimic
+19N0116,https://zenodo.org/record/4288311/files/19N0116_d.JPG,0,19377,malleti,19377_19N0116_d.JPG,mimic
+19N0118,https://zenodo.org/record/4288311/files/19N0118_d.JPG,0,19381,malleti,19381_19N0118_d.JPG,mimic
+19N0123,https://zenodo.org/record/4288311/files/19N0123_d.JPG,0,19391,malleti,19391_19N0123_d.JPG,mimic
+19N0126,https://zenodo.org/record/4288311/files/19N0126_d.JPG,0,19397,malleti,19397_19N0126_d.JPG,mimic
+19N0127,https://zenodo.org/record/4288311/files/19N0127_d.JPG,0,19399,malleti,19399_19N0127_d.JPG,mimic
+19N0128,https://zenodo.org/record/4288311/files/19N0128_d.JPG,0,19401,malleti,19401_19N0128_d.JPG,mimic
+19N0130,https://zenodo.org/record/4288311/files/19N0130_d.JPG,0,19405,malleti,19405_19N0130_d.JPG,mimic
+19N0131,https://zenodo.org/record/4288311/files/19N0131_d.JPG,0,19407,malleti,19407_19N0131_d.JPG,mimic
+19N0133,https://zenodo.org/record/4288311/files/19N0133_d.JPG,0,19411,malleti,19411_19N0133_d.JPG,mimic
+19N0134,https://zenodo.org/record/4288311/files/19N0134_d.JPG,0,19413,malleti,19413_19N0134_d.JPG,mimic
+19N0135,https://zenodo.org/record/4288311/files/19N0135_d.JPG,0,19415,malleti,19415_19N0135_d.JPG,mimic
+19N0136,https://zenodo.org/record/4288311/files/19N0136_d.JPG,0,19417,malleti,19417_19N0136_d.JPG,mimic
+19N0137,https://zenodo.org/record/4288311/files/19N0137_d.JPG,0,19419,malleti,19419_19N0137_d.JPG,mimic
+19N0140,https://zenodo.org/record/4288311/files/19N0140_d.JPG,0,19425,malleti,19425_19N0140_d.JPG,mimic
+19N0141,https://zenodo.org/record/4288311/files/19N0141_d.JPG,0,19427,malleti,19427_19N0141_d.JPG,mimic
+19N0112,https://zenodo.org/record/4288311/files/19N0112_d.JPG,0,19369,malleti,19369_19N0112_d.JPG,mimic
+19N0110,https://zenodo.org/record/4288311/files/19N0110_d.JPG,0,19365,malleti,19365_19N0110_d.JPG,mimic
+19N0084,https://zenodo.org/record/4288311/files/19N0084_d.JPG,0,19313,malleti,19313_19N0084_d.JPG,mimic
+19N0086,https://zenodo.org/record/4288311/files/19N0086_d.JPG,0,19317,malleti,19317_19N0086_d.JPG,mimic
+19N0088,https://zenodo.org/record/4288311/files/19N0088_d.JPG,0,19321,malleti,19321_19N0088_d.JPG,mimic
+19N0089,https://zenodo.org/record/4288311/files/19N0089_d.JPG,0,19323,malleti,19323_19N0089_d.JPG,mimic
+19N0091,https://zenodo.org/record/4288311/files/19N0091_d.JPG,0,19327,malleti,19327_19N0091_d.JPG,mimic
+19N0094,https://zenodo.org/record/4288311/files/19N0094_d.JPG,0,19333,malleti,19333_19N0094_d.JPG,mimic
+19N0095,https://zenodo.org/record/4288311/files/19N0095_d.JPG,0,19335,malleti,19335_19N0095_d.JPG,mimic
+19N0097,https://zenodo.org/record/4288311/files/19N0097_d.JPG,0,19339,malleti,19339_19N0097_d.JPG,mimic
+19N0098,https://zenodo.org/record/4288311/files/19N0098_d.JPG,0,19341,malleti,19341_19N0098_d.JPG,mimic
+19N0100,https://zenodo.org/record/4288311/files/19N0100_d.JPG,0,19345,malleti,19345_19N0100_d.JPG,mimic
+19N0101,https://zenodo.org/record/4288311/files/19N0101_d.JPG,0,19347,malleti,19347_19N0101_d.JPG,mimic
+19N0102,https://zenodo.org/record/4288311/files/19N0102_d.JPG,0,19349,malleti,19349_19N0102_d.JPG,mimic
+19N0103,https://zenodo.org/record/4288311/files/19N0103_d.JPG,0,19351,malleti,19351_19N0103_d.JPG,mimic
+19N0105,https://zenodo.org/record/4288311/files/19N0105_d.JPG,0,19355,malleti,19355_19N0105_d.JPG,mimic
+19N0106,https://zenodo.org/record/4288311/files/19N0106_d.JPG,0,19357,malleti,19357_19N0106_d.JPG,mimic
+19N0107,https://zenodo.org/record/4288311/files/19N0107_d.JPG,0,19359,malleti,19359_19N0107_d.JPG,mimic
+19N0111,https://zenodo.org/record/4288311/files/19N0111_d.JPG,0,19367,malleti,19367_19N0111_d.JPG,mimic
+19N0226,https://zenodo.org/record/4288311/files/19N0226_d.JPG,0,19597,malleti,19597_19N0226_d.JPG,mimic
+19N0225,https://zenodo.org/record/4288311/files/19N0225_d.JPG,0,19595,malleti,19595_19N0225_d.JPG,mimic
+19N0212,https://zenodo.org/record/4288311/files/19N0212_d.JPG,0,19569,malleti,19569_19N0212_d.JPG,mimic
+19N0205,https://zenodo.org/record/4288311/files/19N0205_d.JPG,0,19555,malleti,19555_19N0205_d.JPG,mimic
+19N0242,https://zenodo.org/record/4288311/files/19N0242_d.JPG,0,19629,malleti,19629_19N0242_d.JPG,mimic
+19N0246,https://zenodo.org/record/4288311/files/19N0246_d.JPG,0,19637,malleti,19637_19N0246_d.JPG,mimic
+19N0280,https://zenodo.org/record/4288311/files/19N0280_d.JPG,0,19706,malleti,19706_19N0280_d.JPG,mimic
+19N0279,https://zenodo.org/record/4288311/files/19N0279_d.JPG,0,19704,malleti,19704_19N0279_d.JPG,mimic
+19N0278,https://zenodo.org/record/4288311/files/19N0278_d.JPG,0,19702,malleti,19702_19N0278_d.JPG,mimic
+19N0275,https://zenodo.org/record/4288311/files/19N0275_d.JPG,0,19696,malleti,19696_19N0275_d.JPG,mimic
+19N0267,https://zenodo.org/record/4288311/files/19N0267_d.JPG,0,19679,malleti,19679_19N0267_d.JPG,mimic
+19N0261,https://zenodo.org/record/4288311/files/19N0261_d.JPG,0,19667,malleti,19667_19N0261_d.JPG,mimic
+19N0257,https://zenodo.org/record/4288311/files/19N0257_d.JPG,0,19659,malleti,19659_19N0257_d.JPG,mimic
+19N0255,https://zenodo.org/record/4288311/files/19N0255_d.JPG,0,19655,malleti,19655_19N0255_d.JPG,mimic
+19N0010,https://zenodo.org/record/4288311/files/19N0010_d.JPG,0,19159,malleti,19159_19N0010_d.JPG,mimic
+19N0162,https://zenodo.org/record/4288311/files/19N0162_d.JPG,0,19469,malleti,19469_19N0162_d.JPG,mimic
+19N0160,https://zenodo.org/record/4288311/files/19N0160_d.JPG,0,19465,malleti,19465_19N0160_d.JPG,mimic
+19N0158,https://zenodo.org/record/4288311/files/19N0158_d.JPG,0,19461,malleti,19461_19N0158_d.JPG,mimic
+19N0153,https://zenodo.org/record/4288311/files/19N0153_d.JPG,0,19451,malleti,19451_19N0153_d.JPG,mimic
+19N0152,https://zenodo.org/record/4288311/files/19N0152_d.JPG,0,19449,malleti,19449_19N0152_d.JPG,mimic
+19N0150,https://zenodo.org/record/4288311/files/19N0150_d.JPG,0,19445,malleti,19445_19N0150_d.JPG,mimic
+19N0148,https://zenodo.org/record/4288311/files/19N0148_d.JPG,0,19441,malleti,19441_19N0148_d.JPG,mimic
+19N0147,https://zenodo.org/record/4288311/files/19N0147_d.JPG,0,19439,malleti,19439_19N0147_d.JPG,mimic
+19N1238,https://zenodo.org/record/4288311/files/19N1238_d.JPG,0,20249,erato,20249_19N1238_d.JPG,minor
+19N0000,https://zenodo.org/record/4288311/files/19N0000_d.JPG,0,19139,malleti,19139_19N0000_d.JPG,mimic
+19N0163,https://zenodo.org/record/4288311/files/19N0163_d.JPG,0,19471,malleti,19471_19N0163_d.JPG,mimic
+19N0196,https://zenodo.org/record/4288311/files/19N0196_d.JPG,0,19537,malleti,19537_19N0196_d.JPG,mimic
+19N0164,https://zenodo.org/record/4288311/files/19N0164_d.JPG,0,19473,malleti,19473_19N0164_d.JPG,mimic
+19N0190,https://zenodo.org/record/4288311/files/19N0190_d.JPG,0,19525,malleti,19525_19N0190_d.JPG,mimic
+19N0187,https://zenodo.org/record/4288311/files/19N0187_d.JPG,0,19519,malleti,19519_19N0187_d.JPG,mimic
+19N0186,https://zenodo.org/record/4288311/files/19N0186_d.JPG,0,19517,malleti,19517_19N0186_d.JPG,mimic
+19N0185,https://zenodo.org/record/4288311/files/19N0185_d.JPG,0,19515,malleti,19515_19N0185_d.JPG,mimic
+19N0184,https://zenodo.org/record/4288311/files/19N0184_d.JPG,0,19513,malleti,19513_19N0184_d.JPG,mimic
+19N0183,https://zenodo.org/record/4288311/files/19N0183_d.JPG,0,19511,malleti,19511_19N0183_d.JPG,mimic
+19N0182,https://zenodo.org/record/4288311/files/19N0182_d.JPG,0,19509,malleti,19509_19N0182_d.JPG,mimic
+19N0181,https://zenodo.org/record/4288311/files/19N0181_d.JPG,0,19507,malleti,19507_19N0181_d.JPG,mimic
+19N0180,https://zenodo.org/record/4288311/files/19N0180_d.JPG,0,19505,malleti,19505_19N0180_d.JPG,mimic
+19N0179,https://zenodo.org/record/4288311/files/19N0179_d.JPG,0,19503,malleti,19503_19N0179_d.JPG,mimic
+19N0178,https://zenodo.org/record/4288311/files/19N0178_d.JPG,0,19501,malleti,19501_19N0178_d.JPG,mimic
+19N0177,https://zenodo.org/record/4288311/files/19N0177_d.JPG,0,19499,malleti,19499_19N0177_d.JPG,mimic
+19N0175,https://zenodo.org/record/4288311/files/19N0175_d.JPG,0,19495,malleti,19495_19N0175_d.JPG,mimic
+19N0174,https://zenodo.org/record/4288311/files/19N0174_d.JPG,0,19493,malleti,19493_19N0174_d.JPG,mimic
+19N0173,https://zenodo.org/record/4288311/files/19N0173_d.JPG,0,19491,malleti,19491_19N0173_d.JPG,mimic
+19N0172,https://zenodo.org/record/4288311/files/19N0172_d.JPG,0,19489,malleti,19489_19N0172_d.JPG,mimic
+19N0171,https://zenodo.org/record/4288311/files/19N0171_d.JPG,0,19487,malleti,19487_19N0171_d.JPG,mimic
+19N0170,https://zenodo.org/record/4288311/files/19N0170_d.JPG,0,19485,malleti,19485_19N0170_d.JPG,mimic
+19N0169,https://zenodo.org/record/4288311/files/19N0169_d.JPG,0,19483,malleti,19483_19N0169_d.JPG,mimic
+19N2260,https://zenodo.org/record/4288311/files/19N2260_d.JPG,0,21967,malleti,21967_19N2260_d.JPG,mimic
+19N1260,https://zenodo.org/record/4288311/files/19N1260_d.JPG,0,20255,malleti,20255_19N1260_d.JPG,mimic
+19N2257,https://zenodo.org/record/4288311/files/19N2257_d.JPG,0,21955,malleti,21955_19N2257_d.JPG,mimic
+19N2259,https://zenodo.org/record/4288311/files/19N2259_d.JPG,0,21963,malleti,21963_19N2259_d.JPG,mimic
+19N2270,https://zenodo.org/record/4288311/files/19N2270_d.JPG,0,22007,malleti,22007_19N2270_d.JPG,mimic
+19N2272,https://zenodo.org/record/4288311/files/19N2272_d.JPG,0,22015,malleti,22015_19N2272_d.JPG,mimic
+19N2273,https://zenodo.org/record/4288311/files/19N2273_d.JPG,0,22019,malleti,22019_19N2273_d.JPG,mimic
+19N2254,https://zenodo.org/record/4288311/files/19N2254_d.JPG,0,21943,malleti,21943_19N2254_d.JPG,mimic
+19N2253,https://zenodo.org/record/4288311/files/19N2253_d.JPG,0,21939,malleti,21939_19N2253_d.JPG,mimic
+19N2235,https://zenodo.org/record/4288311/files/19N2235_d.JPG,0,21867,malleti,21867_19N2235_d.JPG,mimic
+19N2236,https://zenodo.org/record/4288311/files/19N2236_d.JPG,0,21871,malleti,21871_19N2236_d.JPG,mimic
+19N2237,https://zenodo.org/record/4288311/files/19N2237_d.JPG,0,21875,malleti,21875_19N2237_d.JPG,mimic
+19N2242,https://zenodo.org/record/4288311/files/19N2242_d.JPG,0,21895,malleti,21895_19N2242_d.JPG,mimic
+19N2244,https://zenodo.org/record/4288311/files/19N2244_d.JPG,0,21903,malleti,21903_19N2244_d.JPG,mimic
+19N2246,https://zenodo.org/record/4288311/files/19N2246_d.JPG,0,21911,malleti,21911_19N2246_d.JPG,mimic
+19N2249,https://zenodo.org/record/4288311/files/19N2249_d.JPG,0,21923,malleti,21923_19N2249_d.JPG,mimic
+19N2250,https://zenodo.org/record/4288311/files/19N2250_d.JPG,0,21927,malleti,21927_19N2250_d.JPG,mimic
+19N2251,https://zenodo.org/record/4288311/files/19N2251_d.JPG,0,21931,malleti,21931_19N2251_d.JPG,mimic
+19N2252,https://zenodo.org/record/4288311/files/19N2252_d.JPG,0,21935,malleti,21935_19N2252_d.JPG,mimic
+19N2277,https://zenodo.org/record/4288311/files/19N2277_d.JPG,0,22035,malleti,22035_19N2277_d.JPG,mimic
+19N2279,https://zenodo.org/record/4288311/files/19N2279_d.JPG,0,22043,malleti,22043_19N2279_d.JPG,mimic
+19N1997,https://zenodo.org/record/4288311/files/19N1997_d.JPG,0,21387,malleti,21387_19N1997_d.JPG,mimic
+19N1996,https://zenodo.org/record/4288311/files/19N1996_d.JPG,0,21383,malleti,21383_19N1996_d.JPG,mimic
+19N1983,https://zenodo.org/record/4288311/files/19N1983_d.JPG,0,21347,malleti,21347_19N1983_d.JPG,mimic
+19N1981,https://zenodo.org/record/4288311/files/19N1981_d.JPG,0,21339,malleti,21339_19N1981_d.JPG,mimic
+19N1977,https://zenodo.org/record/4288311/files/19N1977_d.JPG,0,21335,malleti,21335_19N1977_d.JPG,mimic
+19N1989,https://zenodo.org/record/4288311/files/19N1989_d.JPG,0,21367,malleti,21367_19N1989_d.JPG,mimic
+19N2011,https://zenodo.org/record/4288311/files/19N2011_d.JPG,0,21415,malleti,21415_19N2011_d.JPG,mimic
+19N2280,https://zenodo.org/record/4288311/files/19N2280_d.JPG,0,22047,malleti,22047_19N2280_d.JPG,mimic
+19N2283,https://zenodo.org/record/4288311/files/19N2283_d.JPG,0,22059,malleti,22059_19N2283_d.JPG,mimic
+19N2284,https://zenodo.org/record/4288311/files/19N2284_d.JPG,0,22063,malleti,22063_19N2284_d.JPG,mimic
+19N2040,https://zenodo.org/record/4288311/files/19N2040_d.JPG,0,21487,malleti,21487_19N2040_d.JPG,mimic
+19N2036,https://zenodo.org/record/4288311/files/19N2036_d.JPG,0,21475,malleti,21475_19N2036_d.JPG,mimic
+19N2034,https://zenodo.org/record/4288311/files/19N2034_d.JPG,0,21467,malleti,21467_19N2034_d.JPG,mimic
+19N2033,https://zenodo.org/record/4288311/files/19N2033_d.JPG,0,21463,malleti,21463_19N2033_d.JPG,mimic
+19N2027,https://zenodo.org/record/4288311/files/19N2027_d.JPG,0,21459,malleti,21459_19N2027_d.JPG,mimic
+19N2026,https://zenodo.org/record/4288311/files/19N2026_d.JPG,0,21455,malleti,21455_19N2026_d.JPG,mimic
+19N2025,https://zenodo.org/record/4288311/files/19N2025_d.JPG,0,21451,malleti,21451_19N2025_d.JPG,mimic
+19N2020,https://zenodo.org/record/4288311/files/19N2020_d.JPG,0,21435,malleti,21435_19N2020_d.JPG,mimic
+19N2230,https://zenodo.org/record/4288311/files/19N2230_d.JPG,0,21847,malleti,21847_19N2230_d.JPG,mimic
+19N2088,https://zenodo.org/record/4288311/files/19N2088_d.JPG,0,21595,malleti,21595_19N2088_d.JPG,mimic
+19N2115,https://zenodo.org/record/4288311/files/19N2115_d.JPG,0,21611,malleti,21611_19N2115_d.JPG,mimic
+19N2116,https://zenodo.org/record/4288311/files/19N2116_d.JPG,0,21615,malleti,21615_19N2116_d.JPG,mimic
+19N2082,https://zenodo.org/record/4288311/files/19N2082_d.JPG,0,21579,malleti,21579_19N2082_d.JPG,mimic
+19N2118,https://zenodo.org/record/4288311/files/19N2118_d.JPG,0,21623,malleti,21623_19N2118_d.JPG,mimic
+19N2122,https://zenodo.org/record/4288311/files/19N2122_d.JPG,0,21635,malleti,21635_19N2122_d.JPG,mimic
+19N2126,https://zenodo.org/record/4288311/files/19N2126_d.JPG,0,21643,malleti,21643_19N2126_d.JPG,mimic
+19N2127,https://zenodo.org/record/4288311/files/19N2127_d.JPG,0,21647,malleti,21647_19N2127_d.JPG,mimic
+19N2119,https://zenodo.org/record/4288311/files/19N2119_d.JPG,0,21627,malleti,21627_19N2119_d.JPG,mimic
+19N2081,https://zenodo.org/record/4288311/files/19N2081_d.JPG,0,21575,malleti,21575_19N2081_d.JPG,mimic
+19N2079,https://zenodo.org/record/4288311/files/19N2079_d.JPG,0,21571,malleti,21571_19N2079_d.JPG,mimic
+19N2078,https://zenodo.org/record/4288311/files/19N2078_d.JPG,0,21567,malleti,21567_19N2078_d.JPG,mimic
+19N2041,https://zenodo.org/record/4288311/files/19N2041_d.JPG,0,21491,malleti,21491_19N2041_d.JPG,mimic
+19N2042,https://zenodo.org/record/4288311/files/19N2042_d.JPG,0,21495,malleti,21495_19N2042_d.JPG,mimic
+19N2043,https://zenodo.org/record/4288311/files/19N2043_d.JPG,0,21499,malleti,21499_19N2043_d.JPG,mimic
+19N2056,https://zenodo.org/record/4288311/files/19N2056_d.JPG,0,21511,malleti,21511_19N2056_d.JPG,mimic
+19N2059,https://zenodo.org/record/4288311/files/19N2059_d.JPG,0,21523,malleti,21523_19N2059_d.JPG,mimic
+19N2060,https://zenodo.org/record/4288311/files/19N2060_d.JPG,0,21527,malleti,21527_19N2060_d.JPG,mimic
+19N2061,https://zenodo.org/record/4288311/files/19N2061_d.JPG,0,21531,malleti,21531_19N2061_d.JPG,mimic
+19N2063,https://zenodo.org/record/4288311/files/19N2063_d.JPG,0,21539,malleti,21539_19N2063_d.JPG,mimic
+19N2068,https://zenodo.org/record/4288311/files/19N2068_d.JPG,0,21547,malleti,21547_19N2068_d.JPG,mimic
+19N2070,https://zenodo.org/record/4288311/files/19N2070_d.JPG,0,21555,malleti,21555_19N2070_d.JPG,mimic
+19N2231,https://zenodo.org/record/4288311/files/19N2231_d.JPG,0,21851,malleti,21851_19N2231_d.JPG,mimic
+19N2141,https://zenodo.org/record/4288311/files/19N2141_d.JPG,0,21667,malleti,21667_19N2141_d.JPG,mimic
+19N2143,https://zenodo.org/record/4288311/files/19N2143_d.JPG,0,21675,malleti,21675_19N2143_d.JPG,mimic
+19N2216,https://zenodo.org/record/4288311/files/19N2216_d.JPG,0,21791,malleti,21791_19N2216_d.JPG,mimic
+19N2219,https://zenodo.org/record/4288311/files/19N2219_d.JPG,0,21803,malleti,21803_19N2219_d.JPG,mimic
+19N2220,https://zenodo.org/record/4288311/files/19N2220_d.JPG,0,21807,malleti,21807_19N2220_d.JPG,mimic
+19N2224,https://zenodo.org/record/4288311/files/19N2224_d.JPG,0,21823,malleti,21823_19N2224_d.JPG,mimic
+19N2225,https://zenodo.org/record/4288311/files/19N2225_d.JPG,0,21827,malleti,21827_19N2225_d.JPG,mimic
+19N2227,https://zenodo.org/record/4288311/files/19N2227_d.JPG,0,21835,malleti,21835_19N2227_d.JPG,mimic
+19N2228,https://zenodo.org/record/4288311/files/19N2228_d.JPG,0,21839,malleti,21839_19N2228_d.JPG,mimic
+19N2229,https://zenodo.org/record/4288311/files/19N2229_d.JPG,0,21843,malleti,21843_19N2229_d.JPG,mimic
+19N2221,https://zenodo.org/record/4288311/files/19N2221_d.JPG,0,21811,malleti,21811_19N2221_d.JPG,mimic
+19N2144,https://zenodo.org/record/4288311/files/19N2144_d.JPG,0,21679,malleti,21679_19N2144_d.JPG,mimic
+19N2158,https://zenodo.org/record/4288311/files/19N2158_d.JPG,0,21687,malleti,21687_19N2158_d.JPG,mimic
+19N2165,https://zenodo.org/record/4288311/files/19N2165_d.JPG,0,21695,malleti,21695_19N2165_d.JPG,mimic
+19N2166,https://zenodo.org/record/4288311/files/19N2166_d.JPG,0,21699,malleti,21699_19N2166_d.JPG,mimic
+19N2188,https://zenodo.org/record/4288311/files/19N2188_d.JPG,0,21719,malleti,21719_19N2188_d.JPG,mimic
+19N2189,https://zenodo.org/record/4288311/files/19N2189_d.JPG,0,21723,malleti,21723_19N2189_d.JPG,mimic
+19N2142,https://zenodo.org/record/4288311/files/19N2142_d.JPG,0,21671,malleti,21671_19N2142_d.JPG,mimic
+19N1974,https://zenodo.org/record/4288311/files/19N1974_d.JPG,0,21323,malleti,21323_19N1974_d.JPG,mimic
+19N2038,https://zenodo.org/record/4288311/files/19N2038_d.JPG,0,21479,malleti,21479_19N2038_d.JPG,mimic
+19N1735,https://zenodo.org/record/4288311/files/19N1735_d.JPG,0,20935,malleti,20935_19N1735_d.JPG,mimic
+19N1714,https://zenodo.org/record/4288311/files/19N1714_d.JPG,0,20899,malleti,20899_19N1714_d.JPG,mimic
+19N1699,https://zenodo.org/record/4288311/files/19N1699_d.JPG,0,20891,malleti,20891_19N1699_d.JPG,mimic
+19N1646,https://zenodo.org/record/4288311/files/19N1646_d.JPG,0,20835,malleti,20835_19N1646_d.JPG,mimic
+19N1743,https://zenodo.org/record/4288311/files/19N1743_d.JPG,0,20943,malleti,20943_19N1743_d.JPG,mimic
+19N1744,https://zenodo.org/record/4288311/files/19N1744_d.JPG,0,20947,malleti,20947_19N1744_d.JPG,mimic
+19N1745,https://zenodo.org/record/4288311/files/19N1745_d.JPG,0,20951,malleti,20951_19N1745_d.JPG,mimic
+19N1821,https://zenodo.org/record/4288311/files/19N1821_d.JPG,0,21071,malleti,21071_19N1821_d.JPG,mimic
+19N1820,https://zenodo.org/record/4288311/files/19N1820_d.JPG,0,21067,malleti,21067_19N1820_d.JPG,mimic
+19N1813,https://zenodo.org/record/4288311/files/19N1813_d.JPG,0,21059,malleti,21059_19N1813_d.JPG,mimic
+19N1810,https://zenodo.org/record/4288311/files/19N1810_d.JPG,0,21047,malleti,21047_19N1810_d.JPG,mimic
+19N1806,https://zenodo.org/record/4288311/files/19N1806_d.JPG,0,21039,malleti,21039_19N1806_d.JPG,mimic
+19N1771,https://zenodo.org/record/4288311/files/19N1771_d.JPG,0,20999,malleti,20999_19N1771_d.JPG,mimic
+19N1769,https://zenodo.org/record/4288311/files/19N1769_d.JPG,0,20991,malleti,20991_19N1769_d.JPG,mimic
+19N1763,https://zenodo.org/record/4288311/files/19N1763_d.JPG,0,20979,malleti,20979_19N1763_d.JPG,mimic
+19N1762,https://zenodo.org/record/4288311/files/19N1762_d.JPG,0,20975,malleti,20975_19N1762_d.JPG,mimic
+19N1761,https://zenodo.org/record/4288311/files/19N1761_d.JPG,0,20971,malleti,20971_19N1761_d.JPG,mimic
+19N1754,https://zenodo.org/record/4288311/files/19N1754_d.JPG,0,20967,malleti,20967_19N1754_d.JPG,mimic
+19N1379,https://zenodo.org/record/4288311/files/19N1379_d.JPG,0,20313,malleti,20313_19N1379_d.JPG,mimic
+19N1377,https://zenodo.org/record/4288311/files/19N1377_d.JPG,0,20309,malleti,20309_19N1377_d.JPG,mimic
+19N1373,https://zenodo.org/record/4288311/files/19N1373_d.JPG,0,20305,malleti,20305_19N1373_d.JPG,mimic
+19N1367,https://zenodo.org/record/4288311/files/19N1367_d.JPG,0,20301,malleti,20301_19N1367_d.JPG,mimic
+19N1363,https://zenodo.org/record/4288311/files/19N1363_d.JPG,0,20299,malleti,20299_19N1363_d.JPG,mimic
+19N1349,https://zenodo.org/record/4288311/files/19N1349_d.JPG,0,20289,malleti,20289_19N1349_d.JPG,mimic
+19N1348,https://zenodo.org/record/4288311/files/19N1348_d.JPG,0,20287,malleti,20287_19N1348_d.JPG,mimic
+19N1334,https://zenodo.org/record/4288311/files/19N1334_d.JPG,0,20283,malleti,20283_19N1334_d.JPG,mimic
+19N1333,https://zenodo.org/record/4288311/files/19N1333_d.JPG,0,20281,malleti,20281_19N1333_d.JPG,mimic
+19N1332,https://zenodo.org/record/4288311/files/19N1332_d.JPG,0,20279,malleti,20279_19N1332_d.JPG,mimic
+19N1318,https://zenodo.org/record/4288311/files/19N1318_d.JPG,0,20275,malleti,20275_19N1318_d.JPG,mimic
+19N1316,https://zenodo.org/record/4288311/files/19N1316_d.JPG,0,20271,malleti,20271_19N1316_d.JPG,mimic
+19N1312,https://zenodo.org/record/4288311/files/19N1312_d.JPG,0,20269,malleti,20269_19N1312_d.JPG,mimic
+19N1299,https://zenodo.org/record/4288311/files/19N1299_d.JPG,0,20267,malleti,20267_19N1299_d.JPG,mimic
+19N1298,https://zenodo.org/record/4288311/files/19N1298_d.JPG,0,20265,malleti,20265_19N1298_d.JPG,mimic
+19N1380,https://zenodo.org/record/4288311/files/19N1380_d.JPG,0,20315,malleti,20315_19N1380_d.JPG,mimic
+19N1381,https://zenodo.org/record/4288311/files/19N1381_d.JPG,0,20317,malleti,20317_19N1381_d.JPG,mimic
+19N1382,https://zenodo.org/record/4288311/files/19N1382_d.JPG,0,20319,malleti,20319_19N1382_d.JPG,mimic
+19N1471,https://zenodo.org/record/4288311/files/19N1471_d.JPG,0,20381,malleti,20381_19N1471_d.JPG,mimic
+19N1467,https://zenodo.org/record/4288311/files/19N1467_d.JPG,0,20379,malleti,20379_19N1467_d.JPG,mimic
+19N1446,https://zenodo.org/record/4288311/files/19N1446_d.JPG,0,20371,malleti,20371_19N1446_d.JPG,mimic
+19N1432,https://zenodo.org/record/4288311/files/19N1432_d.JPG,0,20363,malleti,20363_19N1432_d.JPG,mimic
+19N1426,https://zenodo.org/record/4288311/files/19N1426_d.JPG,0,20357,malleti,20357_19N1426_d.JPG,mimic
+19N1422,https://zenodo.org/record/4288311/files/19N1422_d.JPG,0,20353,malleti,20353_19N1422_d.JPG,mimic
+19N1421,https://zenodo.org/record/4288311/files/19N1421_d.JPG,0,20351,malleti,20351_19N1421_d.JPG,mimic
+19N1419,https://zenodo.org/record/4288311/files/19N1419_d.JPG,0,20347,malleti,20347_19N1419_d.JPG,mimic
+19N1398,https://zenodo.org/record/4288311/files/19N1398_d.JPG,0,20339,malleti,20339_19N1398_d.JPG,mimic
+19N1394,https://zenodo.org/record/4288311/files/19N1394_d.JPG,0,20333,malleti,20333_19N1394_d.JPG,mimic
+19N1393,https://zenodo.org/record/4288311/files/19N1393_d.JPG,0,20331,malleti,20331_19N1393_d.JPG,mimic
+19N1392,https://zenodo.org/record/4288311/files/19N1392_d.JPG,0,20329,malleti,20329_19N1392_d.JPG,mimic
+19N1389,https://zenodo.org/record/4288311/files/19N1389_d.JPG,0,20327,malleti,20327_19N1389_d.JPG,mimic
+19N1388,https://zenodo.org/record/4288311/files/19N1388_d.JPG,0,20325,malleti,20325_19N1388_d.JPG,mimic
+19N1387,https://zenodo.org/record/4288311/files/19N1387_d.JPG,0,20323,malleti,20323_19N1387_d.JPG,mimic
+19N1827,https://zenodo.org/record/4288311/files/19N1827_d.JPG,0,21087,malleti,21087_19N1827_d.JPG,mimic
+19N1912,https://zenodo.org/record/4288311/files/19N1912_d.JPG,0,21219,malleti,21219_19N1912_d.JPG,mimic
+19N1909,https://zenodo.org/record/4288311/files/19N1909_d.JPG,0,21215,malleti,21215_19N1909_d.JPG,mimic
+19N1908,https://zenodo.org/record/4288311/files/19N1908_d.JPG,0,21211,malleti,21211_19N1908_d.JPG,mimic
+19N1907,https://zenodo.org/record/4288311/files/19N1907_d.JPG,0,21207,malleti,21207_19N1907_d.JPG,mimic
+19N1896,https://zenodo.org/record/4288311/files/19N1896_d.JPG,0,21191,malleti,21191_19N1896_d.JPG,mimic
+19N1892,https://zenodo.org/record/4288311/files/19N1892_d.JPG,0,21183,malleti,21183_19N1892_d.JPG,mimic
+19N1890,https://zenodo.org/record/4288311/files/19N1890_d.JPG,0,21179,malleti,21179_19N1890_d.JPG,mimic
+19N1888,https://zenodo.org/record/4288311/files/19N1888_d.JPG,0,21171,malleti,21171_19N1888_d.JPG,mimic
+19N1877,https://zenodo.org/record/4288311/files/19N1877_d.JPG,0,21159,malleti,21159_19N1877_d.JPG,mimic
+19N1957,https://zenodo.org/record/4288311/files/19N1957_d.JPG,0,21299,malleti,21299_19N1957_d.JPG,mimic
+19N1876,https://zenodo.org/record/4288311/files/19N1876_d.JPG,0,21155,malleti,21155_19N1876_d.JPG,mimic
+19N1945,https://zenodo.org/record/4288311/files/19N1945_d.JPG,0,21275,malleti,21275_19N1945_d.JPG,mimic
+19N1932,https://zenodo.org/record/4288311/files/19N1932_d.JPG,0,21251,malleti,21251_19N1932_d.JPG,mimic
+19N1251,https://zenodo.org/record/4288311/files/19N1251_d.JPG,0,20253,malleti,20253_19N1251_d.JPG,mimic
+19N1867,https://zenodo.org/record/4288311/files/19N1867_d.JPG,0,21143,malleti,21143_19N1867_d.JPG,mimic
+19N1875,https://zenodo.org/record/4288311/files/19N1875_d.JPG,0,21151,malleti,21151_19N1875_d.JPG,mimic
+19N1864,https://zenodo.org/record/4288311/files/19N1864_d.JPG,0,21131,malleti,21131_19N1864_d.JPG,mimic
+19N1861,https://zenodo.org/record/4288311/files/19N1861_d.JPG,0,21123,malleti,21123_19N1861_d.JPG,mimic
+19N1857,https://zenodo.org/record/4288311/files/19N1857_d.JPG,0,21115,malleti,21115_19N1857_d.JPG,mimic
+19N1856,https://zenodo.org/record/4288311/files/19N1856_d.JPG,0,21111,malleti,21111_19N1856_d.JPG,mimic
+19N1855,https://zenodo.org/record/4288311/files/19N1855_d.JPG,0,21107,malleti,21107_19N1855_d.JPG,mimic
+19N1850,https://zenodo.org/record/4288311/files/19N1850_d.JPG,0,21103,malleti,21103_19N1850_d.JPG,mimic
+19N1845,https://zenodo.org/record/4288311/files/19N1845_d.JPG,0,21099,malleti,21099_19N1845_d.JPG,mimic
+19N1841,https://zenodo.org/record/4288311/files/19N1841_d.JPG,0,21095,malleti,21095_19N1841_d.JPG,mimic
+19N1860,https://zenodo.org/record/4288311/files/19N1860_d.JPG,0,21119,malleti,21119_19N1860_d.JPG,mimic
+15N261,https://zenodo.org/record/4289223/files/15N261_d.JPG,0,15220,venus,15220_15N261_d.JPG,minor
+15N145,https://zenodo.org/record/4289223/files/15N145_d.JPG,0,14957,venus,14957_15N145_d.JPG,minor
+15N146,https://zenodo.org/record/4289223/files/15N146_d.JPG,0,14959,venus,14959_15N146_d.JPG,minor
+15N149,https://zenodo.org/record/4289223/files/15N149_d.JPG,0,14961,venus,14961_15N149_d.JPG,minor
+15N192,https://zenodo.org/record/4289223/files/15N192_d.JPG,0,15202,venus,15202_15N192_d.JPG,minor
+15N193,https://zenodo.org/record/4289223/files/15N193_d.JPG,0,15204,venus,15204_15N193_d.JPG,minor
+15N194,https://zenodo.org/record/4289223/files/15N194_d.JPG,0,15206,venus,15206_15N194_d.JPG,minor
+15N195,https://zenodo.org/record/4289223/files/15N195_d.JPG,0,15208,venus,15208_15N195_d.JPG,minor
+15N238,https://zenodo.org/record/4289223/files/15N238_d.JPG,0,15210,venus,15210_15N238_d.JPG,minor
+15N239,https://zenodo.org/record/4289223/files/15N239_d.JPG,0,15212,venus,15212_15N239_d.JPG,minor
+15N241,https://zenodo.org/record/4289223/files/15N241_d.JPG,0,15216,venus,15216_15N241_d.JPG,minor
+15N136,https://zenodo.org/record/4289223/files/15N136_d.JPG,0,15184,chestertonii,15184_15N136_d.JPG,minor
+15N135,https://zenodo.org/record/4289223/files/15N135_d.JPG,0,15182,chestertonii,15182_15N135_d.JPG,minor
+15N101,https://zenodo.org/record/4289223/files/15N101_d.JPG,0,14953,venus,14953_15N101_d.JPG,minor
+15N111,https://zenodo.org/record/4289223/files/15N111_d.JPG,0,15169,venus,15169_15N111_d.JPG,minor
+15N112,https://zenodo.org/record/4289223/files/15N112_d.JPG,0,15171,venus,15171_15N112_d.JPG,minor
+15N113,https://zenodo.org/record/4289223/files/15N113_d.JPG,0,15173,venus,15173_15N113_d.JPG,minor
+15N115,https://zenodo.org/record/4289223/files/15N115_d.JPG,0,14955,venus,14955_15N115_d.JPG,minor
+15N120,https://zenodo.org/record/4289223/files/15N120_d.JPG,0,15174,venus,15174_15N120_d.JPG,minor
+15N121,https://zenodo.org/record/4289223/files/15N121_d.JPG,0,15176,venus,15176_15N121_d.JPG,minor
+CAM041525,https://zenodo.org/record/4291095/files/CAM041525_d.JPG,0,39072,malleti,39072_CAM041525_d.JPG,mimic
+CAM041524,https://zenodo.org/record/4291095/files/CAM041524_d.JPG,0,39068,malleti,39068_CAM041524_d.JPG,mimic
+CAM041517,https://zenodo.org/record/4291095/files/CAM041517_d.JPG,0,39040,malleti,39040_CAM041517_d.JPG,mimic
+CAM041526,https://zenodo.org/record/4291095/files/CAM041526_d.JPG,0,39076,malleti,39076_CAM041526_d.JPG,mimic
+CAM041500,https://zenodo.org/record/4291095/files/CAM041500_d.JPG,0,38972,malleti,38972_CAM041500_d.JPG,mimic
+CAM041499,https://zenodo.org/record/4291095/files/CAM041499_d.JPG,0,38968,malleti,38968_CAM041499_d.JPG,mimic
+CAM041498,https://zenodo.org/record/4291095/files/CAM041498_d.JPG,0,38964,malleti,38964_CAM041498_d.JPG,mimic
+CAM041497,https://zenodo.org/record/4291095/files/CAM041497_d.JPG,0,38960,malleti,38960_CAM041497_d.JPG,mimic
+CAM041496,https://zenodo.org/record/4291095/files/CAM041496_d.JPG,0,38956,malleti,38956_CAM041496_d.JPG,mimic
+CAM041582,https://zenodo.org/record/4291095/files/CAM041582_d.JPG,0,39296,malleti,39296_CAM041582_d.JPG,mimic
+CAM041581,https://zenodo.org/record/4291095/files/CAM041581_d.JPG,0,39292,malleti,39292_CAM041581_d.JPG,mimic
+CAM041580,https://zenodo.org/record/4291095/files/CAM041580_d.JPG,0,39288,malleti,39288_CAM041580_d.JPG,mimic
+CAM041579,https://zenodo.org/record/4291095/files/CAM041579_d.JPG,0,39284,malleti,39284_CAM041579_d.JPG,mimic
+CAM041578,https://zenodo.org/record/4291095/files/CAM041578_d.JPG,0,39280,malleti,39280_CAM041578_d.JPG,mimic
+CAM041577,https://zenodo.org/record/4291095/files/CAM041577_d.JPG,0,39276,malleti,39276_CAM041577_d.JPG,mimic
+CAM041576,https://zenodo.org/record/4291095/files/CAM041576_d.JPG,0,39272,malleti,39272_CAM041576_d.JPG,mimic
+CAM041557,https://zenodo.org/record/4291095/files/CAM041557_d.JPG,0,39196,malleti,39196_CAM041557_d.JPG,mimic
+CAM041547,https://zenodo.org/record/4291095/files/CAM041547_d.JPG,0,39160,malleti,39160_CAM041547_d.JPG,mimic
+CAM041546,https://zenodo.org/record/4291095/files/CAM041546_d.JPG,0,39156,malleti,39156_CAM041546_d.JPG,mimic
+CAM041542,https://zenodo.org/record/4291095/files/CAM041542_d.JPG,0,39140,malleti,39140_CAM041542_d.JPG,mimic
+CAM041372,https://zenodo.org/record/4291095/files/CAM041372_d.JPG,0,38468,malleti,38468_CAM041372_d.JPG,mimic
+CAM041371,https://zenodo.org/record/4291095/files/CAM041371_d.JPG,0,38464,malleti,38464_CAM041371_d.JPG,mimic
+CAM041369,https://zenodo.org/record/4291095/files/CAM041369_d.JPG,0,38456,malleti,38456_CAM041369_d.JPG,mimic
+CAM041368,https://zenodo.org/record/4291095/files/CAM041368_d.JPG,0,38452,malleti,38452_CAM041368_d.JPG,mimic
+CAM041367,https://zenodo.org/record/4291095/files/CAM041367_d.JPG,0,38448,malleti,38448_CAM041367_d.JPG,mimic
+CAM041475,https://zenodo.org/record/4291095/files/CAM041475_d.JPG,0,38868,malleti,38868_CAM041475_d.JPG,mimic
+CAM041458,https://zenodo.org/record/4291095/files/CAM041458_d.JPG,0,38804,malleti,38804_CAM041458_d.JPG,mimic
+CAM041456,https://zenodo.org/record/4291095/files/CAM041456_d.JPG,0,38796,malleti,38796_CAM041456_d.JPG,mimic
+CAM041403,https://zenodo.org/record/4291095/files/CAM041403_d.JPG,0,38584,malleti,38584_CAM041403_d.JPG,mimic
+CAM041400,https://zenodo.org/record/4291095/files/CAM041400_d.JPG,0,38572,malleti,38572_CAM041400_d.JPG,mimic
+CAM041587,https://zenodo.org/record/4291095/files/CAM041587_d.JPG,0,39315,malleti,39315_CAM041587_d.JPG,mimic
+CAM041588,https://zenodo.org/record/4291095/files/CAM041588_d.JPG,0,39319,malleti,39319_CAM041588_d.JPG,mimic
+CAM041803,https://zenodo.org/record/4291095/files/CAM041803_d.JPG,0,40179,lativitta,40179_CAM041803_d.JPG,major
+CAM041802,https://zenodo.org/record/4291095/files/CAM041802_d.JPG,0,40175,lativitta,40175_CAM041802_d.JPG,major
+CAM041801,https://zenodo.org/record/4291095/files/CAM041801_d.JPG,0,40171,lativitta,40171_CAM041801_d.JPG,major
+CAM041800,https://zenodo.org/record/4291095/files/CAM041800_d.JPG,0,40167,lativitta,40167_CAM041800_d.JPG,major
+CAM041799,https://zenodo.org/record/4291095/files/CAM041799_d.JPG,0,40163,lativitta,40163_CAM041799_d.JPG,major
+CAM041798,https://zenodo.org/record/4291095/files/CAM041798_d.JPG,0,40159,lativitta,40159_CAM041798_d.JPG,major
+CAM041797,https://zenodo.org/record/4291095/files/CAM041797_d.JPG,0,40155,lativitta,40155_CAM041797_d.JPG,major
+CAM041796,https://zenodo.org/record/4291095/files/CAM041796_d.JPG,0,40151,lativitta,40151_CAM041796_d.JPG,major
+CAM041795,https://zenodo.org/record/4291095/files/CAM041795_d.JPG,0,40147,lativitta,40147_CAM041795_d.JPG,major
+CAM041794,https://zenodo.org/record/4291095/files/CAM041794_d.JPG,0,40143,lativitta,40143_CAM041794_d.JPG,major
+CAM041793,https://zenodo.org/record/4291095/files/CAM041793_d.JPG,0,40139,lativitta,40139_CAM041793_d.JPG,major
+CAM041792,https://zenodo.org/record/4291095/files/CAM041792_d.JPG,0,40135,lativitta,40135_CAM041792_d.JPG,major
+CAM041791,https://zenodo.org/record/4291095/files/CAM041791_d.JPG,0,40131,lativitta,40131_CAM041791_d.JPG,major
+CAM041790,https://zenodo.org/record/4291095/files/CAM041790_d.JPG,0,40127,lativitta,40127_CAM041790_d.JPG,major
+CAM041789,https://zenodo.org/record/4291095/files/CAM041789_d.JPG,0,40123,lativitta,40123_CAM041789_d.JPG,major
+CAM041788,https://zenodo.org/record/4291095/files/CAM041788_d.JPG,0,40119,lativitta,40119_CAM041788_d.JPG,major
+CAM041787,https://zenodo.org/record/4291095/files/CAM041787_d.JPG,0,40115,lativitta,40115_CAM041787_d.JPG,major
+CAM041786,https://zenodo.org/record/4291095/files/CAM041786_d.JPG,0,40111,lativitta,40111_CAM041786_d.JPG,major
+CAM041785,https://zenodo.org/record/4291095/files/CAM041785_d.JPG,0,40107,lativitta,40107_CAM041785_d.JPG,major
+CAM041784,https://zenodo.org/record/4291095/files/CAM041784_d.JPG,0,40103,lativitta,40103_CAM041784_d.JPG,major
+CAM041783,https://zenodo.org/record/4291095/files/CAM041783_d.JPG,0,40099,lativitta,40099_CAM041783_d.JPG,major
+CAM041782,https://zenodo.org/record/4291095/files/CAM041782_d.JPG,0,40095,lativitta,40095_CAM041782_d.JPG,major
+CAM041780,https://zenodo.org/record/4291095/files/CAM041780_d.JPG,0,40087,lativitta,40087_CAM041780_d.JPG,major
+CAM041805,https://zenodo.org/record/4291095/files/CAM041805_d.JPG,0,40187,lativitta,40187_CAM041805_d.JPG,major
+CAM041753,https://zenodo.org/record/4291095/files/CAM041753_d.JPG,0,39979,lativitta,39979_CAM041753_d.JPG,major
+CAM041751,https://zenodo.org/record/4291095/files/CAM041751_d.JPG,0,39971,lativitta,39971_CAM041751_d.JPG,major
+CAM041723,https://zenodo.org/record/4291095/files/CAM041723_d.JPG,0,39859,lativitta,39859_CAM041723_d.JPG,major
+CAM041722,https://zenodo.org/record/4291095/files/CAM041722_d.JPG,0,39855,lativitta,39855_CAM041722_d.JPG,major
+CAM041721,https://zenodo.org/record/4291095/files/CAM041721_d.JPG,0,39851,lativitta,39851_CAM041721_d.JPG,major
+CAM041720,https://zenodo.org/record/4291095/files/CAM041720_d.JPG,0,39847,lativitta,39847_CAM041720_d.JPG,major
+CAM041719,https://zenodo.org/record/4291095/files/CAM041719_d.JPG,0,39843,lativitta,39843_CAM041719_d.JPG,major
+CAM041718,https://zenodo.org/record/4291095/files/CAM041718_d.JPG,0,39839,lativitta,39839_CAM041718_d.JPG,major
+CAM041717,https://zenodo.org/record/4291095/files/CAM041717_d.JPG,0,39835,lativitta,39835_CAM041717_d.JPG,major
+CAM041716,https://zenodo.org/record/4291095/files/CAM041716_d.JPG,0,39831,lativitta,39831_CAM041716_d.JPG,major
+CAM041715,https://zenodo.org/record/4291095/files/CAM041715_d.JPG,0,39827,lativitta,39827_CAM041715_d.JPG,major
+CAM041714,https://zenodo.org/record/4291095/files/CAM041714_d.JPG,0,39823,lativitta,39823_CAM041714_d.JPG,major
+CAM041713,https://zenodo.org/record/4291095/files/CAM041713_d.JPG,0,39819,lativitta,39819_CAM041713_d.JPG,major
+CAM041712,https://zenodo.org/record/4291095/files/CAM041712_d.JPG,0,39815,lativitta,39815_CAM041712_d.JPG,major
+CAM041711,https://zenodo.org/record/4291095/files/CAM041711_d.JPG,0,39811,lativitta,39811_CAM041711_d.JPG,major
+CAM041710,https://zenodo.org/record/4291095/files/CAM041710_d.JPG,0,39807,lativitta,39807_CAM041710_d.JPG,major
+CAM041709,https://zenodo.org/record/4291095/files/CAM041709_d.JPG,0,39803,lativitta,39803_CAM041709_d.JPG,major
+CAM041708,https://zenodo.org/record/4291095/files/CAM041708_d.JPG,0,39799,lativitta,39799_CAM041708_d.JPG,major
+CAM041707,https://zenodo.org/record/4291095/files/CAM041707_d.JPG,0,39795,lativitta,39795_CAM041707_d.JPG,major
+CAM041706,https://zenodo.org/record/4291095/files/CAM041706_d.JPG,0,39791,lativitta,39791_CAM041706_d.JPG,major
+CAM041705,https://zenodo.org/record/4291095/files/CAM041705_d.JPG,0,39787,lativitta,39787_CAM041705_d.JPG,major
+CAM041704,https://zenodo.org/record/4291095/files/CAM041704_d.JPG,0,39783,lativitta,39783_CAM041704_d.JPG,major
+CAM041703,https://zenodo.org/record/4291095/files/CAM041703_d.JPG,0,39779,lativitta,39779_CAM041703_d.JPG,major
+CAM041702,https://zenodo.org/record/4291095/files/CAM041702_d.JPG,0,39775,lativitta,39775_CAM041702_d.JPG,major
+CAM041701,https://zenodo.org/record/4291095/files/CAM041701_d.JPG,0,39771,lativitta,39771_CAM041701_d.JPG,major
+CAM041724,https://zenodo.org/record/4291095/files/CAM041724_d.JPG,0,39863,lativitta,39863_CAM041724_d.JPG,major
+CAM041752,https://zenodo.org/record/4291095/files/CAM041752_d.JPG,0,39975,lativitta,39975_CAM041752_d.JPG,major
+CAM041725,https://zenodo.org/record/4291095/files/CAM041725_d.JPG,0,39867,lativitta,39867_CAM041725_d.JPG,major
+CAM041727,https://zenodo.org/record/4291095/files/CAM041727_d.JPG,0,39875,lativitta,39875_CAM041727_d.JPG,major
+CAM041750,https://zenodo.org/record/4291095/files/CAM041750_d.JPG,0,39967,lativitta,39967_CAM041750_d.JPG,major
+CAM041749,https://zenodo.org/record/4291095/files/CAM041749_d.JPG,0,39963,lativitta,39963_CAM041749_d.JPG,major
+CAM041748,https://zenodo.org/record/4291095/files/CAM041748_d.JPG,0,39959,lativitta,39959_CAM041748_d.JPG,major
+CAM041747,https://zenodo.org/record/4291095/files/CAM041747_d.JPG,0,39955,lativitta,39955_CAM041747_d.JPG,major
+CAM041746,https://zenodo.org/record/4291095/files/CAM041746_d.JPG,0,39951,lativitta,39951_CAM041746_d.JPG,major
+CAM041745,https://zenodo.org/record/4291095/files/CAM041745_d.JPG,0,39947,lativitta,39947_CAM041745_d.JPG,major
+CAM041744,https://zenodo.org/record/4291095/files/CAM041744_d.JPG,0,39943,lativitta,39943_CAM041744_d.JPG,major
+CAM041743,https://zenodo.org/record/4291095/files/CAM041743_d.JPG,0,39939,lativitta,39939_CAM041743_d.JPG,major
+CAM041742,https://zenodo.org/record/4291095/files/CAM041742_d.JPG,0,39935,lativitta,39935_CAM041742_d.JPG,major
+CAM041741,https://zenodo.org/record/4291095/files/CAM041741_d.JPG,0,39931,lativitta,39931_CAM041741_d.JPG,major
+CAM041740,https://zenodo.org/record/4291095/files/CAM041740_d.JPG,0,39927,lativitta,39927_CAM041740_d.JPG,major
+CAM041739,https://zenodo.org/record/4291095/files/CAM041739_d.JPG,0,39923,lativitta,39923_CAM041739_d.JPG,major
+CAM041738,https://zenodo.org/record/4291095/files/CAM041738_d.JPG,0,39919,lativitta,39919_CAM041738_d.JPG,major
+CAM041737,https://zenodo.org/record/4291095/files/CAM041737_d.JPG,0,39915,lativitta,39915_CAM041737_d.JPG,major
+CAM041736,https://zenodo.org/record/4291095/files/CAM041736_d.JPG,0,39911,lativitta,39911_CAM041736_d.JPG,major
+CAM041735,https://zenodo.org/record/4291095/files/CAM041735_d.JPG,0,39907,lativitta,39907_CAM041735_d.JPG,major
+CAM041734,https://zenodo.org/record/4291095/files/CAM041734_d.JPG,0,39903,lativitta,39903_CAM041734_d.JPG,major
+CAM041733,https://zenodo.org/record/4291095/files/CAM041733_d.JPG,0,39899,lativitta,39899_CAM041733_d.JPG,major
+CAM041732,https://zenodo.org/record/4291095/files/CAM041732_d.JPG,0,39895,lativitta,39895_CAM041732_d.JPG,major
+CAM041731,https://zenodo.org/record/4291095/files/CAM041731_d.JPG,0,39891,lativitta,39891_CAM041731_d.JPG,major
+CAM041730,https://zenodo.org/record/4291095/files/CAM041730_d.JPG,0,39887,lativitta,39887_CAM041730_d.JPG,major
+CAM041729,https://zenodo.org/record/4291095/files/CAM041729_d.JPG,0,39883,lativitta,39883_CAM041729_d.JPG,major
+CAM041728,https://zenodo.org/record/4291095/files/CAM041728_d.JPG,0,39879,lativitta,39879_CAM041728_d.JPG,major
+CAM041726,https://zenodo.org/record/4291095/files/CAM041726_d.JPG,0,39871,lativitta,39871_CAM041726_d.JPG,major
+CAM041806,https://zenodo.org/record/4291095/files/CAM041806_d.JPG,0,40191,lativitta,40191_CAM041806_d.JPG,major
+CAM041779,https://zenodo.org/record/4291095/files/CAM041779_d.JPG,0,40083,lativitta,40083_CAM041779_d.JPG,major
+CAM041808,https://zenodo.org/record/4291095/files/CAM041808_d.JPG,0,40199,lativitta,40199_CAM041808_d.JPG,major
+CAM041885,https://zenodo.org/record/4291095/files/CAM041885_d.JPG,0,40504,lativitta,40504_CAM041885_d.JPG,major
+CAM041884,https://zenodo.org/record/4291095/files/CAM041884_d.JPG,0,40500,lativitta,40500_CAM041884_d.JPG,major
+CAM041883,https://zenodo.org/record/4291095/files/CAM041883_d.JPG,0,40496,lativitta,40496_CAM041883_d.JPG,major
+CAM041882,https://zenodo.org/record/4291095/files/CAM041882_d.JPG,0,40492,lativitta,40492_CAM041882_d.JPG,major
+CAM041881,https://zenodo.org/record/4291095/files/CAM041881_d.JPG,0,40488,lativitta,40488_CAM041881_d.JPG,major
+CAM041880,https://zenodo.org/record/4291095/files/CAM041880_d.JPG,0,40484,lativitta,40484_CAM041880_d.JPG,major
+CAM041879,https://zenodo.org/record/4291095/files/CAM041879_d.JPG,0,40480,lativitta,40480_CAM041879_d.JPG,major
+CAM041878,https://zenodo.org/record/4291095/files/CAM041878_d.JPG,0,40476,lativitta,40476_CAM041878_d.JPG,major
+CAM041877,https://zenodo.org/record/4291095/files/CAM041877_d.JPG,0,40472,lativitta,40472_CAM041877_d.JPG,major
+CAM041876,https://zenodo.org/record/4291095/files/CAM041876_d.JPG,0,40468,lativitta,40468_CAM041876_d.JPG,major
+CAM041886,https://zenodo.org/record/4291095/files/CAM041886_d.JPG,0,40508,lativitta,40508_CAM041886_d.JPG,major
+CAM041875,https://zenodo.org/record/4291095/files/CAM041875_d.JPG,0,40464,lativitta,40464_CAM041875_d.JPG,major
+CAM041873,https://zenodo.org/record/4291095/files/CAM041873_d.JPG,0,40456,lativitta,40456_CAM041873_d.JPG,major
+CAM041872,https://zenodo.org/record/4291095/files/CAM041872_d.JPG,0,40452,lativitta,40452_CAM041872_d.JPG,major
+CAM041871,https://zenodo.org/record/4291095/files/CAM041871_d.JPG,0,40448,lativitta,40448_CAM041871_d.JPG,major
+CAM041870,https://zenodo.org/record/4291095/files/CAM041870_d.JPG,0,40444,lativitta,40444_CAM041870_d.JPG,major
+CAM041869,https://zenodo.org/record/4291095/files/CAM041869_d.JPG,0,40440,lativitta,40440_CAM041869_d.JPG,major
+CAM041868,https://zenodo.org/record/4291095/files/CAM041868_d.JPG,0,40436,lativitta,40436_CAM041868_d.JPG,major
+CAM041867,https://zenodo.org/record/4291095/files/CAM041867_d.JPG,0,40432,lativitta,40432_CAM041867_d.JPG,major
+CAM041866,https://zenodo.org/record/4291095/files/CAM041866_d.JPG,0,40428,lativitta,40428_CAM041866_d.JPG,major
+CAM041865,https://zenodo.org/record/4291095/files/CAM041865_d.JPG,0,40424,lativitta,40424_CAM041865_d.JPG,major
+CAM041864,https://zenodo.org/record/4291095/files/CAM041864_d.JPG,0,40420,lativitta,40420_CAM041864_d.JPG,major
+CAM041874,https://zenodo.org/record/4291095/files/CAM041874_d.JPG,0,40460,lativitta,40460_CAM041874_d.JPG,major
+CAM041888,https://zenodo.org/record/4291095/files/CAM041888_d.JPG,0,40516,lativitta,40516_CAM041888_d.JPG,major
+CAM041807,https://zenodo.org/record/4291095/files/CAM041807_d.JPG,0,40195,lativitta,40195_CAM041807_d.JPG,major
+CAM041890,https://zenodo.org/record/4291095/files/CAM041890_d.JPG,0,40524,lativitta,40524_CAM041890_d.JPG,major
+CAM041354,https://zenodo.org/record/4291095/files/CAM041354_d.JPG,0,38396,lativitta,38396_CAM041354_d.JPG,major
+CAM041912,https://zenodo.org/record/4291095/files/CAM041912_d.JPG,0,40612,lativitta,40612_CAM041912_d.JPG,major
+CAM041911,https://zenodo.org/record/4291095/files/CAM041911_d.JPG,0,40608,lativitta,40608_CAM041911_d.JPG,major
+CAM041910,https://zenodo.org/record/4291095/files/CAM041910_d.JPG,0,40604,lativitta,40604_CAM041910_d.JPG,major
+CAM041909,https://zenodo.org/record/4291095/files/CAM041909_d.JPG,0,40600,lativitta,40600_CAM041909_d.JPG,major
+CAM041908,https://zenodo.org/record/4291095/files/CAM041908_d.JPG,0,40596,lativitta,40596_CAM041908_d.JPG,major
+CAM041907,https://zenodo.org/record/4291095/files/CAM041907_d.JPG,0,40592,lativitta,40592_CAM041907_d.JPG,major
+CAM041906,https://zenodo.org/record/4291095/files/CAM041906_d.JPG,0,40588,lativitta,40588_CAM041906_d.JPG,major
+CAM041905,https://zenodo.org/record/4291095/files/CAM041905_d.JPG,0,40584,lativitta,40584_CAM041905_d.JPG,major
+CAM041904,https://zenodo.org/record/4291095/files/CAM041904_d.JPG,0,40580,lativitta,40580_CAM041904_d.JPG,major
+CAM041903,https://zenodo.org/record/4291095/files/CAM041903_d.JPG,0,40576,lativitta,40576_CAM041903_d.JPG,major
+CAM041902,https://zenodo.org/record/4291095/files/CAM041902_d.JPG,0,40572,lativitta,40572_CAM041902_d.JPG,major
+CAM041901,https://zenodo.org/record/4291095/files/CAM041901_d.JPG,0,40568,lativitta,40568_CAM041901_d.JPG,major
+CAM041900,https://zenodo.org/record/4291095/files/CAM041900_d.JPG,0,40564,lativitta,40564_CAM041900_d.JPG,major
+CAM041899,https://zenodo.org/record/4291095/files/CAM041899_d.JPG,0,40560,lativitta,40560_CAM041899_d.JPG,major
+CAM041898,https://zenodo.org/record/4291095/files/CAM041898_d.JPG,0,40556,lativitta,40556_CAM041898_d.JPG,major
+CAM041897,https://zenodo.org/record/4291095/files/CAM041897_d.JPG,0,40552,lativitta,40552_CAM041897_d.JPG,major
+CAM041896,https://zenodo.org/record/4291095/files/CAM041896_d.JPG,0,40548,lativitta,40548_CAM041896_d.JPG,major
+CAM041895,https://zenodo.org/record/4291095/files/CAM041895_d.JPG,0,40544,lativitta,40544_CAM041895_d.JPG,major
+CAM041894,https://zenodo.org/record/4291095/files/CAM041894_d.JPG,0,40540,lativitta,40540_CAM041894_d.JPG,major
+CAM041893,https://zenodo.org/record/4291095/files/CAM041893_d.JPG,0,40536,lativitta,40536_CAM041893_d.JPG,major
+CAM041892,https://zenodo.org/record/4291095/files/CAM041892_d.JPG,0,40532,lativitta,40532_CAM041892_d.JPG,major
+CAM041891,https://zenodo.org/record/4291095/files/CAM041891_d.JPG,0,40528,lativitta,40528_CAM041891_d.JPG,major
+CAM041863,https://zenodo.org/record/4291095/files/CAM041863_d.JPG,0,40416,lativitta,40416_CAM041863_d.JPG,major
+CAM041862,https://zenodo.org/record/4291095/files/CAM041862_d.JPG,0,40412,lativitta,40412_CAM041862_d.JPG,major
+CAM041889,https://zenodo.org/record/4291095/files/CAM041889_d.JPG,0,40520,lativitta,40520_CAM041889_d.JPG,major
+CAM041860,https://zenodo.org/record/4291095/files/CAM041860_d.JPG,0,40404,lativitta,40404_CAM041860_d.JPG,major
+CAM041831,https://zenodo.org/record/4291095/files/CAM041831_d.JPG,0,40291,lativitta,40291_CAM041831_d.JPG,major
+CAM041830,https://zenodo.org/record/4291095/files/CAM041830_d.JPG,0,40287,lativitta,40287_CAM041830_d.JPG,major
+CAM041829,https://zenodo.org/record/4291095/files/CAM041829_d.JPG,0,40283,lativitta,40283_CAM041829_d.JPG,major
+CAM041828,https://zenodo.org/record/4291095/files/CAM041828_d.JPG,0,40279,lativitta,40279_CAM041828_d.JPG,major
+CAM041827,https://zenodo.org/record/4291095/files/CAM041827_d.JPG,0,40275,lativitta,40275_CAM041827_d.JPG,major
+CAM041826,https://zenodo.org/record/4291095/files/CAM041826_d.JPG,0,40271,lativitta,40271_CAM041826_d.JPG,major
+CAM041825,https://zenodo.org/record/4291095/files/CAM041825_d.JPG,0,40267,lativitta,40267_CAM041825_d.JPG,major
+CAM041824,https://zenodo.org/record/4291095/files/CAM041824_d.JPG,0,40263,lativitta,40263_CAM041824_d.JPG,major
+CAM041823,https://zenodo.org/record/4291095/files/CAM041823_d.JPG,0,40259,lativitta,40259_CAM041823_d.JPG,major
+CAM041822,https://zenodo.org/record/4291095/files/CAM041822_d.JPG,0,40255,lativitta,40255_CAM041822_d.JPG,major
+CAM041820,https://zenodo.org/record/4291095/files/CAM041820_d.JPG,0,40247,lativitta,40247_CAM041820_d.JPG,major
+CAM041819,https://zenodo.org/record/4291095/files/CAM041819_d.JPG,0,40243,lativitta,40243_CAM041819_d.JPG,major
+CAM041818,https://zenodo.org/record/4291095/files/CAM041818_d.JPG,0,40239,lativitta,40239_CAM041818_d.JPG,major
+CAM041817,https://zenodo.org/record/4291095/files/CAM041817_d.JPG,0,40235,lativitta,40235_CAM041817_d.JPG,major
+CAM041816,https://zenodo.org/record/4291095/files/CAM041816_d.JPG,0,40231,lativitta,40231_CAM041816_d.JPG,major
+CAM041815,https://zenodo.org/record/4291095/files/CAM041815_d.JPG,0,40227,lativitta,40227_CAM041815_d.JPG,major
+CAM041814,https://zenodo.org/record/4291095/files/CAM041814_d.JPG,0,40223,lativitta,40223_CAM041814_d.JPG,major
+CAM041813,https://zenodo.org/record/4291095/files/CAM041813_d.JPG,0,40219,lativitta,40219_CAM041813_d.JPG,major
+CAM041812,https://zenodo.org/record/4291095/files/CAM041812_d.JPG,0,40215,lativitta,40215_CAM041812_d.JPG,major
+CAM041811,https://zenodo.org/record/4291095/files/CAM041811_d.JPG,0,40211,lativitta,40211_CAM041811_d.JPG,major
+CAM041810,https://zenodo.org/record/4291095/files/CAM041810_d.JPG,0,40207,lativitta,40207_CAM041810_d.JPG,major
+CAM041861,https://zenodo.org/record/4291095/files/CAM041861_d.JPG,0,40408,lativitta,40408_CAM041861_d.JPG,major
+CAM041809,https://zenodo.org/record/4291095/files/CAM041809_d.JPG,0,40203,lativitta,40203_CAM041809_d.JPG,major
+CAM041832,https://zenodo.org/record/4291095/files/CAM041832_d.JPG,0,40295,lativitta,40295_CAM041832_d.JPG,major
+CAM041833,https://zenodo.org/record/4291095/files/CAM041833_d.JPG,0,40299,lativitta,40299_CAM041833_d.JPG,major
+CAM041821,https://zenodo.org/record/4291095/files/CAM041821_d.JPG,0,40251,lativitta,40251_CAM041821_d.JPG,major
+CAM041851,https://zenodo.org/record/4291095/files/CAM041851_d.JPG,0,40371,lativitta,40371_CAM041851_d.JPG,major
+CAM041859,https://zenodo.org/record/4291095/files/CAM041859_d.JPG,0,40400,lativitta,40400_CAM041859_d.JPG,major
+CAM041834,https://zenodo.org/record/4291095/files/CAM041834_d.JPG,0,40303,lativitta,40303_CAM041834_d.JPG,major
+CAM041857,https://zenodo.org/record/4291095/files/CAM041857_d.JPG,0,40392,lativitta,40392_CAM041857_d.JPG,major
+CAM041856,https://zenodo.org/record/4291095/files/CAM041856_d.JPG,0,40388,lativitta,40388_CAM041856_d.JPG,major
+CAM041855,https://zenodo.org/record/4291095/files/CAM041855_d.JPG,0,40384,lativitta,40384_CAM041855_d.JPG,major
+CAM041853,https://zenodo.org/record/4291095/files/CAM041853_d.JPG,0,40379,lativitta,40379_CAM041853_d.JPG,major
+CAM041852,https://zenodo.org/record/4291095/files/CAM041852_d.JPG,0,40375,lativitta,40375_CAM041852_d.JPG,major
+CAM041850,https://zenodo.org/record/4291095/files/CAM041850_d.JPG,0,40367,lativitta,40367_CAM041850_d.JPG,major
+CAM041849,https://zenodo.org/record/4291095/files/CAM041849_d.JPG,0,40363,lativitta,40363_CAM041849_d.JPG,major
+CAM041848,https://zenodo.org/record/4291095/files/CAM041848_d.JPG,0,40359,lativitta,40359_CAM041848_d.JPG,major
+CAM041858,https://zenodo.org/record/4291095/files/CAM041858_d.JPG,0,40396,lativitta,40396_CAM041858_d.JPG,major
+CAM041846,https://zenodo.org/record/4291095/files/CAM041846_d.JPG,0,40351,lativitta,40351_CAM041846_d.JPG,major
+CAM041847,https://zenodo.org/record/4291095/files/CAM041847_d.JPG,0,40355,lativitta,40355_CAM041847_d.JPG,major
+CAM041845,https://zenodo.org/record/4291095/files/CAM041845_d.JPG,0,40347,lativitta,40347_CAM041845_d.JPG,major
+CAM041844,https://zenodo.org/record/4291095/files/CAM041844_d.JPG,0,40343,lativitta,40343_CAM041844_d.JPG,major
+CAM041843,https://zenodo.org/record/4291095/files/CAM041843_d.JPG,0,40339,lativitta,40339_CAM041843_d.JPG,major
+CAM041842,https://zenodo.org/record/4291095/files/CAM041842_d.JPG,0,40335,lativitta,40335_CAM041842_d.JPG,major
+CAM041841,https://zenodo.org/record/4291095/files/CAM041841_d.JPG,0,40331,lativitta,40331_CAM041841_d.JPG,major
+CAM041840,https://zenodo.org/record/4291095/files/CAM041840_d.JPG,0,40327,lativitta,40327_CAM041840_d.JPG,major
+CAM041839,https://zenodo.org/record/4291095/files/CAM041839_d.JPG,0,40323,lativitta,40323_CAM041839_d.JPG,major
+CAM041838,https://zenodo.org/record/4291095/files/CAM041838_d.JPG,0,40319,lativitta,40319_CAM041838_d.JPG,major
+CAM041837,https://zenodo.org/record/4291095/files/CAM041837_d.JPG,0,40315,lativitta,40315_CAM041837_d.JPG,major
+CAM041836,https://zenodo.org/record/4291095/files/CAM041836_d.JPG,0,40311,lativitta,40311_CAM041836_d.JPG,major
+CAM041835,https://zenodo.org/record/4291095/files/CAM041835_d.JPG,0,40307,lativitta,40307_CAM041835_d.JPG,major
+CAM045262,https://zenodo.org/record/5526257/files/CAM045262_d.JPG,0,43611,cyrbia,43611_CAM045262_d.JPG,minor
+CAM045263,https://zenodo.org/record/5526257/files/CAM045263_d.JPG,0,43615,cyrbia,43615_CAM045263_d.JPG,minor
+CAM045248,https://zenodo.org/record/5526257/files/CAM045248_d.JPG,0,43555,cyrbia,43555_CAM045248_d.JPG,minor
+CAM045264,https://zenodo.org/record/5526257/files/CAM045264_d.JPG,0,43619,cyrbia,43619_CAM045264_d.JPG,minor
+CAM045230,https://zenodo.org/record/5526257/files/CAM045230_d.JPG,0,43483,cyrbia,43483_CAM045230_d.JPG,minor
+CAM045228,https://zenodo.org/record/5526257/files/CAM045228_d.JPG,0,43475,cyrbia,43475_CAM045228_d.JPG,minor
+CAM045136,https://zenodo.org/record/5526257/files/CAM045136_d.JPG,0,43111,cyrbia,43111_CAM045136_d.JPG,minor
+CAM045199,https://zenodo.org/record/5526257/files/CAM045199_d.JPG,0,43361,cyrbia,43361_CAM045199_d.JPG,minor
+CAM045200,https://zenodo.org/record/5526257/files/CAM045200_d.JPG,0,43365,cyrbia,43365_CAM045200_d.JPG,minor
+CAM045201,https://zenodo.org/record/5526257/files/CAM045201_d.JPG,0,43367,cyrbia,43367_CAM045201_d.JPG,minor
+CAM045202,https://zenodo.org/record/5526257/files/CAM045202_d.JPG,0,43371,cyrbia,43371_CAM045202_d.JPG,minor
+CAM045203,https://zenodo.org/record/5526257/files/CAM045203_d.JPG,0,43375,cyrbia,43375_CAM045203_d.JPG,minor
+CAM045204,https://zenodo.org/record/5526257/files/CAM045204_d.JPG,0,43379,cyrbia,43379_CAM045204_d.JPG,minor
+CAM045205,https://zenodo.org/record/5526257/files/CAM045205_d.JPG,0,43383,cyrbia,43383_CAM045205_d.JPG,minor
+CAM045206,https://zenodo.org/record/5526257/files/CAM045206_d.JPG,0,43387,cyrbia,43387_CAM045206_d.JPG,minor
+CAM045207,https://zenodo.org/record/5526257/files/CAM045207_d.JPG,0,43391,cyrbia,43391_CAM045207_d.JPG,minor
+CAM045208,https://zenodo.org/record/5526257/files/CAM045208_d.JPG,0,43395,cyrbia,43395_CAM045208_d.JPG,minor
+CAM045209,https://zenodo.org/record/5526257/files/CAM045209_d.JPG,0,43399,cyrbia,43399_CAM045209_d.JPG,minor
+CAM045210,https://zenodo.org/record/5526257/files/CAM045210_d.JPG,0,43403,cyrbia,43403_CAM045210_d.JPG,minor
+CAM045211,https://zenodo.org/record/5526257/files/CAM045211_d.JPG,0,43407,cyrbia,43407_CAM045211_d.JPG,minor
+CAM045229,https://zenodo.org/record/5526257/files/CAM045229_d.JPG,0,43479,cyrbia,43479_CAM045229_d.JPG,minor
+CAM045212,https://zenodo.org/record/5526257/files/CAM045212_d.JPG,0,43411,cyrbia,43411_CAM045212_d.JPG,minor
+CAM045214,https://zenodo.org/record/5526257/files/CAM045214_d.JPG,0,43419,cyrbia,43419_CAM045214_d.JPG,minor
+CAM045215,https://zenodo.org/record/5526257/files/CAM045215_d.JPG,0,43423,cyrbia,43423_CAM045215_d.JPG,minor
+CAM045216,https://zenodo.org/record/5526257/files/CAM045216_d.JPG,0,43427,cyrbia,43427_CAM045216_d.JPG,minor
+CAM045217,https://zenodo.org/record/5526257/files/CAM045217_d.JPG,0,43431,cyrbia,43431_CAM045217_d.JPG,minor
+CAM045218,https://zenodo.org/record/5526257/files/CAM045218_d.JPG,0,43435,cyrbia,43435_CAM045218_d.JPG,minor
+CAM045219,https://zenodo.org/record/5526257/files/CAM045219_d.JPG,0,43439,cyrbia,43439_CAM045219_d.JPG,minor
+CAM045220,https://zenodo.org/record/5526257/files/CAM045220_d.JPG,0,43443,cyrbia,43443_CAM045220_d.JPG,minor
+CAM045221,https://zenodo.org/record/5526257/files/CAM045221_d.JPG,0,43447,cyrbia,43447_CAM045221_d.JPG,minor
+CAM045222,https://zenodo.org/record/5526257/files/CAM045222_d.JPG,0,43451,cyrbia,43451_CAM045222_d.JPG,minor
+CAM045223,https://zenodo.org/record/5526257/files/CAM045223_d.JPG,0,43455,cyrbia,43455_CAM045223_d.JPG,minor
+CAM045224,https://zenodo.org/record/5526257/files/CAM045224_d.JPG,0,43459,cyrbia,43459_CAM045224_d.JPG,minor
+CAM045225,https://zenodo.org/record/5526257/files/CAM045225_d.JPG,0,43463,cyrbia,43463_CAM045225_d.JPG,minor
+CAM045226,https://zenodo.org/record/5526257/files/CAM045226_d.JPG,0,43467,cyrbia,43467_CAM045226_d.JPG,minor
+CAM045227,https://zenodo.org/record/5526257/files/CAM045227_d.JPG,0,43471,cyrbia,43471_CAM045227_d.JPG,minor
+CAM045213,https://zenodo.org/record/5526257/files/CAM045213_d.JPG,0,43415,cyrbia,43415_CAM045213_d.JPG,minor
+CAM045265,https://zenodo.org/record/5526257/files/CAM045265_d.JPG,0,43623,cyrbia,43623_CAM045265_d.JPG,minor
+CAM045251,https://zenodo.org/record/5526257/files/CAM045251_d.JPG,0,43567,cyrbia,43567_CAM045251_d.JPG,minor
+CAM045198,https://zenodo.org/record/5526257/files/CAM045198_d.JPG,0,43357,cyrbia,43357_CAM045198_d.JPG,minor
+CAM045168,https://zenodo.org/record/5526257/files/CAM045168_d.JPG,0,43237,cyrbia,43237_CAM045168_d.JPG,minor
+CAM045167,https://zenodo.org/record/5526257/files/CAM045167_d.JPG,0,43233,cyrbia,43233_CAM045167_d.JPG,minor
+CAM045166,https://zenodo.org/record/5526257/files/CAM045166_d.JPG,0,43229,cyrbia,43229_CAM045166_d.JPG,minor
+CAM045165,https://zenodo.org/record/5526257/files/CAM045165_d.JPG,0,43225,cyrbia,43225_CAM045165_d.JPG,minor
+CAM045164,https://zenodo.org/record/5526257/files/CAM045164_d.JPG,0,43221,cyrbia,43221_CAM045164_d.JPG,minor
+CAM045163,https://zenodo.org/record/5526257/files/CAM045163_d.JPG,0,43217,cyrbia,43217_CAM045163_d.JPG,minor
+CAM045162,https://zenodo.org/record/5526257/files/CAM045162_d.JPG,0,43213,cyrbia,43213_CAM045162_d.JPG,minor
+CAM045161,https://zenodo.org/record/5526257/files/CAM045161_d.JPG,0,43209,cyrbia,43209_CAM045161_d.JPG,minor
+CAM045160,https://zenodo.org/record/5526257/files/CAM045160_d.JPG,0,43205,cyrbia,43205_CAM045160_d.JPG,minor
+CAM045159,https://zenodo.org/record/5526257/files/CAM045159_d.JPG,0,43201,cyrbia,43201_CAM045159_d.JPG,minor
+CAM045158,https://zenodo.org/record/5526257/files/CAM045158_d.JPG,0,43197,cyrbia,43197_CAM045158_d.JPG,minor
+CAM045157,https://zenodo.org/record/5526257/files/CAM045157_d.JPG,0,43193,cyrbia,43193_CAM045157_d.JPG,minor
+CAM045266,https://zenodo.org/record/5526257/files/CAM045266_d.JPG,0,43627,cyrbia,43627_CAM045266_d.JPG,minor
+CAM045155,https://zenodo.org/record/5526257/files/CAM045155_d.JPG,0,43187,cyrbia,43187_CAM045155_d.JPG,minor
+CAM045154,https://zenodo.org/record/5526257/files/CAM045154_d.JPG,0,43183,cyrbia,43183_CAM045154_d.JPG,minor
+CAM045153,https://zenodo.org/record/5526257/files/CAM045153_d.JPG,0,43179,cyrbia,43179_CAM045153_d.JPG,minor
+CAM045152,https://zenodo.org/record/5526257/files/CAM045152_d.JPG,0,43175,cyrbia,43175_CAM045152_d.JPG,minor
+CAM045138,https://zenodo.org/record/5526257/files/CAM045138_d.JPG,0,43119,cyrbia,43119_CAM045138_d.JPG,minor
+CAM045139,https://zenodo.org/record/5526257/files/CAM045139_d.JPG,0,43123,cyrbia,43123_CAM045139_d.JPG,minor
+CAM045140,https://zenodo.org/record/5526257/files/CAM045140_d.JPG,0,43127,cyrbia,43127_CAM045140_d.JPG,minor
+CAM045141,https://zenodo.org/record/5526257/files/CAM045141_d.JPG,0,43131,cyrbia,43131_CAM045141_d.JPG,minor
+CAM045142,https://zenodo.org/record/5526257/files/CAM045142_d.JPG,0,43135,cyrbia,43135_CAM045142_d.JPG,minor
+CAM045143,https://zenodo.org/record/5526257/files/CAM045143_d.JPG,0,43139,cyrbia,43139_CAM045143_d.JPG,minor
+CAM045169,https://zenodo.org/record/5526257/files/CAM045169_d.JPG,0,43241,cyrbia,43241_CAM045169_d.JPG,minor
+CAM045144,https://zenodo.org/record/5526257/files/CAM045144_d.JPG,0,43143,cyrbia,43143_CAM045144_d.JPG,minor
+CAM045146,https://zenodo.org/record/5526257/files/CAM045146_d.JPG,0,43151,cyrbia,43151_CAM045146_d.JPG,minor
+CAM045147,https://zenodo.org/record/5526257/files/CAM045147_d.JPG,0,43155,cyrbia,43155_CAM045147_d.JPG,minor
+CAM045148,https://zenodo.org/record/5526257/files/CAM045148_d.JPG,0,43159,cyrbia,43159_CAM045148_d.JPG,minor
+CAM045149,https://zenodo.org/record/5526257/files/CAM045149_d.JPG,0,43163,cyrbia,43163_CAM045149_d.JPG,minor
+CAM045150,https://zenodo.org/record/5526257/files/CAM045150_d.JPG,0,43167,cyrbia,43167_CAM045150_d.JPG,minor
+CAM045151,https://zenodo.org/record/5526257/files/CAM045151_d.JPG,0,43171,cyrbia,43171_CAM045151_d.JPG,minor
+CAM045145,https://zenodo.org/record/5526257/files/CAM045145_d.JPG,0,43147,cyrbia,43147_CAM045145_d.JPG,minor
+CAM045170,https://zenodo.org/record/5526257/files/CAM045170_d.JPG,0,43245,cyrbia,43245_CAM045170_d.JPG,minor
+CAM045156,https://zenodo.org/record/5526257/files/CAM045156_d.JPG,0,43191,cyrbia,43191_CAM045156_d.JPG,minor
+CAM045172,https://zenodo.org/record/5526257/files/CAM045172_d.JPG,0,43253,cyrbia,43253_CAM045172_d.JPG,minor
+CAM045267,https://zenodo.org/record/5526257/files/CAM045267_d.JPG,0,43631,cyrbia,43631_CAM045267_d.JPG,minor
+CAM045171,https://zenodo.org/record/5526257/files/CAM045171_d.JPG,0,43249,cyrbia,43249_CAM045171_d.JPG,minor
+CAM045269,https://zenodo.org/record/5526257/files/CAM045269_d.JPG,0,43639,cyrbia,43639_CAM045269_d.JPG,minor
+CAM045270,https://zenodo.org/record/5526257/files/CAM045270_d.JPG,0,43643,cyrbia,43643_CAM045270_d.JPG,minor
+CAM045271,https://zenodo.org/record/5526257/files/CAM045271_d.JPG,0,43647,cyrbia,43647_CAM045271_d.JPG,minor
+CAM045197,https://zenodo.org/record/5526257/files/CAM045197_d.JPG,0,43353,cyrbia,43353_CAM045197_d.JPG,minor
+CAM045196,https://zenodo.org/record/5526257/files/CAM045196_d.JPG,0,43349,cyrbia,43349_CAM045196_d.JPG,minor
+CAM045195,https://zenodo.org/record/5526257/files/CAM045195_d.JPG,0,43345,cyrbia,43345_CAM045195_d.JPG,minor
+CAM045194,https://zenodo.org/record/5526257/files/CAM045194_d.JPG,0,43341,cyrbia,43341_CAM045194_d.JPG,minor
+CAM045193,https://zenodo.org/record/5526257/files/CAM045193_d.JPG,0,43337,cyrbia,43337_CAM045193_d.JPG,minor
+CAM045192,https://zenodo.org/record/5526257/files/CAM045192_d.JPG,0,43333,cyrbia,43333_CAM045192_d.JPG,minor
+CAM045191,https://zenodo.org/record/5526257/files/CAM045191_d.JPG,0,43329,cyrbia,43329_CAM045191_d.JPG,minor
+CAM045190,https://zenodo.org/record/5526257/files/CAM045190_d.JPG,0,43325,cyrbia,43325_CAM045190_d.JPG,minor
+CAM045189,https://zenodo.org/record/5526257/files/CAM045189_d.JPG,0,43321,cyrbia,43321_CAM045189_d.JPG,minor
+CAM045188,https://zenodo.org/record/5526257/files/CAM045188_d.JPG,0,43317,cyrbia,43317_CAM045188_d.JPG,minor
+CAM045268,https://zenodo.org/record/5526257/files/CAM045268_d.JPG,0,43635,cyrbia,43635_CAM045268_d.JPG,minor
+CAM045186,https://zenodo.org/record/5526257/files/CAM045186_d.JPG,0,43309,cyrbia,43309_CAM045186_d.JPG,minor
+CAM045187,https://zenodo.org/record/5526257/files/CAM045187_d.JPG,0,43313,cyrbia,43313_CAM045187_d.JPG,minor
+CAM045174,https://zenodo.org/record/5526257/files/CAM045174_d.JPG,0,43261,cyrbia,43261_CAM045174_d.JPG,minor
+CAM045175,https://zenodo.org/record/5526257/files/CAM045175_d.JPG,0,43265,cyrbia,43265_CAM045175_d.JPG,minor
+CAM045176,https://zenodo.org/record/5526257/files/CAM045176_d.JPG,0,43269,cyrbia,43269_CAM045176_d.JPG,minor
+CAM045177,https://zenodo.org/record/5526257/files/CAM045177_d.JPG,0,43273,cyrbia,43273_CAM045177_d.JPG,minor
+CAM045178,https://zenodo.org/record/5526257/files/CAM045178_d.JPG,0,43277,cyrbia,43277_CAM045178_d.JPG,minor
+CAM045179,https://zenodo.org/record/5526257/files/CAM045179_d.JPG,0,43281,cyrbia,43281_CAM045179_d.JPG,minor
+CAM045173,https://zenodo.org/record/5526257/files/CAM045173_d.JPG,0,43257,cyrbia,43257_CAM045173_d.JPG,minor
+CAM045181,https://zenodo.org/record/5526257/files/CAM045181_d.JPG,0,43289,cyrbia,43289_CAM045181_d.JPG,minor
+CAM045182,https://zenodo.org/record/5526257/files/CAM045182_d.JPG,0,43293,cyrbia,43293_CAM045182_d.JPG,minor
+CAM045183,https://zenodo.org/record/5526257/files/CAM045183_d.JPG,0,43297,cyrbia,43297_CAM045183_d.JPG,minor
+CAM045184,https://zenodo.org/record/5526257/files/CAM045184_d.JPG,0,43301,cyrbia,43301_CAM045184_d.JPG,minor
+CAM045185,https://zenodo.org/record/5526257/files/CAM045185_d.JPG,0,43305,cyrbia,43305_CAM045185_d.JPG,minor
+CAM045180,https://zenodo.org/record/5526257/files/CAM045180_d.JPG,0,43285,cyrbia,43285_CAM045180_d.JPG,minor
+CAM036275,https://zenodo.org/record/5561246/files/CAM036275_d.JPG,0,41755,phyllis,41755_CAM036275_d.JPG,minor
+CAM036274,https://zenodo.org/record/5561246/files/CAM036274_d.JPG,0,41751,phyllis,41751_CAM036274_d.JPG,minor
+CAM036260,https://zenodo.org/record/5561246/files/CAM036260_d.JPG,0,41719,phyllis,41719_CAM036260_d.JPG,minor
+CAM036257,https://zenodo.org/record/5561246/files/CAM036257_d.JPG,0,41707,phyllis,41707_CAM036257_d.JPG,minor
+CAM036256,https://zenodo.org/record/5561246/files/CAM036256_d.JPG,0,41703,phyllis,41703_CAM036256_d.JPG,minor
+CAM036255,https://zenodo.org/record/5561246/files/CAM036255_d.JPG,0,41699,phyllis,41699_CAM036255_d.JPG,minor
+CAM036254,https://zenodo.org/record/5561246/files/CAM036254_d.JPG,0,41695,phyllis,41695_CAM036254_d.JPG,minor
+CAM036253,https://zenodo.org/record/5561246/files/CAM036253_d.JPG,0,41691,phyllis,41691_CAM036253_d.JPG,minor
+CAM036232,https://zenodo.org/record/5561246/files/CAM036232_d.JPG,0,41639,phyllis,41639_CAM036232_d.JPG,minor
+CAM036231,https://zenodo.org/record/5561246/files/CAM036231_d.JPG,0,41635,phyllis,41635_CAM036231_d.JPG,minor
+CAM036230,https://zenodo.org/record/5561246/files/CAM036230_d.JPG,0,41631,phyllis,41631_CAM036230_d.JPG,minor
+CAM036229,https://zenodo.org/record/5561246/files/CAM036229_d.JPG,0,41627,phyllis,41627_CAM036229_d.JPG,minor
+CAM036226,https://zenodo.org/record/5561246/files/CAM036226_d.JPG,0,41615,phyllis,41615_CAM036226_d.JPG,minor
+CAM036225,https://zenodo.org/record/5561246/files/CAM036225_d.JPG,0,41611,phyllis,41611_CAM036225_d.JPG,minor
+CAM036587,https://zenodo.org/record/5561246/files/CAM036587_d.JPG,0,42515,phyllis,42515_CAM036587_d.JPG,minor
+CAM017800,https://zenodo.org/record/1748277/files/CAM017800_v_whitestandard.JPG,0,16459,plesseni,16459_CAM017800_v_whitestandard.JPG,mimic
+CAM017908,https://zenodo.org/record/1748277/files/CAM017908_v_whitestandard.JPG,0,16887,malleti,16887_CAM017908_v_whitestandard.JPG,mimic
+CAM017449,https://zenodo.org/record/1748277/files/CAM017449_d_whitestandard.JPG,0,15259,malleti,15259_CAM017449_d_whitestandard.JPG,mimic
+CAM017453,https://zenodo.org/record/1748277/files/CAM017453_d_whitestandard.JPG,0,15275,plesseni,15275_CAM017453_d_whitestandard.JPG,mimic
+CAM017455,https://zenodo.org/record/1748277/files/CAM017455_d_whitestandard.JPG,0,15283,malleti,15283_CAM017455_d_whitestandard.JPG,mimic
+CAM017458,https://zenodo.org/record/1748277/files/CAM017458_d_whitestandard.JPG,0,15295,plesseni,15295_CAM017458_d_whitestandard.JPG,mimic
+CAM017704,https://zenodo.org/record/1748277/files/CAM017704_d_whitestandard.JPG,0,16079,plesseni,16079_CAM017704_d_whitestandard.JPG,mimic
+CAM018268,https://zenodo.org/record/2548678/files/CAM018268_v_whitestandard.JPG,0,17501,plesseni,17501_CAM018268_v_whitestandard.JPG,mimic
+CAM018282,https://zenodo.org/record/2548678/files/CAM018282_v_whitestandard.JPG,0,17557,malleti,17557_CAM018282_v_whitestandard.JPG,mimic
+CAM018353,https://zenodo.org/record/2548678/files/CAM018353_v_whitestandard.JPG,0,17829,malleti,17829_CAM018353_v_whitestandard.JPG,mimic
+CAM018339,https://zenodo.org/record/2548678/files/CAM018339_v_whitestandard.JPG,0,17773,plesseni,17773_CAM018339_v_whitestandard.JPG,mimic
+CAM018357,https://zenodo.org/record/2548678/files/CAM018357_v_whitestandard.JPG,1,17845,plesseni x malleti,17845_CAM018357_v_whitestandard.JPG,mimic
+CAM018438,https://zenodo.org/record/2548678/files/CAM018438_v_whitestandard.JPG,0,18165,malleti,18165_CAM018438_v_whitestandard.JPG,mimic
+CAM018447,https://zenodo.org/record/2548678/files/CAM018447_v_whitestandard.JPG,0,18201,plesseni,18201_CAM018447_v_whitestandard.JPG,mimic
+CAM018528,https://zenodo.org/record/2548678/files/CAM018528_v_whitestandard.JPG,0,18525,malleti,18525_CAM018528_v_whitestandard.JPG,mimic
+CAM010077,https://zenodo.org/record/2549524/files/CAM010077_d.JPG,0,26327,malleti,26327_CAM010077_d.JPG,mimic
+CAM010014,https://zenodo.org/record/2549524/files/CAM010014_d.JPG,0,26227,malleti,26227_CAM010014_d.JPG,mimic
+CAM010006,https://zenodo.org/record/2549524/files/CAM010006_d.JPG,0,26215,malleti,26215_CAM010006_d.JPG,mimic
+CAM010089,https://zenodo.org/record/2549524/files/CAM010089_d.JPG,0,26347,malleti,26347_CAM010089_d.JPG,mimic
+CAM011423,https://zenodo.org/record/2550097/files/CAM011423_d.JPG,0,28192,plesseni,28192_CAM011423_d.JPG,mimic
+CAM011411,https://zenodo.org/record/2550097/files/CAM011411_d.JPG,0,28144,plesseni,28144_CAM011411_d.JPG,mimic
+CAM011428,https://zenodo.org/record/2550097/files/CAM011428_d.JPG,0,28212,malleti,28212_CAM011428_d.JPG,mimic
+CAM011410,https://zenodo.org/record/2550097/files/CAM011410_d.JPG,0,28140,plesseni,28140_CAM011410_d.JPG,mimic
+CAM011438,https://zenodo.org/record/2550097/files/CAM011438_d.JPG,0,28244,plesseni,28244_CAM011438_d.JPG,mimic
+CAM011406,https://zenodo.org/record/2550097/files/CAM011406_d.JPG,0,28124,plesseni,28124_CAM011406_d.JPG,mimic
+CAM011296,https://zenodo.org/record/2550097/files/CAM011296_d.JPG,0,27822,malleti,27822_CAM011296_d.JPG,mimic
+CAM011443,https://zenodo.org/record/2550097/files/CAM011443_d.JPG,0,28264,plesseni,28264_CAM011443_d.JPG,mimic
+CAM011449,https://zenodo.org/record/2550097/files/CAM011449_d.JPG,0,28288,plesseni,28288_CAM011449_d.JPG,mimic
+CAM011444,https://zenodo.org/record/2550097/files/CAM011444_d.JPG,0,28268,malleti,28268_CAM011444_d.JPG,mimic
+CAM011447,https://zenodo.org/record/2550097/files/CAM011447_d.JPG,0,28280,malleti,28280_CAM011447_d.JPG,mimic
+CAM011456,https://zenodo.org/record/2550097/files/CAM011456_d.JPG,0,28316,plesseni,28316_CAM011456_d.JPG,mimic
+CAM010035,https://zenodo.org/record/2552371/files/10035d.jpg,0,23118,malleti,23118_10035d.jpg,mimic
+CAM011437,https://zenodo.org/record/2552371/files/11437d.jpg,0,24550,plesseni,24550_11437d.jpg,mimic
+CAM011440,https://zenodo.org/record/2552371/files/11440d.jpg,0,24552,plesseni,24552_11440d.jpg,mimic
+CAM011446,https://zenodo.org/record/2552371/files/11446d.jpg,0,24556,plesseni,24556_11446d.jpg,mimic
+CS003830,https://zenodo.org/record/2553501/files/CS3830 dorsal.jpeg,0,25987,malleti,25987_CS3830 dorsal.jpeg,mimic
+CS003815,https://zenodo.org/record/2553501/files/CS3815 dorsal.jpeg,0,25983,malleti,25983_CS3815 dorsal.jpeg,mimic
+CS003728,https://zenodo.org/record/2553501/files/CS3728 dorsal.jpeg,0,25967,malleti,25967_CS3728 dorsal.jpeg,mimic
+CS003730,https://zenodo.org/record/2553501/files/CS3730 dorsal.jpeg,0,25969,malleti,25969_CS3730 dorsal.jpeg,mimic
+CS003820,https://zenodo.org/record/2553501/files/CS3820 dorsal.jpeg,0,25985,malleti,25985_CS3820 dorsal.jpeg,mimic
+CS003709,https://zenodo.org/record/2553501/files/CS3709 dorsal.jpeg,0,25965,malleti,25965_CS3709 dorsal.jpeg,mimic
+CS003706,https://zenodo.org/record/2553501/files/CS3706 dorsal.jpeg,0,25963,malleti,25963_CS3706 dorsal.jpeg,mimic
+CS001011,https://zenodo.org/record/2553501/files/CS1011 dorsal.jpeg,0,25595,malleti,25595_CS1011 dorsal.jpeg,mimic
+CS001002,https://zenodo.org/record/2553501/files/CS1002 dorsal.jpeg,0,25591,malleti,25591_CS1002 dorsal.jpeg,mimic
+CS001286,https://zenodo.org/record/2553501/files/CS1286 dorsal.jpeg,0,25625,malleti,25625_CS1286 dorsal.jpeg,mimic
+CS000615,https://zenodo.org/record/2553501/files/CS615 dorsal.jpeg,0,26011,malleti,26011_CS615 dorsal.jpeg,mimic
+CS000594,https://zenodo.org/record/2553501/files/CS594 dorsal.jpeg,0,26007,malleti,26007_CS594 dorsal.jpeg,mimic
+CS000583,https://zenodo.org/record/2553501/files/CS583 dorsal.jpeg,0,26003,malleti,26003_CS583 dorsal.jpeg,mimic
+CS000470,https://zenodo.org/record/2553501/files/CS470 dorsal.jpeg,0,25997,malleti,25997_CS470 dorsal.jpeg,mimic
+CS000604,https://zenodo.org/record/2553501/files/CS604 dorsal.jpeg,0,26009,malleti,26009_CS604 dorsal.jpeg,mimic
+CS001321,https://zenodo.org/record/2553501/files/CS1321 dorsal.jpeg,0,25627,malleti,25627_CS1321 dorsal.jpeg,mimic
+CS000586,https://zenodo.org/record/2553501/files/CS586 dorsal.jpeg,0,26005,malleti,26005_CS586 dorsal.jpeg,mimic
+CS003544,https://zenodo.org/record/2553501/files/CS3544 dorsal.jpeg,0,25941,malleti,25941_CS3544 dorsal.jpeg,mimic
+CS003543,https://zenodo.org/record/2553501/files/CS3543 dorsal.jpeg,0,25939,malleti,25939_CS3543 dorsal.jpeg,mimic
+CS003542,https://zenodo.org/record/2553501/files/CS3542 dorsal.jpeg,0,25937,malleti,25937_CS3542 dorsal.jpeg,mimic
+CS003541,https://zenodo.org/record/2553501/files/CS3541 dorsal.jpeg,0,25935,malleti,25935_CS3541 dorsal.jpeg,mimic
+CS003447,https://zenodo.org/record/2553501/files/CS3447 dorsal.jpeg,0,25933,malleti,25933_CS3447 dorsal.jpeg,mimic
+CS003366,https://zenodo.org/record/2553501/files/CS3366 dorsal.jpeg,0,25901,malleti,25901_CS3366 dorsal.jpeg,mimic
+CS003109,https://zenodo.org/record/2553501/files/CS3109 dorsal.jpeg,0,25847,malleti,25847_CS3109 dorsal.jpeg,mimic
+CS002311,https://zenodo.org/record/2553501/files/CS2311 dorsal.jpeg,0,25701,malleti,25701_CS2311 dorsal.jpeg,mimic
+CS001815,https://zenodo.org/record/2553501/files/CS1815 dorsal.jpeg,0,25643,malleti,25643_CS1815 dorsal.jpeg,mimic
+CAM017162,https://zenodo.org/record/2553977/files/17162_H_melpomene_malleti_D.JPG.jpg,0,26053,malleti,26053_17162_H_melpomene_malleti_D.JPG.jpg,mimic
+CAM016293,https://zenodo.org/record/2553977/files/16293_H_melpomene_plesseni_D.JPG.jpg,0,26047,plesseni,26047_16293_H_melpomene_plesseni_D.JPG.jpg,mimic
+F875,https://zenodo.org/record/2555086/files/F875_d.JPG,0,38136,demophoon,38136_F875_d.JPG,minor
+F876,https://zenodo.org/record/2555086/files/F876_d.JPG,0,38140,demophoon,38140_F876_d.JPG,minor
+F880,https://zenodo.org/record/2555086/files/F880_d.JPG,0,38144,demophoon,38144_F880_d.JPG,minor
+F884,https://zenodo.org/record/2555086/files/F884_d.JPG,0,38148,demophoon,38148_F884_d.JPG,minor
+F868,https://zenodo.org/record/2555086/files/F868_d.JPG,0,38120,demophoon,38120_F868_d.JPG,minor
+F889,https://zenodo.org/record/2555086/files/F889_d.JPG,0,38152,demophoon,38152_F889_d.JPG,minor
+F895,https://zenodo.org/record/2555086/files/F895_d.JPG,0,38160,demophoon,38160_F895_d.JPG,minor
+F901,https://zenodo.org/record/2555086/files/F901_d.JPG,0,38168,demophoon,38168_F901_d.JPG,minor
+F902,https://zenodo.org/record/2555086/files/F902_d.JPG,0,38172,demophoon,38172_F902_d.JPG,minor
+F905,https://zenodo.org/record/2555086/files/F905_d.JPG,0,38176,demophoon,38176_F905_d.JPG,minor
+F906,https://zenodo.org/record/2555086/files/F906_d.JPG,0,38180,demophoon,38180_F906_d.JPG,minor
+F907,https://zenodo.org/record/2555086/files/F907_d.JPG,0,38184,demophoon,38184_F907_d.JPG,minor
+F794,https://zenodo.org/record/2555086/files/F794_d.JPG,0,38040,demophoon,38040_F794_d.JPG,minor
+F891,https://zenodo.org/record/2555086/files/F891_d.JPG,0,38156,demophoon,38156_F891_d.JPG,minor
+F867,https://zenodo.org/record/2555086/files/F867_d.JPG,0,38116,demophoon,38116_F867_d.JPG,minor
+F900,https://zenodo.org/record/2555086/files/F900_d.JPG,0,38164,demophoon,38164_F900_d.JPG,minor
+F865,https://zenodo.org/record/2555086/files/F865_d.JPG,0,38108,demophoon,38108_F865_d.JPG,minor
+CAM000057,https://zenodo.org/record/2677821/files/CAM000057_d.JPG,1,5949,chestertonii x venus,5949_CAM000057_d.JPG,minor
+CAM000171,https://zenodo.org/record/2677821/files/CAM000171_d.JPG,0,6174,chestertonii,6174_CAM000171_d.JPG,minor
+CAM000170,https://zenodo.org/record/2677821/files/CAM000170_d.JPG,0,6172,chestertonii,6172_CAM000170_d.JPG,minor
+CAM000169,https://zenodo.org/record/2677821/files/CAM000169_d.JPG,0,6170,chestertonii,6170_CAM000169_d.JPG,minor
+CAM000149,https://zenodo.org/record/2677821/files/CAM000149_d.JPG,0,6130,chestertonii,6130_CAM000149_d.JPG,minor
+CAM000148,https://zenodo.org/record/2677821/files/CAM000148_d.JPG,0,6128,chestertonii,6128_CAM000148_d.JPG,minor
+CAM000230,https://zenodo.org/record/2677821/files/CAM000230_d.JPG,0,6286,chestertonii,6286_CAM000230_d.JPG,minor
+CAM000231,https://zenodo.org/record/2677821/files/CAM000231_d.JPG,0,6288,chestertonii,6288_CAM000231_d.JPG,minor
+CAM000232,https://zenodo.org/record/2677821/files/CAM000232_d.JPG,0,6290,chestertonii,6290_CAM000232_d.JPG,minor
+CAM000233,https://zenodo.org/record/2677821/files/CAM000233_d.JPG,0,6292,chestertonii,6292_CAM000233_d.JPG,minor
+CAM000243,https://zenodo.org/record/2677821/files/CAM000243_d.JPG,0,6312,chestertonii,6312_CAM000243_d.JPG,minor
+CAM002903,https://zenodo.org/record/2684906/files/CAM002903_d.JPG,1,8491,hydara x petiverana,8491_CAM002903_d.JPG,minor
+CAM008158,https://zenodo.org/record/2684906/files/CAM008158_d.JPG,0,8762,malleti,8762_CAM008158_d.JPG,mimic
+CAM008226,https://zenodo.org/record/2684906/files/CAM008226_d.JPG,0,8895,malleti,8895_CAM008226_d.JPG,mimic
+CAM008163,https://zenodo.org/record/2684906/files/CAM008163_d.JPG,0,8772,malleti,8772_CAM008163_d.JPG,mimic
+CAM008160,https://zenodo.org/record/2684906/files/CAM008160_d.JPG,0,8766,malleti,8766_CAM008160_d.JPG,mimic
+CAM008159,https://zenodo.org/record/2684906/files/CAM008159_d.JPG,0,8764,malleti,8764_CAM008159_d.JPG,mimic
+CAM008161,https://zenodo.org/record/2684906/files/CAM008161_d.JPG,0,8768,malleti,8768_CAM008161_d.JPG,mimic
+CAM008546,https://zenodo.org/record/2684906/files/CAM008546_d.JPG,0,9444,plesseni,9444_CAM008546_d.JPG,mimic
+CAM008545,https://zenodo.org/record/2684906/files/CAM008545_d.JPG,0,9442,plesseni,9442_CAM008545_d.JPG,mimic
+CAM008544,https://zenodo.org/record/2684906/files/CAM008544_d.JPG,0,9440,plesseni,9440_CAM008544_d.JPG,mimic
+CAM008543,https://zenodo.org/record/2684906/files/CAM008543_d.JPG,0,9438,plesseni,9438_CAM008543_d.JPG,mimic
+CAM008539,https://zenodo.org/record/2684906/files/CAM008539_d.JPG,0,9432,plesseni,9432_CAM008539_d.JPG,mimic
+CAM008542,https://zenodo.org/record/2684906/files/CAM008542_d.JPG,0,9436,plesseni,9436_CAM008542_d.JPG,mimic
+CAM008244,https://zenodo.org/record/2684906/files/CAM008244_d.JPG,0,8923,malleti,8923_CAM008244_d.JPG,mimic
+CAM009424,https://zenodo.org/record/2686762/files/CAM009424_d.JPG,0,10646,plesseni,10646_CAM009424_d.JPG,mimic
+CAM009416,https://zenodo.org/record/2686762/files/CAM009416_d.JPG,0,10630,plesseni,10630_CAM009416_d.JPG,mimic
+CAM009417,https://zenodo.org/record/2686762/files/CAM009417_d.JPG,0,10632,plesseni,10632_CAM009417_d.JPG,mimic
+CAM009423,https://zenodo.org/record/2686762/files/CAM009423_d.JPG,0,10644,plesseni,10644_CAM009423_d.JPG,mimic
+CAM009429,https://zenodo.org/record/2686762/files/CAM009429_d.JPG,0,10656,plesseni,10656_CAM009429_d.JPG,mimic
+CAM009436,https://zenodo.org/record/2686762/files/CAM009436_d.JPG,0,10670,plesseni,10670_CAM009436_d.JPG,mimic
+CAM009437,https://zenodo.org/record/2686762/files/CAM009437_d.JPG,0,10672,plesseni,10672_CAM009437_d.JPG,mimic
+CAM009438,https://zenodo.org/record/2686762/files/CAM009438_d.JPG,0,10674,plesseni,10674_CAM009438_d.JPG,mimic
+CAM009439,https://zenodo.org/record/2686762/files/CAM009439_d.JPG,0,10676,plesseni,10676_CAM009439_d.JPG,mimic
+CAM009442,https://zenodo.org/record/2686762/files/CAM009442_d.JPG,0,10682,plesseni,10682_CAM009442_d.JPG,mimic
+CAM009500,https://zenodo.org/record/2686762/files/CAM009500_d.JPG,1,10742,hydara x petiverana,10742_CAM009500_d.JPG,minor
+CAM009407,https://zenodo.org/record/2686762/files/CAM009407_d.JPG,0,10612,malleti,10612_CAM009407_d.JPG,mimic
+CAM009544,https://zenodo.org/record/2686762/files/CAM009544_d.JPG,1,10830,hydara x petiverana,10830_CAM009544_d.JPG,minor
+CAM009504,https://zenodo.org/record/2686762/files/CAM009504_d.JPG,1,10750,hydara x petiverana,10750_CAM009504_d.JPG,minor
+CAM009546,https://zenodo.org/record/2686762/files/CAM009546_d.JPG,1,10834,hydara x petiverana,10834_CAM009546_d.JPG,minor
+CAM009549,https://zenodo.org/record/2686762/files/CAM009549_d.JPG,1,10840,hydara x petiverana,10840_CAM009549_d.JPG,minor
+CAM009551,https://zenodo.org/record/2686762/files/CAM009551_d.JPG,1,10844,hydara x petiverana,10844_CAM009551_d.JPG,minor
+CAM009552,https://zenodo.org/record/2686762/files/CAM009552_d.JPG,1,10846,hydara x petiverana,10846_CAM009552_d.JPG,minor
+CAM009524,https://zenodo.org/record/2686762/files/CAM009524_d.JPG,0,10790,petiverana,10790_CAM009524_d.JPG,minor
+CAM009525,https://zenodo.org/record/2686762/files/CAM009525_d.JPG,0,10792,petiverana,10792_CAM009525_d.JPG,minor
+CAM009206,https://zenodo.org/record/2686762/files/CAM009206_d.JPG,0,10381,plesseni,10381_CAM009206_d.JPG,mimic
+CAM009008,https://zenodo.org/record/2686762/files/CAM009008_d.JPG,0,10121,hydara,10121_CAM009008_d.JPG,minor
+CAM009007,https://zenodo.org/record/2686762/files/CAM009007_d.JPG,0,10119,hydara,10119_CAM009007_d.JPG,minor
+CAM009006,https://zenodo.org/record/2686762/files/CAM009006_d.JPG,0,10117,hydara,10117_CAM009006_d.JPG,minor
+CAM009004,https://zenodo.org/record/2686762/files/CAM009004_d.JPG,0,10113,hydara,10113_CAM009004_d.JPG,minor
+CAM009003,https://zenodo.org/record/2686762/files/CAM009003_d.JPG,0,10111,hydara,10111_CAM009003_d.JPG,minor
+CAM009002,https://zenodo.org/record/2686762/files/CAM009002_d.JPG,0,10109,hydara,10109_CAM009002_d.JPG,minor
+CAM009001,https://zenodo.org/record/2686762/files/CAM009001_d.JPG,0,10107,hydara,10107_CAM009001_d.JPG,minor
+CAM008999,https://zenodo.org/record/2686762/files/CAM008999_d.JPG,0,10103,hydara,10103_CAM008999_d.JPG,minor
+CAM008998,https://zenodo.org/record/2686762/files/CAM008998_d.JPG,0,10101,hydara,10101_CAM008998_d.JPG,minor
+CAM008997,https://zenodo.org/record/2686762/files/CAM008997_d.JPG,0,10099,hydara,10099_CAM008997_d.JPG,minor
+CAM008986,https://zenodo.org/record/2686762/files/CAM008986_d.JPG,0,10077,hydara,10077_CAM008986_d.JPG,minor
+CAM008985,https://zenodo.org/record/2686762/files/CAM008985_d.JPG,0,10075,hydara,10075_CAM008985_d.JPG,minor
+CAM009000,https://zenodo.org/record/2686762/files/CAM009000_d.JPG,0,10105,hydara,10105_CAM009000_d.JPG,minor
+CAM008867,https://zenodo.org/record/2686762/files/CAM008867_d.JPG,0,9955,hydara,9955_CAM008867_d.JPG,minor
+CAM008866,https://zenodo.org/record/2686762/files/CAM008866_d.JPG,0,9953,hydara,9953_CAM008866_d.JPG,minor
+CAM009332,https://zenodo.org/record/2686762/files/CAM009332_d.JPG,0,10516,hydara,10516_CAM009332_d.JPG,minor
+CAM008865,https://zenodo.org/record/2686762/files/CAM008865_d.JPG,0,9951,hydara,9951_CAM008865_d.JPG,minor
+CAM008864,https://zenodo.org/record/2686762/files/CAM008864_d.JPG,0,9949,hydara,9949_CAM008864_d.JPG,minor
+CAM008801,https://zenodo.org/record/2686762/files/CAM008801_d.JPG,0,9855,hydara,9855_CAM008801_d.JPG,minor
+CAM008961,https://zenodo.org/record/2686762/files/CAM008961_d.JPG,0,10027,hydara,10027_CAM008961_d.JPG,minor
+CAM009300,https://zenodo.org/record/2686762/files/CAM009300_d.JPG,0,10452,hydara,10452_CAM009300_d.JPG,minor
+CAM009237,https://zenodo.org/record/2686762/files/CAM009237_d.JPG,0,10442,plesseni,10442_CAM009237_d.JPG,mimic
+CAM009236,https://zenodo.org/record/2686762/files/CAM009236_d.JPG,0,10440,plesseni,10440_CAM009236_d.JPG,mimic
+CAM009235,https://zenodo.org/record/2686762/files/CAM009235_d.JPG,0,10438,plesseni,10438_CAM009235_d.JPG,mimic
+CAM009233,https://zenodo.org/record/2686762/files/CAM009233_d.JPG,0,10434,plesseni,10434_CAM009233_d.JPG,mimic
+CAM009232,https://zenodo.org/record/2686762/files/CAM009232_d.JPG,0,10432,plesseni,10432_CAM009232_d.JPG,mimic
+CAM009231,https://zenodo.org/record/2686762/files/CAM009231_d.JPG,0,10430,plesseni,10430_CAM009231_d.JPG,mimic
+CAM009230,https://zenodo.org/record/2686762/files/CAM009230_d.JPG,0,10428,plesseni,10428_CAM009230_d.JPG,mimic
+CAM009229,https://zenodo.org/record/2686762/files/CAM009229_d.JPG,0,10426,plesseni,10426_CAM009229_d.JPG,mimic
+CAM009234,https://zenodo.org/record/2686762/files/CAM009234_d.JPG,0,10436,plesseni,10436_CAM009234_d.JPG,mimic
+CAM009207,https://zenodo.org/record/2686762/files/CAM009207_d.JPG,0,10383,plesseni,10383_CAM009207_d.JPG,mimic
+CAM009205,https://zenodo.org/record/2686762/files/CAM009205_d.JPG,0,10379,plesseni,10379_CAM009205_d.JPG,mimic
+CAM009228,https://zenodo.org/record/2686762/files/CAM009228_d.JPG,0,10424,plesseni,10424_CAM009228_d.JPG,mimic
+CAM009203,https://zenodo.org/record/2686762/files/CAM009203_d.JPG,0,10375,plesseni,10375_CAM009203_d.JPG,mimic
+CAM009159,https://zenodo.org/record/2686762/files/CAM009159_d.JPG,0,10287,plesseni,10287_CAM009159_d.JPG,mimic
+CAM009204,https://zenodo.org/record/2686762/files/CAM009204_d.JPG,0,10377,plesseni,10377_CAM009204_d.JPG,mimic
+CAM009157,https://zenodo.org/record/2686762/files/CAM009157_d.JPG,0,10283,plesseni,10283_CAM009157_d.JPG,mimic
+CAM009156,https://zenodo.org/record/2686762/files/CAM009156_d.JPG,0,10281,plesseni,10281_CAM009156_d.JPG,mimic
+CAM009126,https://zenodo.org/record/2686762/files/CAM009126_d.JPG,0,10221,etylus,10221_CAM009126_d.JPG,minor
+CAM009160,https://zenodo.org/record/2686762/files/CAM009160_d.JPG,0,10289,plesseni,10289_CAM009160_d.JPG,mimic
+CAM009161,https://zenodo.org/record/2686762/files/CAM009161_d.JPG,0,10291,plesseni,10291_CAM009161_d.JPG,mimic
+CAM009158,https://zenodo.org/record/2686762/files/CAM009158_d.JPG,0,10285,plesseni,10285_CAM009158_d.JPG,mimic
+CAM009194,https://zenodo.org/record/2686762/files/CAM009194_d.JPG,0,10357,plesseni,10357_CAM009194_d.JPG,mimic
+CAM009197,https://zenodo.org/record/2686762/files/CAM009197_d.JPG,0,10363,plesseni,10363_CAM009197_d.JPG,mimic
+CAM009198,https://zenodo.org/record/2686762/files/CAM009198_d.JPG,0,10365,plesseni,10365_CAM009198_d.JPG,mimic
+CAM009193,https://zenodo.org/record/2686762/files/CAM009193_d.JPG,0,10355,plesseni,10355_CAM009193_d.JPG,mimic
+CAM009199,https://zenodo.org/record/2686762/files/CAM009199_d.JPG,0,10367,plesseni,10367_CAM009199_d.JPG,mimic
+CAM009192,https://zenodo.org/record/2686762/files/CAM009192_d.JPG,0,10353,plesseni,10353_CAM009192_d.JPG,mimic
+CAM009191,https://zenodo.org/record/2686762/files/CAM009191_d.JPG,0,10351,plesseni,10351_CAM009191_d.JPG,mimic
+CAM009195,https://zenodo.org/record/2686762/files/CAM009195_d.JPG,0,10359,plesseni,10359_CAM009195_d.JPG,mimic
+CAM009200,https://zenodo.org/record/2686762/files/CAM009200_d.JPG,0,10369,plesseni,10369_CAM009200_d.JPG,mimic
+CAM009201,https://zenodo.org/record/2686762/files/CAM009201_d.JPG,0,10371,plesseni,10371_CAM009201_d.JPG,mimic
+CAM009202,https://zenodo.org/record/2686762/files/CAM009202_d.JPG,0,10373,plesseni,10373_CAM009202_d.JPG,mimic
+CAM009189,https://zenodo.org/record/2686762/files/CAM009189_d.JPG,0,10347,plesseni,10347_CAM009189_d.JPG,mimic
+CAM009188,https://zenodo.org/record/2686762/files/CAM009188_d.JPG,0,10345,plesseni,10345_CAM009188_d.JPG,mimic
+CAM009190,https://zenodo.org/record/2686762/files/CAM009190_d.JPG,0,10349,plesseni,10349_CAM009190_d.JPG,mimic
+CAM009196,https://zenodo.org/record/2686762/files/CAM009196_d.JPG,0,10361,plesseni,10361_CAM009196_d.JPG,mimic
+CAM018530,https://zenodo.org/record/2702457/files/CAM018530_d.JPG,1,11391,malleti x plesseni,11391_CAM018530_d.JPG,mimic
+CAM018532,https://zenodo.org/record/2702457/files/CAM018532_d.JPG,1,11393,plesseni x malleti,11393_CAM018532_d.JPG,mimic
+CAM017998,https://zenodo.org/record/2702457/files/CAM017998_d.JPG,1,10916,plesseni x malleti,10916_CAM017998_d.JPG,mimic
+CAM018529,https://zenodo.org/record/2702457/files/CAM018529_d.JPG,1,11389,malleti x plesseni,11389_CAM018529_d.JPG,mimic
+CAM018517,https://zenodo.org/record/2702457/files/CAM018517_d.JPG,1,11369,plesseni x malleti,11369_CAM018517_d.JPG,mimic
+CAM018518,https://zenodo.org/record/2702457/files/CAM018518_d.JPG,1,11371,malleti x plesseni,11371_CAM018518_d.JPG,mimic
+CAM018519,https://zenodo.org/record/2702457/files/CAM018519_d.JPG,1,11373,plesseni x malleti,11373_CAM018519_d.JPG,mimic
+CAM018520,https://zenodo.org/record/2702457/files/CAM018520_d.JPG,1,11375,malleti x plesseni,11375_CAM018520_d.JPG,mimic
+CAM021060,https://zenodo.org/record/2702457/files/CAM021060_d.JPG,0,11549,erato,11549_CAM021060_d.JPG,minor
+CAM021062,https://zenodo.org/record/2702457/files/CAM021062_d.JPG,0,11553,erato,11553_CAM021062_d.JPG,minor
+CAM021077,https://zenodo.org/record/2702457/files/CAM021077_d.JPG,0,11581,erato,11581_CAM021077_d.JPG,minor
+CAM021073,https://zenodo.org/record/2702457/files/CAM021073_d.JPG,0,11575,erato,11575_CAM021073_d.JPG,minor
+CAM021068,https://zenodo.org/record/2702457/files/CAM021068_d.JPG,0,11565,erato,11565_CAM021068_d.JPG,minor
+CAM021054,https://zenodo.org/record/2702457/files/CAM021054_d.JPG,1,11540,hydara x erato,11540_CAM021054_d.JPG,minor
+CAM021021,https://zenodo.org/record/2702457/files/CAM021021_d.JPG,0,11480,amalfreda,11480_CAM021021_d.JPG,minor
+CAM021022,https://zenodo.org/record/2702457/files/CAM021022_d.JPG,0,11482,amalfreda,11482_CAM021022_d.JPG,minor
+CAM021023,https://zenodo.org/record/2702457/files/CAM021023_d.JPG,0,11484,amalfreda,11484_CAM021023_d.JPG,minor
+CAM021025,https://zenodo.org/record/2702457/files/CAM021025_d.JPG,0,11488,amalfreda,11488_CAM021025_d.JPG,minor
+CAM021028,https://zenodo.org/record/2702457/files/CAM021028_d.JPG,1,11490,hydara x amalfreda,11490_CAM021028_d.JPG,minor
+CAM021029,https://zenodo.org/record/2702457/files/CAM021029_d.JPG,1,11492,hydara x amalfreda,11492_CAM021029_d.JPG,minor
+CAM021030,https://zenodo.org/record/2702457/files/CAM021030_d.JPG,1,11494,hydara x amalfreda,11494_CAM021030_d.JPG,minor
+CAM021031,https://zenodo.org/record/2702457/files/CAM021031_d.JPG,1,11496,hydara x amalfreda,11496_CAM021031_d.JPG,minor
+CAM018315,https://zenodo.org/record/2702457/files/CAM018315_d.JPG,1,11060,plesseni x malleti,11060_CAM018315_d.JPG,mimic
+CAM018309,https://zenodo.org/record/2702457/files/CAM018309_d.JPG,1,11052,plesseni x malleti,11052_CAM018309_d.JPG,mimic
+CAM018405,https://zenodo.org/record/2702457/files/CAM018405_d.JPG,1,11174,plesseni x malleti,11174_CAM018405_d.JPG,mimic
+CAM018360,https://zenodo.org/record/2702457/files/CAM018360_d.JPG,1,11127,plesseni x malleti,11127_CAM018360_d.JPG,mimic
+CAM018361,https://zenodo.org/record/2702457/files/CAM018361_d.JPG,1,11128,plesseni x malleti,11128_CAM018361_d.JPG,mimic
+CAM018365,https://zenodo.org/record/2702457/files/CAM018365_d.JPG,1,11130,malleti x plesseni,11130_CAM018365_d.JPG,mimic
+CAM018391,https://zenodo.org/record/2702457/files/CAM018391_d.JPG,1,11156,malleti x plesseni,11156_CAM018391_d.JPG,mimic
+CAM018401,https://zenodo.org/record/2702457/files/CAM018401_d.JPG,1,11166,plesseni x malleti,11166_CAM018401_d.JPG,mimic
+CAM018402,https://zenodo.org/record/2702457/files/CAM018402_d.JPG,1,11168,plesseni x malleti,11168_CAM018402_d.JPG,mimic
+CAM018403,https://zenodo.org/record/2702457/files/CAM018403_d.JPG,1,11170,plesseni x malleti,11170_CAM018403_d.JPG,mimic
+CAM018404,https://zenodo.org/record/2702457/files/CAM018404_d.JPG,1,11172,plesseni x malleti,11172_CAM018404_d.JPG,mimic
+CAM018338,https://zenodo.org/record/2702457/files/CAM018338_d.JPG,1,11096,malleti x plesseni,11096_CAM018338_d.JPG,mimic
+CAM018466,https://zenodo.org/record/2702457/files/CAM018466_d.JPG,1,11274,plesseni x malleti,11274_CAM018466_d.JPG,mimic
+CAM018259,https://zenodo.org/record/2702457/files/CAM018259_d.JPG,1,10990,plesseni x malleti,10990_CAM018259_d.JPG,mimic
+CAM018258,https://zenodo.org/record/2702457/files/CAM018258_d.JPG,1,10988,plesseni x malleti,10988_CAM018258_d.JPG,mimic
+CAM018482,https://zenodo.org/record/2702457/files/CAM018482_d.JPG,1,11305,plesseni x malleti,11305_CAM018482_d.JPG,mimic
+CAM018257,https://zenodo.org/record/2702457/files/CAM018257_d.JPG,1,10986,plesseni x malleti,10986_CAM018257_d.JPG,mimic
+CAM018256,https://zenodo.org/record/2702457/files/CAM018256_d.JPG,1,10984,plesseni x malleti,10984_CAM018256_d.JPG,mimic
+CAM018250,https://zenodo.org/record/2702457/files/CAM018250_d.JPG,1,10974,plesseni x malleti,10974_CAM018250_d.JPG,mimic
+CAM018296,https://zenodo.org/record/2702457/files/CAM018296_d.JPG,1,11034,malleti x plesseni,11034_CAM018296_d.JPG,mimic
+CAM018295,https://zenodo.org/record/2702457/files/CAM018295_d.JPG,1,11032,plesseni x malleti,11032_CAM018295_d.JPG,mimic
+CAM018294,https://zenodo.org/record/2702457/files/CAM018294_d.JPG,1,11030,plesseni x malleti,11030_CAM018294_d.JPG,mimic
+CAM018285,https://zenodo.org/record/2702457/files/CAM018285_d.JPG,1,11022,plesseni x malleti,11022_CAM018285_d.JPG,mimic
+CAM018281,https://zenodo.org/record/2702457/files/CAM018281_d.JPG,1,11018,plesseni x malleti,11018_CAM018281_d.JPG,mimic
+CAM040293,https://zenodo.org/record/2707828/files/CAM040293_d.JPG,0,12202,malleti,12202_CAM040293_d.JPG,mimic
+CAM040440,https://zenodo.org/record/2707828/files/CAM040440_d.JPG,0,12492,malleti,12492_CAM040440_d.JPG,mimic
+CAM040129,https://zenodo.org/record/2707828/files/CAM040129_d.JPG,0,11898,malleti,11898_CAM040129_d.JPG,mimic
+CAM040150,https://zenodo.org/record/2707828/files/CAM040150_d.JPG,0,11936,malleti,11936_CAM040150_d.JPG,mimic
+CAM040149,https://zenodo.org/record/2707828/files/CAM040149_d.JPG,0,11934,malleti,11934_CAM040149_d.JPG,mimic
+CAM040038,https://zenodo.org/record/2707828/files/CAM040038_d.JPG,0,11756,dignus,11756_CAM040038_d.JPG,minor
+CAM040023,https://zenodo.org/record/2707828/files/CAM040023_d.JPG,0,11730,malleti,11730_CAM040023_d.JPG,mimic
+CAM040022,https://zenodo.org/record/2707828/files/CAM040022_d.JPG,0,11728,malleti,11728_CAM040022_d.JPG,mimic
+CAM040021,https://zenodo.org/record/2707828/files/CAM040021_d.JPG,0,11726,malleti,11726_CAM040021_d.JPG,mimic
+CAM040020,https://zenodo.org/record/2707828/files/CAM040020_d.JPG,0,11724,malleti,11724_CAM040020_d.JPG,mimic
+CAM040019,https://zenodo.org/record/2707828/files/CAM040019_d.JPG,0,11722,malleti,11722_CAM040019_d.JPG,mimic
+CAM040018,https://zenodo.org/record/2707828/files/CAM040018_d.JPG,0,11720,dignus,11720_CAM040018_d.JPG,minor
+CAM040017,https://zenodo.org/record/2707828/files/CAM040017_d.JPG,0,11718,dignus,11718_CAM040017_d.JPG,minor
+CAM040294,https://zenodo.org/record/2707828/files/CAM040294_d.JPG,0,12204,malleti,12204_CAM040294_d.JPG,mimic
+CAM040292,https://zenodo.org/record/2707828/files/CAM040292_d.JPG,0,12200,malleti,12200_CAM040292_d.JPG,mimic
+CAM040291,https://zenodo.org/record/2707828/files/CAM040291_d.JPG,0,12198,malleti,12198_CAM040291_d.JPG,mimic
+CAM040290,https://zenodo.org/record/2707828/files/CAM040290_d.JPG,0,12196,malleti,12196_CAM040290_d.JPG,mimic
+CAM040289,https://zenodo.org/record/2707828/files/CAM040289_d.JPG,0,12194,malleti,12194_CAM040289_d.JPG,mimic
+CAM040288,https://zenodo.org/record/2707828/files/CAM040288_d.JPG,0,12192,malleti,12192_CAM040288_d.JPG,mimic
+CAM040287,https://zenodo.org/record/2707828/files/CAM040287_d.JPG,0,12190,malleti,12190_CAM040287_d.JPG,mimic
+CAM040286,https://zenodo.org/record/2707828/files/CAM040286_d.JPG,0,12188,malleti,12188_CAM040286_d.JPG,mimic
+CAM040285,https://zenodo.org/record/2707828/files/CAM040285_d.JPG,0,12186,malleti,12186_CAM040285_d.JPG,mimic
+CAM040284,https://zenodo.org/record/2707828/files/CAM040284_d.JPG,0,12184,malleti,12184_CAM040284_d.JPG,mimic
+CAM040283,https://zenodo.org/record/2707828/files/CAM040283_d.JPG,0,12182,malleti,12182_CAM040283_d.JPG,mimic
+CAM040282,https://zenodo.org/record/2707828/files/CAM040282_d.JPG,0,12180,malleti,12180_CAM040282_d.JPG,mimic
+CAM040281,https://zenodo.org/record/2707828/files/CAM040281_d.JPG,0,12178,malleti,12178_CAM040281_d.JPG,mimic
+CAM040269,https://zenodo.org/record/2707828/files/CAM040269_d.JPG,0,12154,malleti,12154_CAM040269_d.JPG,mimic
+CAM040268,https://zenodo.org/record/2707828/files/CAM040268_d.JPG,0,12152,malleti,12152_CAM040268_d.JPG,mimic
+CAM040267,https://zenodo.org/record/2707828/files/CAM040267_d.JPG,0,12150,malleti,12150_CAM040267_d.JPG,mimic
+CAM040266,https://zenodo.org/record/2707828/files/CAM040266_d.JPG,0,12148,malleti,12148_CAM040266_d.JPG,mimic
+CAM040265,https://zenodo.org/record/2707828/files/CAM040265_d.JPG,0,12146,malleti,12146_CAM040265_d.JPG,mimic
+CAM040264,https://zenodo.org/record/2707828/files/CAM040264_d.JPG,0,12144,malleti,12144_CAM040264_d.JPG,mimic
+CAM040263,https://zenodo.org/record/2707828/files/CAM040263_d.JPG,0,12142,malleti,12142_CAM040263_d.JPG,mimic
+CAM040262,https://zenodo.org/record/2707828/files/CAM040262_d.JPG,0,12140,malleti,12140_CAM040262_d.JPG,mimic
+CAM040261,https://zenodo.org/record/2707828/files/CAM040261_d.JPG,0,12138,malleti,12138_CAM040261_d.JPG,mimic
+CAM040260,https://zenodo.org/record/2707828/files/CAM040260_d.JPG,0,12136,malleti,12136_CAM040260_d.JPG,mimic
+CAM040295,https://zenodo.org/record/2707828/files/CAM040295_d.JPG,0,12206,malleti,12206_CAM040295_d.JPG,mimic
+CAM040259,https://zenodo.org/record/2707828/files/CAM040259_d.JPG,0,12134,malleti,12134_CAM040259_d.JPG,mimic
+CAM040296,https://zenodo.org/record/2707828/files/CAM040296_d.JPG,0,12208,malleti,12208_CAM040296_d.JPG,mimic
+CAM040298,https://zenodo.org/record/2707828/files/CAM040298_d.JPG,0,12212,malleti,12212_CAM040298_d.JPG,mimic
+CAM040297,https://zenodo.org/record/2707828/files/CAM040297_d.JPG,0,12210,malleti,12210_CAM040297_d.JPG,mimic
+CAM040258,https://zenodo.org/record/2707828/files/CAM040258_d.JPG,0,12132,malleti,12132_CAM040258_d.JPG,mimic
+CAM040256,https://zenodo.org/record/2707828/files/CAM040256_d.JPG,0,12128,malleti,12128_CAM040256_d.JPG,mimic
+CAM040198,https://zenodo.org/record/2707828/files/CAM040198_d.JPG,0,12022,malleti,12022_CAM040198_d.JPG,mimic
+CAM040197,https://zenodo.org/record/2707828/files/CAM040197_d.JPG,0,12020,malleti,12020_CAM040197_d.JPG,mimic
+CAM040192,https://zenodo.org/record/2707828/files/CAM040192_d.JPG,0,12012,malleti,12012_CAM040192_d.JPG,mimic
+CAM040190,https://zenodo.org/record/2707828/files/CAM040190_d.JPG,0,12008,malleti,12008_CAM040190_d.JPG,mimic
+CAM040183,https://zenodo.org/record/2707828/files/CAM040183_d.JPG,0,11994,malleti,11994_CAM040183_d.JPG,mimic
+CAM040181,https://zenodo.org/record/2707828/files/CAM040181_d.JPG,0,11992,malleti,11992_CAM040181_d.JPG,mimic
+CAM040180,https://zenodo.org/record/2707828/files/CAM040180_d.JPG,0,11990,malleti,11990_CAM040180_d.JPG,mimic
+CAM040172,https://zenodo.org/record/2707828/files/CAM040172_d.JPG,0,11974,malleti,11974_CAM040172_d.JPG,mimic
+CAM040171,https://zenodo.org/record/2707828/files/CAM040171_d.JPG,0,11972,malleti,11972_CAM040171_d.JPG,mimic
+CAM040257,https://zenodo.org/record/2707828/files/CAM040257_d.JPG,0,12130,malleti,12130_CAM040257_d.JPG,mimic
+CAM040201,https://zenodo.org/record/2707828/files/CAM040201_d.JPG,0,12028,malleti,12028_CAM040201_d.JPG,mimic
+CAM040210,https://zenodo.org/record/2707828/files/CAM040210_d.JPG,0,12044,malleti,12044_CAM040210_d.JPG,mimic
+CAM040240,https://zenodo.org/record/2707828/files/CAM040240_d.JPG,0,12096,malleti,12096_CAM040240_d.JPG,mimic
+CAM040255,https://zenodo.org/record/2707828/files/CAM040255_d.JPG,0,12126,malleti,12126_CAM040255_d.JPG,mimic
+CAM040253,https://zenodo.org/record/2707828/files/CAM040253_d.JPG,0,12122,malleti,12122_CAM040253_d.JPG,mimic
+CAM040245,https://zenodo.org/record/2707828/files/CAM040245_d.JPG,0,12106,malleti,12106_CAM040245_d.JPG,mimic
+CAM040238,https://zenodo.org/record/2707828/files/CAM040238_d.JPG,0,12092,malleti,12092_CAM040238_d.JPG,mimic
+CAM040237,https://zenodo.org/record/2707828/files/CAM040237_d.JPG,0,12090,malleti,12090_CAM040237_d.JPG,mimic
+CAM040235,https://zenodo.org/record/2707828/files/CAM040235_d.JPG,0,12086,malleti,12086_CAM040235_d.JPG,mimic
+CAM040254,https://zenodo.org/record/2707828/files/CAM040254_d.JPG,0,12124,malleti,12124_CAM040254_d.JPG,mimic
+CAM040222,https://zenodo.org/record/2707828/files/CAM040222_d.JPG,0,12064,malleti,12064_CAM040222_d.JPG,mimic
+CAM041061,https://zenodo.org/record/2714333/files/CAM041061_d.JPG,0,13761,malleti,13761_CAM041061_d.JPG,mimic
+CAM041093,https://zenodo.org/record/2714333/files/CAM041093_d.JPG,0,13824,malleti,13824_CAM041093_d.JPG,mimic
+CAM041091,https://zenodo.org/record/2714333/files/CAM041091_d.JPG,0,13820,malleti,13820_CAM041091_d.JPG,mimic
+CAM041100,https://zenodo.org/record/2714333/files/CAM041100_d.JPG,0,13838,malleti,13838_CAM041100_d.JPG,mimic
+CAM041067,https://zenodo.org/record/2714333/files/CAM041067_d.JPG,0,13773,malleti,13773_CAM041067_d.JPG,mimic
+CAM041065,https://zenodo.org/record/2714333/files/CAM041065_d.JPG,0,13769,malleti,13769_CAM041065_d.JPG,mimic
+CAM041064,https://zenodo.org/record/2714333/files/CAM041064_d.JPG,0,13767,malleti,13767_CAM041064_d.JPG,mimic
+CAM041063,https://zenodo.org/record/2714333/files/CAM041063_d.JPG,0,13765,malleti,13765_CAM041063_d.JPG,mimic
+CAM041101,https://zenodo.org/record/2714333/files/CAM041101_d.JPG,0,13840,malleti,13840_CAM041101_d.JPG,mimic
+CAM041138,https://zenodo.org/record/2714333/files/CAM041138_d.JPG,0,13914,malleti,13914_CAM041138_d.JPG,mimic
+CAM041121,https://zenodo.org/record/2714333/files/CAM041121_d.JPG,0,13880,malleti,13880_CAM041121_d.JPG,mimic
+CAM041062,https://zenodo.org/record/2714333/files/CAM041062_d.JPG,0,13763,malleti,13763_CAM041062_d.JPG,mimic
+CAM041060,https://zenodo.org/record/2714333/files/CAM041060_d.JPG,0,13759,malleti,13759_CAM041060_d.JPG,mimic
+CAM041053,https://zenodo.org/record/2714333/files/CAM041053_d.JPG,0,13745,malleti,13745_CAM041053_d.JPG,mimic
+CAM041013,https://zenodo.org/record/2714333/files/CAM041013_d.JPG,0,13665,malleti,13665_CAM041013_d.JPG,mimic
+CAM040999,https://zenodo.org/record/2714333/files/CAM040999_d.JPG,0,13637,malleti,13637_CAM040999_d.JPG,mimic
+CAM040992,https://zenodo.org/record/2714333/files/CAM040992_d.JPG,0,13623,malleti,13623_CAM040992_d.JPG,mimic
+CAM041000,https://zenodo.org/record/2714333/files/CAM041000_d.JPG,0,13639,malleti,13639_CAM041000_d.JPG,mimic
+CAM041052,https://zenodo.org/record/2714333/files/CAM041052_d.JPG,0,13743,malleti,13743_CAM041052_d.JPG,mimic
+CAM041051,https://zenodo.org/record/2714333/files/CAM041051_d.JPG,0,13741,malleti,13741_CAM041051_d.JPG,mimic
+CAM041048,https://zenodo.org/record/2714333/files/CAM041048_d.JPG,0,13735,malleti,13735_CAM041048_d.JPG,mimic
+CAM041046,https://zenodo.org/record/2714333/files/CAM041046_d.JPG,0,13731,malleti,13731_CAM041046_d.JPG,mimic
+CAM041038,https://zenodo.org/record/2714333/files/CAM041038_d.JPG,0,13715,malleti,13715_CAM041038_d.JPG,mimic
+CAM041036,https://zenodo.org/record/2714333/files/CAM041036_d.JPG,0,13711,malleti,13711_CAM041036_d.JPG,mimic
+CAM041035,https://zenodo.org/record/2714333/files/CAM041035_d.JPG,0,13709,malleti,13709_CAM041035_d.JPG,mimic
+CAM041027,https://zenodo.org/record/2714333/files/CAM041027_d.JPG,0,13693,malleti,13693_CAM041027_d.JPG,mimic
+CAM041021,https://zenodo.org/record/2714333/files/CAM041021_d.JPG,0,13681,malleti,13681_CAM041021_d.JPG,mimic
+CAM041191,https://zenodo.org/record/2714333/files/CAM041191_d.JPG,0,14019,malleti,14019_CAM041191_d.JPG,mimic
+CAM041187,https://zenodo.org/record/2714333/files/CAM041187_d.JPG,0,14011,malleti,14011_CAM041187_d.JPG,mimic
+CAM041186,https://zenodo.org/record/2714333/files/CAM041186_d.JPG,0,14009,malleti,14009_CAM041186_d.JPG,mimic
+CAM041185,https://zenodo.org/record/2714333/files/CAM041185_d.JPG,0,14007,malleti,14007_CAM041185_d.JPG,mimic
+CAM041184,https://zenodo.org/record/2714333/files/CAM041184_d.JPG,0,14005,malleti,14005_CAM041184_d.JPG,mimic
+CAM041183,https://zenodo.org/record/2714333/files/CAM041183_d.JPG,0,14003,malleti,14003_CAM041183_d.JPG,mimic
+CAM041182,https://zenodo.org/record/2714333/files/CAM041182_d.JPG,0,14001,malleti,14001_CAM041182_d.JPG,mimic
+CAM041181,https://zenodo.org/record/2714333/files/CAM041181_d.JPG,0,13999,malleti,13999_CAM041181_d.JPG,mimic
+CAM041180,https://zenodo.org/record/2714333/files/CAM041180_d.JPG,0,13997,malleti,13997_CAM041180_d.JPG,mimic
+CAM041179,https://zenodo.org/record/2714333/files/CAM041179_d.JPG,0,13995,malleti,13995_CAM041179_d.JPG,mimic
+CAM041159,https://zenodo.org/record/2714333/files/CAM041159_d.JPG,0,13955,malleti,13955_CAM041159_d.JPG,mimic
+CAM041200,https://zenodo.org/record/2714333/files/CAM041200_d.JPG,0,14037,malleti,14037_CAM041200_d.JPG,mimic
+CAM041168,https://zenodo.org/record/2714333/files/CAM041168_d.JPG,0,13973,malleti,13973_CAM041168_d.JPG,mimic
+CAM041174,https://zenodo.org/record/2714333/files/CAM041174_d.JPG,0,13985,malleti,13985_CAM041174_d.JPG,mimic
+CAM041176,https://zenodo.org/record/2714333/files/CAM041176_d.JPG,0,13989,malleti,13989_CAM041176_d.JPG,mimic
+CAM041177,https://zenodo.org/record/2714333/files/CAM041177_d.JPG,0,13991,malleti,13991_CAM041177_d.JPG,mimic
+CAM041178,https://zenodo.org/record/2714333/files/CAM041178_d.JPG,0,13993,malleti,13993_CAM041178_d.JPG,mimic
+CAM041201,https://zenodo.org/record/2714333/files/CAM041201_d.JPG,0,14039,malleti,14039_CAM041201_d.JPG,mimic
+CAM041202,https://zenodo.org/record/2714333/files/CAM041202_d.JPG,0,14041,malleti,14041_CAM041202_d.JPG,mimic
+CAM041203,https://zenodo.org/record/2714333/files/CAM041203_d.JPG,0,14043,malleti,14043_CAM041203_d.JPG,mimic
+CAM041221,https://zenodo.org/record/2714333/files/CAM041221_d.JPG,0,14079,malleti,14079_CAM041221_d.JPG,mimic
+CAM041222,https://zenodo.org/record/2714333/files/CAM041222_d.JPG,0,14081,malleti,14081_CAM041222_d.JPG,mimic
+CAM041223,https://zenodo.org/record/2714333/files/CAM041223_d.JPG,0,14083,malleti,14083_CAM041223_d.JPG,mimic
+CAM041224,https://zenodo.org/record/2714333/files/CAM041224_d.JPG,0,14085,malleti,14085_CAM041224_d.JPG,mimic
+CAM041220,https://zenodo.org/record/2714333/files/CAM041220_d.JPG,0,14077,malleti,14077_CAM041220_d.JPG,mimic
+CAM041218,https://zenodo.org/record/2714333/files/CAM041218_d.JPG,0,14073,malleti,14073_CAM041218_d.JPG,mimic
+CAM041204,https://zenodo.org/record/2714333/files/CAM041204_d.JPG,0,14045,malleti,14045_CAM041204_d.JPG,mimic
+CAM041205,https://zenodo.org/record/2714333/files/CAM041205_d.JPG,0,14047,malleti,14047_CAM041205_d.JPG,mimic
+CAM041206,https://zenodo.org/record/2714333/files/CAM041206_d.JPG,0,14049,malleti,14049_CAM041206_d.JPG,mimic
+CAM041207,https://zenodo.org/record/2714333/files/CAM041207_d.JPG,0,14051,malleti,14051_CAM041207_d.JPG,mimic
+CAM041208,https://zenodo.org/record/2714333/files/CAM041208_d.JPG,0,14053,malleti,14053_CAM041208_d.JPG,mimic
+CAM041209,https://zenodo.org/record/2714333/files/CAM041209_d.JPG,0,14055,malleti,14055_CAM041209_d.JPG,mimic
+CAM041219,https://zenodo.org/record/2714333/files/CAM041219_d.JPG,0,14075,malleti,14075_CAM041219_d.JPG,mimic
+CAM041210,https://zenodo.org/record/2714333/files/CAM041210_d.JPG,0,14057,malleti,14057_CAM041210_d.JPG,mimic
+CAM041212,https://zenodo.org/record/2714333/files/CAM041212_d.JPG,0,14061,malleti,14061_CAM041212_d.JPG,mimic
+CAM041213,https://zenodo.org/record/2714333/files/CAM041213_d.JPG,0,14063,malleti,14063_CAM041213_d.JPG,mimic
+CAM041214,https://zenodo.org/record/2714333/files/CAM041214_d.JPG,0,14065,malleti,14065_CAM041214_d.JPG,mimic
+CAM041215,https://zenodo.org/record/2714333/files/CAM041215_d.JPG,0,14067,malleti,14067_CAM041215_d.JPG,mimic
+CAM041216,https://zenodo.org/record/2714333/files/CAM041216_d.JPG,0,14069,malleti,14069_CAM041216_d.JPG,mimic
+CAM041217,https://zenodo.org/record/2714333/files/CAM041217_d.JPG,0,14071,malleti,14071_CAM041217_d.JPG,mimic
+CAM041211,https://zenodo.org/record/2714333/files/CAM041211_d.JPG,0,14059,malleti,14059_CAM041211_d.JPG,mimic
+CAM040731,https://zenodo.org/record/2714333/files/CAM040731_d.JPG,0,13093,malleti,13093_CAM040731_d.JPG,mimic
+CAM040732,https://zenodo.org/record/2714333/files/CAM040732_d.JPG,0,13097,malleti,13097_CAM040732_d.JPG,mimic
+CAM040708,https://zenodo.org/record/2714333/files/CAM040708_d.JPG,0,13001,malleti,13001_CAM040708_d.JPG,mimic
+CAM041147,https://zenodo.org/record/2714333/files/CAM041147_d.JPG,0,13931,malleti,13931_CAM041147_d.JPG,mimic
+CAM041149,https://zenodo.org/record/2714333/files/CAM041149_d.JPG,0,13935,malleti,13935_CAM041149_d.JPG,mimic
+CAM041274,https://zenodo.org/record/2714333/files/CAM041274_d.JPG,0,14184,malleti,14184_CAM041274_d.JPG,mimic
+CAM041276,https://zenodo.org/record/2714333/files/CAM041276_d.JPG,0,14188,malleti,14188_CAM041276_d.JPG,mimic
+CAM041275,https://zenodo.org/record/2714333/files/CAM041275_d.JPG,0,14186,malleti,14186_CAM041275_d.JPG,mimic
+CS002633,https://zenodo.org/record/2735056/files/CS002633_d.JPG,0,40923,venus,40923_CS002633_d.JPG,minor
+CS002631,https://zenodo.org/record/2735056/files/CS002631_d.JPG,0,40919,venus,40919_CS002631_d.JPG,minor
+CS002627,https://zenodo.org/record/2735056/files/CS002627_d.JPG,0,40915,venus,40915_CS002627_d.JPG,minor
+CS003358,https://zenodo.org/record/2735056/files/CS003358_d.JPG,0,40991,venus,40991_CS003358_d.JPG,minor
+CS003660,https://zenodo.org/record/2735056/files/CS003660_d.JPG,0,41075,venus,41075_CS003660_d.JPG,minor
+CS003652,https://zenodo.org/record/2735056/files/CS003652_d.JPG,0,41043,venus,41043_CS003652_d.JPG,minor
+CS002280,https://zenodo.org/record/2735056/files/CS002280_d.JPG,0,40875,venus,40875_CS002280_d.JPG,minor
+CS002272,https://zenodo.org/record/2735056/files/CS002272_d.JPG,0,40843,venus,40843_CS002272_d.JPG,minor
+CS002281,https://zenodo.org/record/2735056/files/CS002281_d.JPG,0,40879,venus,40879_CS002281_d.JPG,minor
+CS002273,https://zenodo.org/record/2735056/files/CS002273_d.JPG,0,40847,venus,40847_CS002273_d.JPG,minor
+CS002274,https://zenodo.org/record/2735056/files/CS002274_d.JPG,0,40851,venus,40851_CS002274_d.JPG,minor
+CS002276,https://zenodo.org/record/2735056/files/CS002276_d.JPG,0,40859,venus,40859_CS002276_d.JPG,minor
+CS002279,https://zenodo.org/record/2735056/files/CS002279_d.JPG,0,40871,venus,40871_CS002279_d.JPG,minor
+CS002275,https://zenodo.org/record/2735056/files/CS002275_d.JPG,0,40855,venus,40855_CS002275_d.JPG,minor
+CS002277,https://zenodo.org/record/2735056/files/CS002277_d.JPG,0,40863,venus,40863_CS002277_d.JPG,minor
+CAM120557,https://zenodo.org/record/2813153/files/CAM120557_d.JPG,0,14891,malleti,14891_CAM120557_d.JPG,mimic
+CAM120448,https://zenodo.org/record/2813153/files/CAM120448_d.JPG,0,14885,malleti,14885_CAM120448_d.JPG,mimic
+CS004030,https://zenodo.org/record/2813153/files/CS004030_d.JPG,0,14346,malleti,14346_CS004030_d.JPG,mimic
+CS004032,https://zenodo.org/record/2813153/files/CS004032_d.JPG,0,14350,malleti,14350_CS004032_d.JPG,mimic
+CS004034,https://zenodo.org/record/2813153/files/CS004034_d.JPG,0,14354,malleti,14354_CS004034_d.JPG,mimic
+CS004038,https://zenodo.org/record/2813153/files/CS004038_d.JPG,0,14362,malleti,14362_CS004038_d.JPG,mimic
+CS004039,https://zenodo.org/record/2813153/files/CS004039_d.JPG,0,14364,malleti,14364_CS004039_d.JPG,mimic
+CS004058,https://zenodo.org/record/2813153/files/CS004058_d.JPG,0,14382,reductimacula,14382_CS004058_d.JPG,minor
+CAM016792,https://zenodo.org/record/3082688/files/CAM016792_d.JPG,1,4006,plesseni x malleti,4006_CAM016792_d.JPG,mimic
+CAM016803,https://zenodo.org/record/3082688/files/CAM016803_d.JPG,0,4028,plesseni,4028_CAM016803_d.JPG,mimic
+CAM016765,https://zenodo.org/record/3082688/files/CAM016765_d.JPG,1,3966,plesseni x malleti,3966_CAM016765_d.JPG,mimic
+CAM016766,https://zenodo.org/record/3082688/files/CAM016766_d.JPG,0,3968,malleti,3968_CAM016766_d.JPG,mimic
+CAM016772,https://zenodo.org/record/3082688/files/CAM016772_d.JPG,0,3978,malleti,3978_CAM016772_d.JPG,mimic
+CAM016778,https://zenodo.org/record/3082688/files/CAM016778_d.JPG,1,3982,plesseni x malleti,3982_CAM016778_d.JPG,mimic
+CAM016785,https://zenodo.org/record/3082688/files/CAM016785_d.JPG,1,3992,plesseni x malleti,3992_CAM016785_d.JPG,mimic
+CAM016769,https://zenodo.org/record/3082688/files/CAM016769_d.JPG,1,3974,plesseni x malleti,3974_CAM016769_d.JPG,mimic
+CAM016808,https://zenodo.org/record/3082688/files/CAM016808_d.JPG,1,4038,plesseni x malleti,4038_CAM016808_d.JPG,mimic
+CAM016810,https://zenodo.org/record/3082688/files/CAM016810_d.JPG,0,4042,plesseni,4042_CAM016810_d.JPG,mimic
+CAM016834,https://zenodo.org/record/3082688/files/CAM016834_d.JPG,1,4089,plesseni x malleti,4089_CAM016834_d.JPG,mimic
+CAM016836,https://zenodo.org/record/3082688/files/CAM016836_d.JPG,1,4091,plesseni x malleti,4091_CAM016836_d.JPG,mimic
+CAM016843,https://zenodo.org/record/3082688/files/CAM016843_d.JPG,1,4105,plesseni x malleti,4105_CAM016843_d.JPG,mimic
+CAM016844,https://zenodo.org/record/3082688/files/CAM016844_d.JPG,1,4107,plesseni x malleti,4107_CAM016844_d.JPG,mimic
+CAM016846,https://zenodo.org/record/3082688/files/CAM016846_d.JPG,1,4111,plesseni x malleti,4111_CAM016846_d.JPG,mimic
+CAM016847,https://zenodo.org/record/3082688/files/CAM016847_d.JPG,1,4113,plesseni x malleti,4113_CAM016847_d.JPG,mimic
+CAM016849,https://zenodo.org/record/3082688/files/CAM016849_d.JPG,1,4117,plesseni x malleti,4117_CAM016849_d.JPG,mimic
+CAM016829,https://zenodo.org/record/3082688/files/CAM016829_d.JPG,1,4080,plesseni x malleti,4080_CAM016829_d.JPG,mimic
+CAM016809,https://zenodo.org/record/3082688/files/CAM016809_d.JPG,1,4040,plesseni x malleti,4040_CAM016809_d.JPG,mimic
+CAM016819,https://zenodo.org/record/3082688/files/CAM016819_d.JPG,1,4060,plesseni x malleti,4060_CAM016819_d.JPG,mimic
+CAM016821,https://zenodo.org/record/3082688/files/CAM016821_d.JPG,1,4064,plesseni x malleti,4064_CAM016821_d.JPG,mimic
+CAM016822,https://zenodo.org/record/3082688/files/CAM016822_d.JPG,1,4066,plesseni x malleti,4066_CAM016822_d.JPG,mimic
+CAM016826,https://zenodo.org/record/3082688/files/CAM016826_d.JPG,1,4074,plesseni x malleti,4074_CAM016826_d.JPG,mimic
+CAM016828,https://zenodo.org/record/3082688/files/CAM016828_d.JPG,1,4078,plesseni x malleti,4078_CAM016828_d.JPG,mimic
+CAM016820,https://zenodo.org/record/3082688/files/CAM016820_d.JPG,1,4062,plesseni x malleti,4062_CAM016820_d.JPG,mimic
+CAM016851,https://zenodo.org/record/3082688/files/CAM016851_d.JPG,1,4121,plesseni x malleti,4121_CAM016851_d.JPG,mimic
+CAM016066,https://zenodo.org/record/3082688/files/CAM016066_d.JPG,1,3040,plesseni x malleti,3040_CAM016066_d.JPG,mimic
+CAM016065,https://zenodo.org/record/3082688/files/CAM016065_d.JPG,1,3038,plesseni x malleti,3038_CAM016065_d.JPG,mimic
+CAM016055,https://zenodo.org/record/3082688/files/CAM016055_d.JPG,1,3019,plesseni x malleti,3019_CAM016055_d.JPG,mimic
+CAM016655,https://zenodo.org/record/3082688/files/CAM016655_d.JPG,1,3845,plesseni x malleti,3845_CAM016655_d.JPG,mimic
+CAM016656,https://zenodo.org/record/3082688/files/CAM016656_d.JPG,1,3847,plesseni x malleti,3847_CAM016656_d.JPG,mimic
+CAM016657,https://zenodo.org/record/3082688/files/CAM016657_d.JPG,1,3849,plesseni x malleti,3849_CAM016657_d.JPG,mimic
+CAM016658,https://zenodo.org/record/3082688/files/CAM016658_d.JPG,1,3851,plesseni x malleti,3851_CAM016658_d.JPG,mimic
+CAM016659,https://zenodo.org/record/3082688/files/CAM016659_d.JPG,1,3853,plesseni x malleti,3853_CAM016659_d.JPG,mimic
+CAM016660,https://zenodo.org/record/3082688/files/CAM016660_d.JPG,1,3855,plesseni x malleti,3855_CAM016660_d.JPG,mimic
+CAM016661,https://zenodo.org/record/3082688/files/CAM016661_d.JPG,1,3857,plesseni x malleti,3857_CAM016661_d.JPG,mimic
+CAM016662,https://zenodo.org/record/3082688/files/CAM016662_d.JPG,1,3859,plesseni x malleti,3859_CAM016662_d.JPG,mimic
+CAM016663,https://zenodo.org/record/3082688/files/CAM016663_d.JPG,1,3861,plesseni x malleti,3861_CAM016663_d.JPG,mimic
+CAM016672,https://zenodo.org/record/3082688/files/CAM016672_d.JPG,1,3878,plesseni x malleti,3878_CAM016672_d.JPG,mimic
+CAM016042,https://zenodo.org/record/3082688/files/CAM016042_d.JPG,1,2993,plesseni x malleti,2993_CAM016042_d.JPG,mimic
+CAM016751,https://zenodo.org/record/3082688/files/CAM016751_d.JPG,1,3938,plesseni x malleti,3938_CAM016751_d.JPG,mimic
+CAM016753,https://zenodo.org/record/3082688/files/CAM016753_d.JPG,1,3942,plesseni x malleti,3942_CAM016753_d.JPG,mimic
+CAM016754,https://zenodo.org/record/3082688/files/CAM016754_d.JPG,1,3944,plesseni x malleti,3944_CAM016754_d.JPG,mimic
+CAM016043,https://zenodo.org/record/3082688/files/CAM016043_d.JPG,1,2995,plesseni x malleti,2995_CAM016043_d.JPG,mimic
+CAM016044,https://zenodo.org/record/3082688/files/CAM016044_d.JPG,1,2997,plesseni x malleti,2997_CAM016044_d.JPG,mimic
+CAM016050,https://zenodo.org/record/3082688/files/CAM016050_d.JPG,1,3009,plesseni x malleti,3009_CAM016050_d.JPG,mimic
+CAM017018,https://zenodo.org/record/3082688/files/CAM017018_d.JPG,1,4391,plesseni x malleti,4391_CAM017018_d.JPG,mimic
+CAM017019,https://zenodo.org/record/3082688/files/CAM017019_d.JPG,0,4393,malleti,4393_CAM017019_d.JPG,mimic
+CAM016990,https://zenodo.org/record/3082688/files/CAM016990_d.JPG,0,4342,malleti,4342_CAM016990_d.JPG,mimic
+CAM016998,https://zenodo.org/record/3082688/files/CAM016998_d.JPG,1,4355,notabilis x lativitta,4355_CAM016998_d.JPG,major
+CAM017000,https://zenodo.org/record/3082688/files/CAM017000_d.JPG,1,4359,notabilis x lativitta,4359_CAM017000_d.JPG,major
+CAM017001,https://zenodo.org/record/3082688/files/CAM017001_d.JPG,1,4361,notabilis x lativitta,4361_CAM017001_d.JPG,major
+CAM017002,https://zenodo.org/record/3082688/files/CAM017002_d.JPG,1,4363,notabilis x lativitta,4363_CAM017002_d.JPG,major
+CAM017003,https://zenodo.org/record/3082688/files/CAM017003_d.JPG,1,4365,notabilis x lativitta,4365_CAM017003_d.JPG,major
+CAM017004,https://zenodo.org/record/3082688/files/CAM017004_d.JPG,1,4367,notabilis x lativitta,4367_CAM017004_d.JPG,major
+CAM016997,https://zenodo.org/record/3082688/files/CAM016997_d.JPG,1,4354,notabilis x lativitta,4354_CAM016997_d.JPG,major
+CAM016978,https://zenodo.org/record/3082688/files/CAM016978_d.JPG,1,4326,notabilis x lativitta,4326_CAM016978_d.JPG,major
+CAM017022,https://zenodo.org/record/3082688/files/CAM017022_d.JPG,1,4399,notabilis x lativitta,4399_CAM017022_d.JPG,major
+CAM017963,https://zenodo.org/record/3082688/files/CAM017963_d.JPG,1,5806,lativitta x notabilis,5806_CAM017963_d.JPG,major
+CAM017039,https://zenodo.org/record/3082688/files/CAM017039_d.JPG,1,4431,notabilis x lativitta,4431_CAM017039_d.JPG,major
+CAM017040,https://zenodo.org/record/3082688/files/CAM017040_d.JPG,1,4433,plesseni x malleti,4433_CAM017040_d.JPG,mimic
+CAM017041,https://zenodo.org/record/3082688/files/CAM017041_d.JPG,0,4435,malleti,4435_CAM017041_d.JPG,mimic
+CAM017042,https://zenodo.org/record/3082688/files/CAM017042_d.JPG,1,4437,notabilis x lativitta,4437_CAM017042_d.JPG,major
+CAM016282,https://zenodo.org/record/3082688/files/CAM016282_d.JPG,0,3396,plesseni,3396_CAM016282_d.JPG,mimic
+CAM017044,https://zenodo.org/record/3082688/files/CAM017044_d.JPG,1,4441,notabilis x lativitta,4441_CAM017044_d.JPG,major
+CAM017045,https://zenodo.org/record/3082688/files/CAM017045_d.JPG,1,4443,notabilis x lativitta,4443_CAM017045_d.JPG,major
+CAM017046,https://zenodo.org/record/3082688/files/CAM017046_d.JPG,1,4445,notabilis x lativitta,4445_CAM017046_d.JPG,major
+CAM017038,https://zenodo.org/record/3082688/files/CAM017038_d.JPG,1,4429,notabilis x lativitta,4429_CAM017038_d.JPG,major
+CAM017037,https://zenodo.org/record/3082688/files/CAM017037_d.JPG,1,4427,notabilis x lativitta,4427_CAM017037_d.JPG,major
+CAM017036,https://zenodo.org/record/3082688/files/CAM017036_d.JPG,1,4425,notabilis x lativitta,4425_CAM017036_d.JPG,major
+CAM017034,https://zenodo.org/record/3082688/files/CAM017034_d.JPG,1,4423,notabilis x lativitta,4423_CAM017034_d.JPG,major
+CAM017023,https://zenodo.org/record/3082688/files/CAM017023_d.JPG,1,4401,notabilis x lativitta,4401_CAM017023_d.JPG,major
+CAM017976,https://zenodo.org/record/3082688/files/CAM017976_d.JPG,1,5819,plesseni x malleti,5819_CAM017976_d.JPG,mimic
+CAM017025,https://zenodo.org/record/3082688/files/CAM017025_d.JPG,1,4405,notabilis x lativitta,4405_CAM017025_d.JPG,major
+CAM017028,https://zenodo.org/record/3082688/files/CAM017028_d.JPG,1,4411,notabilis x lativitta,4411_CAM017028_d.JPG,major
+CAM017030,https://zenodo.org/record/3082688/files/CAM017030_d.JPG,0,4415,malleti,4415_CAM017030_d.JPG,mimic
+CAM017031,https://zenodo.org/record/3082688/files/CAM017031_d.JPG,1,4417,notabilis x lativitta,4417_CAM017031_d.JPG,major
+CAM017032,https://zenodo.org/record/3082688/files/CAM017032_d.JPG,1,4419,notabilis x lativitta,4419_CAM017032_d.JPG,major
+CAM017033,https://zenodo.org/record/3082688/files/CAM017033_d.JPG,1,4421,notabilis x lativitta,4421_CAM017033_d.JPG,major
+CAM017029,https://zenodo.org/record/3082688/files/CAM017029_d.JPG,1,4413,notabilis x lativitta,4413_CAM017029_d.JPG,major
+CAM016976,https://zenodo.org/record/3082688/files/CAM016976_d.JPG,1,4322,notabilis x lativitta,4322_CAM016976_d.JPG,major
+CAM016970,https://zenodo.org/record/3082688/files/CAM016970_d.JPG,1,4310,notabilis x lativitta,4310_CAM016970_d.JPG,major
+CAM016858,https://zenodo.org/record/3082688/files/CAM016858_d.JPG,1,4135,plesseni x malleti,4135_CAM016858_d.JPG,mimic
+CAM016859,https://zenodo.org/record/3082688/files/CAM016859_d.JPG,1,4137,plesseni x malleti,4137_CAM016859_d.JPG,mimic
+CAM016860,https://zenodo.org/record/3082688/files/CAM016860_d.JPG,1,4139,plesseni x malleti,4139_CAM016860_d.JPG,mimic
+CAM016861,https://zenodo.org/record/3082688/files/CAM016861_d.JPG,1,4141,plesseni x malleti,4141_CAM016861_d.JPG,mimic
+CAM016862,https://zenodo.org/record/3082688/files/CAM016862_d.JPG,1,4143,notabilis x lativitta,4143_CAM016862_d.JPG,major
+CAM016863,https://zenodo.org/record/3082688/files/CAM016863_d.JPG,1,4145,plesseni x malleti,4145_CAM016863_d.JPG,mimic
+CAM016864,https://zenodo.org/record/3082688/files/CAM016864_d.JPG,1,4147,notabilis x lativitta,4147_CAM016864_d.JPG,major
+CAM016865,https://zenodo.org/record/3082688/files/CAM016865_d.JPG,1,4149,plesseni x malleti,4149_CAM016865_d.JPG,mimic
+CAM016866,https://zenodo.org/record/3082688/files/CAM016866_d.JPG,1,4151,notabilis x lativitta,4151_CAM016866_d.JPG,major
+CAM016869,https://zenodo.org/record/3082688/files/CAM016869_d.JPG,1,4155,plesseni x malleti,4155_CAM016869_d.JPG,mimic
+CAM016867,https://zenodo.org/record/3082688/files/CAM016867_d.JPG,1,4153,plesseni x malleti,4153_CAM016867_d.JPG,mimic
+CAM016927,https://zenodo.org/record/3082688/files/CAM016927_d.JPG,1,4255,notabilis x lativitta,4255_CAM016927_d.JPG,major
+CAM016930,https://zenodo.org/record/3082688/files/CAM016930_d.JPG,1,4261,notabilis x lativitta,4261_CAM016930_d.JPG,major
+CAM016947,https://zenodo.org/record/3082688/files/CAM016947_d.JPG,1,4277,notabilis x lativitta,4277_CAM016947_d.JPG,major
+CAM016954,https://zenodo.org/record/3082688/files/CAM016954_d.JPG,0,4285,malleti,4285_CAM016954_d.JPG,mimic
+CAM016924,https://zenodo.org/record/3082688/files/CAM016924_d.JPG,1,4249,notabilis x lativitta,4249_CAM016924_d.JPG,major
+CAM016955,https://zenodo.org/record/3082688/files/CAM016955_d.JPG,0,4287,malleti,4287_CAM016955_d.JPG,mimic
+CAM016961,https://zenodo.org/record/3082688/files/CAM016961_d.JPG,1,4297,notabilis x lativitta,4297_CAM016961_d.JPG,major
+CAM016964,https://zenodo.org/record/3082688/files/CAM016964_d.JPG,1,4303,notabilis x lativitta,4303_CAM016964_d.JPG,major
+CAM016965,https://zenodo.org/record/3082688/files/CAM016965_d.JPG,1,4305,notabilis x lativitta,4305_CAM016965_d.JPG,major
+CAM016968,https://zenodo.org/record/3082688/files/CAM016968_d.JPG,1,4307,notabilis x lativitta,4307_CAM016968_d.JPG,major
+CAM016969,https://zenodo.org/record/3082688/files/CAM016969_d.JPG,1,4308,notabilis x lativitta,4308_CAM016969_d.JPG,major
+CAM016956,https://zenodo.org/record/3082688/files/CAM016956_d.JPG,0,4289,malleti,4289_CAM016956_d.JPG,mimic
+CAM016654,https://zenodo.org/record/3082688/files/CAM016654_d.JPG,1,3843,plesseni x malleti,3843_CAM016654_d.JPG,mimic
+CAM016923,https://zenodo.org/record/3082688/files/CAM016923_d.JPG,1,4247,plesseni x malleti,4247_CAM016923_d.JPG,mimic
+CAM016041,https://zenodo.org/record/3082688/files/CAM016041_d.JPG,1,2991,plesseni x malleti,2991_CAM016041_d.JPG,mimic
+CAM016040,https://zenodo.org/record/3082688/files/CAM016040_d.JPG,1,2989,notabilis x lativitta,2989_CAM016040_d.JPG,major
+CAM016039,https://zenodo.org/record/3082688/files/CAM016039_d.JPG,1,2987,notabilis x lativitta,2987_CAM016039_d.JPG,major
+CAM016038,https://zenodo.org/record/3082688/files/CAM016038_d.JPG,1,2985,notabilis x lativitta,2985_CAM016038_d.JPG,major
+CAM016036,https://zenodo.org/record/3082688/files/CAM016036_d.JPG,1,2981,plesseni x malleti,2981_CAM016036_d.JPG,mimic
+CAM016035,https://zenodo.org/record/3082688/files/CAM016035_d.JPG,1,2979,notabilis x lativitta,2979_CAM016035_d.JPG,major
+CAM016922,https://zenodo.org/record/3082688/files/CAM016922_d.JPG,1,4245,plesseni x malleti,4245_CAM016922_d.JPG,mimic
+CAM016034,https://zenodo.org/record/3082688/files/CAM016034_d.JPG,1,2977,notabilis x lativitta,2977_CAM016034_d.JPG,major
+CAM016033,https://zenodo.org/record/3082688/files/CAM016033_d.JPG,1,2975,notabilis x lativitta,2975_CAM016033_d.JPG,major
+CAM016920,https://zenodo.org/record/3082688/files/CAM016920_d.JPG,1,4241,plesseni x malleti,4241_CAM016920_d.JPG,mimic
+CAM016653,https://zenodo.org/record/3082688/files/CAM016653_d.JPG,1,3841,notabilis x lativitta,3841_CAM016653_d.JPG,major
+CAM016652,https://zenodo.org/record/3082688/files/CAM016652_d.JPG,1,3839,notabilis x lativitta,3839_CAM016652_d.JPG,major
+CAM016651,https://zenodo.org/record/3082688/files/CAM016651_d.JPG,1,3837,notabilis x lativitta,3837_CAM016651_d.JPG,major
+CAM016117,https://zenodo.org/record/3082688/files/CAM016117_d.JPG,1,3142,plesseni x malleti,3142_CAM016117_d.JPG,mimic
+CAM016116,https://zenodo.org/record/3082688/files/CAM016116_d.JPG,0,3140,plesseni,3140_CAM016116_d.JPG,mimic
+CAM016115,https://zenodo.org/record/3082688/files/CAM016115_d.JPG,1,3138,notabilis x lativitta,3138_CAM016115_d.JPG,major
+CAM016114,https://zenodo.org/record/3082688/files/CAM016114_d.JPG,1,3136,notabilis x lativitta,3136_CAM016114_d.JPG,major
+CAM016113,https://zenodo.org/record/3082688/files/CAM016113_d.JPG,0,3134,plesseni,3134_CAM016113_d.JPG,mimic
+CAM016112,https://zenodo.org/record/3082688/files/CAM016112_d.JPG,1,3132,notabilis x lativitta,3132_CAM016112_d.JPG,major
+CAM016111,https://zenodo.org/record/3082688/files/CAM016111_d.JPG,1,3130,plesseni x malleti,3130_CAM016111_d.JPG,mimic
+CAM016110,https://zenodo.org/record/3082688/files/CAM016110_d.JPG,1,3128,notabilis x lativitta,3128_CAM016110_d.JPG,major
+CAM016106,https://zenodo.org/record/3082688/files/CAM016106_d.JPG,1,3120,plesseni x malleti,3120_CAM016106_d.JPG,mimic
+CAM016105,https://zenodo.org/record/3082688/files/CAM016105_d.JPG,1,3118,notabilis x lativitta,3118_CAM016105_d.JPG,major
+CAM016296,https://zenodo.org/record/3082688/files/CAM016296_d.JPG,0,3408,plesseni,3408_CAM016296_d.JPG,mimic
+CAM016102,https://zenodo.org/record/3082688/files/CAM016102_d.JPG,1,3112,notabilis x lativitta,3112_CAM016102_d.JPG,major
+CAM016118,https://zenodo.org/record/3082688/files/CAM016118_d.JPG,1,3144,plesseni x malleti,3144_CAM016118_d.JPG,mimic
+CAM016119,https://zenodo.org/record/3082688/files/CAM016119_d.JPG,1,3146,plesseni x malleti,3146_CAM016119_d.JPG,mimic
+CAM016120,https://zenodo.org/record/3082688/files/CAM016120_d.JPG,1,3148,plesseni x malleti,3148_CAM016120_d.JPG,mimic
+CAM016121,https://zenodo.org/record/3082688/files/CAM016121_d.JPG,1,3150,notabilis x lativitta,3150_CAM016121_d.JPG,major
+CAM016139,https://zenodo.org/record/3082688/files/CAM016139_d.JPG,1,3186,notabilis x lativitta,3186_CAM016139_d.JPG,major
+CAM016138,https://zenodo.org/record/3082688/files/CAM016138_d.JPG,1,3184,notabilis x lativitta,3184_CAM016138_d.JPG,major
+CAM016137,https://zenodo.org/record/3082688/files/CAM016137_d.JPG,1,3182,plesseni x malleti,3182_CAM016137_d.JPG,mimic
+CAM016136,https://zenodo.org/record/3082688/files/CAM016136_d.JPG,1,3180,plesseni x malleti,3180_CAM016136_d.JPG,mimic
+CAM016135,https://zenodo.org/record/3082688/files/CAM016135_d.JPG,1,3178,plesseni x malleti,3178_CAM016135_d.JPG,mimic
+CAM016134,https://zenodo.org/record/3082688/files/CAM016134_d.JPG,0,3176,plesseni,3176_CAM016134_d.JPG,mimic
+CAM016133,https://zenodo.org/record/3082688/files/CAM016133_d.JPG,1,3174,plesseni x malleti,3174_CAM016133_d.JPG,mimic
+CAM016132,https://zenodo.org/record/3082688/files/CAM016132_d.JPG,1,3172,plesseni x malleti,3172_CAM016132_d.JPG,mimic
+CAM016131,https://zenodo.org/record/3082688/files/CAM016131_d.JPG,1,3170,plesseni x malleti,3170_CAM016131_d.JPG,mimic
+CAM016129,https://zenodo.org/record/3082688/files/CAM016129_d.JPG,1,3166,notabilis x lativitta,3166_CAM016129_d.JPG,major
+CAM016128,https://zenodo.org/record/3082688/files/CAM016128_d.JPG,1,3164,notabilis x lativitta,3164_CAM016128_d.JPG,major
+CAM016127,https://zenodo.org/record/3082688/files/CAM016127_d.JPG,1,3162,plesseni x malleti,3162_CAM016127_d.JPG,mimic
+CAM016126,https://zenodo.org/record/3082688/files/CAM016126_d.JPG,1,3160,plesseni x malleti,3160_CAM016126_d.JPG,mimic
+CAM016125,https://zenodo.org/record/3082688/files/CAM016125_d.JPG,1,3158,plesseni x malleti,3158_CAM016125_d.JPG,mimic
+CAM016124,https://zenodo.org/record/3082688/files/CAM016124_d.JPG,1,3156,notabilis x lativitta,3156_CAM016124_d.JPG,major
+CAM016122,https://zenodo.org/record/3082688/files/CAM016122_d.JPG,1,3152,plesseni x malleti,3152_CAM016122_d.JPG,mimic
+CAM016130,https://zenodo.org/record/3082688/files/CAM016130_d.JPG,1,3168,plesseni x malleti,3168_CAM016130_d.JPG,mimic
+CAM016140,https://zenodo.org/record/3082688/files/CAM016140_d.JPG,1,3188,notabilis x lativitta,3188_CAM016140_d.JPG,major
+CAM016100,https://zenodo.org/record/3082688/files/CAM016100_d.JPG,1,3108,plesseni x malleti,3108_CAM016100_d.JPG,mimic
+CAM016306,https://zenodo.org/record/3082688/files/CAM016306_d.JPG,1,3412,plesseni x malleti,3412_CAM016306_d.JPG,mimic
+CAM016088,https://zenodo.org/record/3082688/files/CAM016088_d.JPG,1,3084,notabilis x lativitta,3084_CAM016088_d.JPG,major
+CAM016354,https://zenodo.org/record/3082688/files/CAM016354_d.JPG,0,3438,plesseni,3438_CAM016354_d.JPG,mimic
+CAM016355,https://zenodo.org/record/3082688/files/CAM016355_d.JPG,0,3440,plesseni,3440_CAM016355_d.JPG,mimic
+CAM016087,https://zenodo.org/record/3082688/files/CAM016087_d.JPG,1,3082,plesseni x malleti,3082_CAM016087_d.JPG,mimic
+CAM016086,https://zenodo.org/record/3082688/files/CAM016086_d.JPG,1,3080,plesseni x malleti,3080_CAM016086_d.JPG,mimic
+CAM016084,https://zenodo.org/record/3082688/files/CAM016084_d.JPG,1,3076,plesseni x malleti,3076_CAM016084_d.JPG,mimic
+CAM016089,https://zenodo.org/record/3082688/files/CAM016089_d.JPG,1,3086,plesseni x malleti,3086_CAM016089_d.JPG,mimic
+CAM016350,https://zenodo.org/record/3082688/files/CAM016350_d.JPG,1,3436,plesseni x malleti,3436_CAM016350_d.JPG,mimic
+CAM016349,https://zenodo.org/record/3082688/files/CAM016349_d.JPG,0,3434,plesseni,3434_CAM016349_d.JPG,mimic
+CAM016347,https://zenodo.org/record/3082688/files/CAM016347_d.JPG,0,3432,plesseni,3432_CAM016347_d.JPG,mimic
+CAM016098,https://zenodo.org/record/3082688/files/CAM016098_d.JPG,1,3104,plesseni x malleti,3104_CAM016098_d.JPG,mimic
+CAM016097,https://zenodo.org/record/3082688/files/CAM016097_d.JPG,1,3102,plesseni x malleti,3102_CAM016097_d.JPG,mimic
+CAM016309,https://zenodo.org/record/3082688/files/CAM016309_d.JPG,1,3414,plesseni x malleti,3414_CAM016309_d.JPG,mimic
+CAM016096,https://zenodo.org/record/3082688/files/CAM016096_d.JPG,1,3100,notabilis x lativitta,3100_CAM016096_d.JPG,major
+CAM016312,https://zenodo.org/record/3082688/files/CAM016312_d.JPG,1,3416,plesseni x malleti,3416_CAM016312_d.JPG,mimic
+CAM016313,https://zenodo.org/record/3082688/files/CAM016313_d.JPG,1,3418,plesseni x malleti,3418_CAM016313_d.JPG,mimic
+CAM016094,https://zenodo.org/record/3082688/files/CAM016094_d.JPG,1,3096,notabilis x lativitta,3096_CAM016094_d.JPG,major
+CAM016099,https://zenodo.org/record/3082688/files/CAM016099_d.JPG,1,3106,notabilis x lativitta,3106_CAM016099_d.JPG,major
+CAM016091,https://zenodo.org/record/3082688/files/CAM016091_d.JPG,1,3090,notabilis x lativitta,3090_CAM016091_d.JPG,major
+CAM016338,https://zenodo.org/record/3082688/files/CAM016338_d.JPG,1,3424,plesseni x malleti,3424_CAM016338_d.JPG,mimic
+CAM016339,https://zenodo.org/record/3082688/files/CAM016339_d.JPG,1,3426,plesseni x malleti,3426_CAM016339_d.JPG,mimic
+CAM016340,https://zenodo.org/record/3082688/files/CAM016340_d.JPG,1,3428,plesseni x malleti,3428_CAM016340_d.JPG,mimic
+CAM016234,https://zenodo.org/record/3082688/files/CAM016234_d.JPG,0,3344,malleti,3344_CAM016234_d.JPG,mimic
+CAM016224,https://zenodo.org/record/3082688/files/CAM016224_d.JPG,0,3334,malleti,3334_CAM016224_d.JPG,mimic
+CAM016205,https://zenodo.org/record/3082688/files/CAM016205_d.JPG,0,3316,malleti,3316_CAM016205_d.JPG,mimic
+CAM016197,https://zenodo.org/record/3082688/files/CAM016197_d.JPG,0,3302,malleti,3302_CAM016197_d.JPG,mimic
+CAM016194,https://zenodo.org/record/3082688/files/CAM016194_d.JPG,1,3296,notabilis x lativitta,3296_CAM016194_d.JPG,major
+CAM016193,https://zenodo.org/record/3082688/files/CAM016193_d.JPG,1,3294,notabilis x lativitta,3294_CAM016193_d.JPG,major
+CAM016192,https://zenodo.org/record/3082688/files/CAM016192_d.JPG,1,3292,notabilis x lativitta,3292_CAM016192_d.JPG,major
+CAM016190,https://zenodo.org/record/3082688/files/CAM016190_d.JPG,0,3288,malleti,3288_CAM016190_d.JPG,mimic
+CAM016274,https://zenodo.org/record/3082688/files/CAM016274_d.JPG,0,3392,malleti,3392_CAM016274_d.JPG,mimic
+CAM016273,https://zenodo.org/record/3082688/files/CAM016273_d.JPG,0,3390,malleti,3390_CAM016273_d.JPG,mimic
+CAM016267,https://zenodo.org/record/3082688/files/CAM016267_d.JPG,0,3380,malleti,3380_CAM016267_d.JPG,mimic
+CAM016266,https://zenodo.org/record/3082688/files/CAM016266_d.JPG,0,3378,malleti,3378_CAM016266_d.JPG,mimic
+CAM016268,https://zenodo.org/record/3082688/files/CAM016268_d.JPG,0,3382,malleti,3382_CAM016268_d.JPG,mimic
+CAM016188,https://zenodo.org/record/3082688/files/CAM016188_d.JPG,1,3284,notabilis x lativitta,3284_CAM016188_d.JPG,major
+CAM016187,https://zenodo.org/record/3082688/files/CAM016187_d.JPG,1,3282,notabilis x lativitta,3282_CAM016187_d.JPG,major
+CAM016186,https://zenodo.org/record/3082688/files/CAM016186_d.JPG,1,3280,notabilis x lativitta,3280_CAM016186_d.JPG,major
+CAM016157,https://zenodo.org/record/3082688/files/CAM016157_d.JPG,1,3222,notabilis x lativitta,3222_CAM016157_d.JPG,major
+CAM016156,https://zenodo.org/record/3082688/files/CAM016156_d.JPG,1,3220,notabilis x lativitta,3220_CAM016156_d.JPG,major
+CAM016155,https://zenodo.org/record/3082688/files/CAM016155_d.JPG,1,3218,notabilis x lativitta,3218_CAM016155_d.JPG,major
+CAM016154,https://zenodo.org/record/3082688/files/CAM016154_d.JPG,1,3216,notabilis x lativitta,3216_CAM016154_d.JPG,major
+CAM016162,https://zenodo.org/record/3082688/files/CAM016162_d.JPG,1,3232,notabilis x lativitta,3232_CAM016162_d.JPG,major
+CAM016153,https://zenodo.org/record/3082688/files/CAM016153_d.JPG,1,3214,notabilis x lativitta,3214_CAM016153_d.JPG,major
+CAM016151,https://zenodo.org/record/3082688/files/CAM016151_d.JPG,1,3210,notabilis x lativitta,3210_CAM016151_d.JPG,major
+CAM016150,https://zenodo.org/record/3082688/files/CAM016150_d.JPG,1,3208,notabilis x lativitta,3208_CAM016150_d.JPG,major
+CAM016149,https://zenodo.org/record/3082688/files/CAM016149_d.JPG,1,3206,notabilis x lativitta,3206_CAM016149_d.JPG,major
+CAM016148,https://zenodo.org/record/3082688/files/CAM016148_d.JPG,1,3204,notabilis x lativitta,3204_CAM016148_d.JPG,major
+CAM016147,https://zenodo.org/record/3082688/files/CAM016147_d.JPG,1,3202,notabilis x lativitta,3202_CAM016147_d.JPG,major
+CAM016146,https://zenodo.org/record/3082688/files/CAM016146_d.JPG,1,3200,notabilis x lativitta,3200_CAM016146_d.JPG,major
+CAM016145,https://zenodo.org/record/3082688/files/CAM016145_d.JPG,1,3198,notabilis x lativitta,3198_CAM016145_d.JPG,major
+CAM016144,https://zenodo.org/record/3082688/files/CAM016144_d.JPG,0,3196,malleti,3196_CAM016144_d.JPG,mimic
+CAM016152,https://zenodo.org/record/3082688/files/CAM016152_d.JPG,1,3212,notabilis x lativitta,3212_CAM016152_d.JPG,major
+CAM016163,https://zenodo.org/record/3082688/files/CAM016163_d.JPG,1,3234,notabilis x lativitta,3234_CAM016163_d.JPG,major
+CAM016185,https://zenodo.org/record/3082688/files/CAM016185_d.JPG,1,3278,notabilis x lativitta,3278_CAM016185_d.JPG,major
+CAM016184,https://zenodo.org/record/3082688/files/CAM016184_d.JPG,1,3276,notabilis x lativitta,3276_CAM016184_d.JPG,major
+CAM016183,https://zenodo.org/record/3082688/files/CAM016183_d.JPG,1,3274,notabilis x lativitta,3274_CAM016183_d.JPG,major
+CAM016182,https://zenodo.org/record/3082688/files/CAM016182_d.JPG,1,3272,notabilis x lativitta,3272_CAM016182_d.JPG,major
+CAM016181,https://zenodo.org/record/3082688/files/CAM016181_d.JPG,1,3270,notabilis x lativitta,3270_CAM016181_d.JPG,major
+CAM016180,https://zenodo.org/record/3082688/files/CAM016180_d.JPG,1,3268,notabilis x lativitta,3268_CAM016180_d.JPG,major
+CAM016179,https://zenodo.org/record/3082688/files/CAM016179_d.JPG,1,3266,notabilis x lativitta,3266_CAM016179_d.JPG,major
+CAM016178,https://zenodo.org/record/3082688/files/CAM016178_d.JPG,1,3264,notabilis x lativitta,3264_CAM016178_d.JPG,major
+CAM016164,https://zenodo.org/record/3082688/files/CAM016164_d.JPG,1,3236,notabilis x lativitta,3236_CAM016164_d.JPG,major
+CAM016177,https://zenodo.org/record/3082688/files/CAM016177_d.JPG,1,3262,notabilis x lativitta,3262_CAM016177_d.JPG,major
+CAM016174,https://zenodo.org/record/3082688/files/CAM016174_d.JPG,1,3256,notabilis x lativitta,3256_CAM016174_d.JPG,major
+CAM016172,https://zenodo.org/record/3082688/files/CAM016172_d.JPG,1,3252,notabilis x lativitta,3252_CAM016172_d.JPG,major
+CAM016171,https://zenodo.org/record/3082688/files/CAM016171_d.JPG,1,3250,notabilis x lativitta,3250_CAM016171_d.JPG,major
+CAM016170,https://zenodo.org/record/3082688/files/CAM016170_d.JPG,1,3248,notabilis x lativitta,3248_CAM016170_d.JPG,major
+CAM016169,https://zenodo.org/record/3082688/files/CAM016169_d.JPG,1,3246,notabilis x lativitta,3246_CAM016169_d.JPG,major
+CAM016168,https://zenodo.org/record/3082688/files/CAM016168_d.JPG,1,3244,notabilis x lativitta,3244_CAM016168_d.JPG,major
+CAM016167,https://zenodo.org/record/3082688/files/CAM016167_d.JPG,1,3242,notabilis x lativitta,3242_CAM016167_d.JPG,major
+CAM016176,https://zenodo.org/record/3082688/files/CAM016176_d.JPG,1,3260,notabilis x lativitta,3260_CAM016176_d.JPG,major
+CAM017049,https://zenodo.org/record/3082688/files/CAM017049_d.JPG,0,4447,malleti,4447_CAM017049_d.JPG,mimic
+CAM016552,https://zenodo.org/record/3082688/files/CAM016552_d.JPG,0,3713,malleti,3713_CAM016552_d.JPG,mimic
+CAM016557,https://zenodo.org/record/3082688/files/CAM016557_d.JPG,1,3719,notabilis x lativitta,3719_CAM016557_d.JPG,major
+CAM016559,https://zenodo.org/record/3082688/files/CAM016559_d.JPG,1,3723,notabilis x lativitta,3723_CAM016559_d.JPG,major
+CAM016560,https://zenodo.org/record/3082688/files/CAM016560_d.JPG,1,3725,notabilis x lativitta,3725_CAM016560_d.JPG,major
+CAM016562,https://zenodo.org/record/3082688/files/CAM016562_d.JPG,1,3729,notabilis x lativitta,3729_CAM016562_d.JPG,major
+CAM016566,https://zenodo.org/record/3082688/files/CAM016566_d.JPG,1,3737,notabilis x lativitta,3737_CAM016566_d.JPG,major
+CAM016567,https://zenodo.org/record/3082688/files/CAM016567_d.JPG,0,3739,malleti,3739_CAM016567_d.JPG,mimic
+CAM016551,https://zenodo.org/record/3082688/files/CAM016551_d.JPG,0,3711,malleti,3711_CAM016551_d.JPG,mimic
+CAM016550,https://zenodo.org/record/3082688/files/CAM016550_d.JPG,0,3709,malleti,3709_CAM016550_d.JPG,mimic
+CAM016549,https://zenodo.org/record/3082688/files/CAM016549_d.JPG,0,3707,malleti,3707_CAM016549_d.JPG,mimic
+CAM016548,https://zenodo.org/record/3082688/files/CAM016548_d.JPG,0,3705,malleti,3705_CAM016548_d.JPG,mimic
+CAM016518,https://zenodo.org/record/3082688/files/CAM016518_d.JPG,1,3669,notabilis x lativitta,3669_CAM016518_d.JPG,major
+CAM016520,https://zenodo.org/record/3082688/files/CAM016520_d.JPG,1,3671,notabilis x lativitta,3671_CAM016520_d.JPG,major
+CAM016521,https://zenodo.org/record/3082688/files/CAM016521_d.JPG,1,3673,notabilis x lativitta,3673_CAM016521_d.JPG,major
+CAM016522,https://zenodo.org/record/3082688/files/CAM016522_d.JPG,1,3675,notabilis x lativitta,3675_CAM016522_d.JPG,major
+CAM016523,https://zenodo.org/record/3082688/files/CAM016523_d.JPG,1,3677,notabilis x lativitta,3677_CAM016523_d.JPG,major
+CAM016524,https://zenodo.org/record/3082688/files/CAM016524_d.JPG,1,3679,notabilis x lativitta,3679_CAM016524_d.JPG,major
+CAM016525,https://zenodo.org/record/3082688/files/CAM016525_d.JPG,1,3681,notabilis x lativitta,3681_CAM016525_d.JPG,major
+CAM016526,https://zenodo.org/record/3082688/files/CAM016526_d.JPG,1,3683,notabilis x lativitta,3683_CAM016526_d.JPG,major
+CAM016527,https://zenodo.org/record/3082688/files/CAM016527_d.JPG,1,3685,notabilis x lativitta,3685_CAM016527_d.JPG,major
+CAM016540,https://zenodo.org/record/3082688/files/CAM016540_d.JPG,0,3691,malleti,3691_CAM016540_d.JPG,mimic
+CAM016541,https://zenodo.org/record/3082688/files/CAM016541_d.JPG,0,3693,malleti,3693_CAM016541_d.JPG,mimic
+CAM016542,https://zenodo.org/record/3082688/files/CAM016542_d.JPG,0,3695,malleti,3695_CAM016542_d.JPG,mimic
+CAM016544,https://zenodo.org/record/3082688/files/CAM016544_d.JPG,0,3697,malleti,3697_CAM016544_d.JPG,mimic
+CAM016545,https://zenodo.org/record/3082688/files/CAM016545_d.JPG,0,3699,malleti,3699_CAM016545_d.JPG,mimic
+CAM016546,https://zenodo.org/record/3082688/files/CAM016546_d.JPG,0,3701,malleti,3701_CAM016546_d.JPG,mimic
+CAM016547,https://zenodo.org/record/3082688/files/CAM016547_d.JPG,0,3703,malleti,3703_CAM016547_d.JPG,mimic
+CAM016538,https://zenodo.org/record/3082688/files/CAM016538_d.JPG,0,3687,malleti,3687_CAM016538_d.JPG,mimic
+CAM016517,https://zenodo.org/record/3082688/files/CAM016517_d.JPG,1,3667,notabilis x lativitta,3667_CAM016517_d.JPG,major
+CAM016577,https://zenodo.org/record/3082688/files/CAM016577_d.JPG,1,3745,notabilis x lativitta,3745_CAM016577_d.JPG,major
+CAM016635,https://zenodo.org/record/3082688/files/CAM016635_d.JPG,1,3811,notabilis x lativitta,3811_CAM016635_d.JPG,major
+CAM016636,https://zenodo.org/record/3082688/files/CAM016636_d.JPG,1,3813,notabilis x lativitta,3813_CAM016636_d.JPG,major
+CAM016639,https://zenodo.org/record/3082688/files/CAM016639_d.JPG,1,3817,notabilis x lativitta,3817_CAM016639_d.JPG,major
+CAM016641,https://zenodo.org/record/3082688/files/CAM016641_d.JPG,1,3819,notabilis x lativitta,3819_CAM016641_d.JPG,major
+CAM016643,https://zenodo.org/record/3082688/files/CAM016643_d.JPG,1,3821,notabilis x lativitta,3821_CAM016643_d.JPG,major
+CAM016644,https://zenodo.org/record/3082688/files/CAM016644_d.JPG,1,3823,notabilis x lativitta,3823_CAM016644_d.JPG,major
+CAM016645,https://zenodo.org/record/3082688/files/CAM016645_d.JPG,1,3825,notabilis x lativitta,3825_CAM016645_d.JPG,major
+CAM016646,https://zenodo.org/record/3082688/files/CAM016646_d.JPG,1,3827,notabilis x lativitta,3827_CAM016646_d.JPG,major
+CAM016647,https://zenodo.org/record/3082688/files/CAM016647_d.JPG,1,3829,notabilis x lativitta,3829_CAM016647_d.JPG,major
+CAM016648,https://zenodo.org/record/3082688/files/CAM016648_d.JPG,1,3831,notabilis x lativitta,3831_CAM016648_d.JPG,major
+CAM016649,https://zenodo.org/record/3082688/files/CAM016649_d.JPG,1,3833,notabilis x lativitta,3833_CAM016649_d.JPG,major
+CAM016650,https://zenodo.org/record/3082688/files/CAM016650_d.JPG,1,3835,notabilis x lativitta,3835_CAM016650_d.JPG,major
+CAM016611,https://zenodo.org/record/3082688/files/CAM016611_d.JPG,0,3807,malleti,3807_CAM016611_d.JPG,mimic
+CAM016610,https://zenodo.org/record/3082688/files/CAM016610_d.JPG,0,3805,malleti,3805_CAM016610_d.JPG,mimic
+CAM016609,https://zenodo.org/record/3082688/files/CAM016609_d.JPG,0,3803,malleti,3803_CAM016609_d.JPG,mimic
+CAM016580,https://zenodo.org/record/3082688/files/CAM016580_d.JPG,1,3751,notabilis x lativitta,3751_CAM016580_d.JPG,major
+CAM016582,https://zenodo.org/record/3082688/files/CAM016582_d.JPG,1,3755,notabilis x lativitta,3755_CAM016582_d.JPG,major
+CAM016584,https://zenodo.org/record/3082688/files/CAM016584_d.JPG,1,3759,notabilis x lativitta,3759_CAM016584_d.JPG,major
+CAM016585,https://zenodo.org/record/3082688/files/CAM016585_d.JPG,1,3761,notabilis x lativitta,3761_CAM016585_d.JPG,major
+CAM016578,https://zenodo.org/record/3082688/files/CAM016578_d.JPG,1,3747,notabilis x lativitta,3747_CAM016578_d.JPG,major
+CAM016588,https://zenodo.org/record/3082688/files/CAM016588_d.JPG,1,3767,notabilis x lativitta,3767_CAM016588_d.JPG,major
+CAM016590,https://zenodo.org/record/3082688/files/CAM016590_d.JPG,1,3771,notabilis x lativitta,3771_CAM016590_d.JPG,major
+CAM016594,https://zenodo.org/record/3082688/files/CAM016594_d.JPG,0,3777,malleti,3777_CAM016594_d.JPG,mimic
+CAM016595,https://zenodo.org/record/3082688/files/CAM016595_d.JPG,0,3779,malleti,3779_CAM016595_d.JPG,mimic
+CAM016598,https://zenodo.org/record/3082688/files/CAM016598_d.JPG,0,3783,malleti,3783_CAM016598_d.JPG,mimic
+CAM016599,https://zenodo.org/record/3082688/files/CAM016599_d.JPG,0,3785,malleti,3785_CAM016599_d.JPG,mimic
+CAM016606,https://zenodo.org/record/3082688/files/CAM016606_d.JPG,0,3799,malleti,3799_CAM016606_d.JPG,mimic
+CAM016516,https://zenodo.org/record/3082688/files/CAM016516_d.JPG,1,3665,notabilis x lativitta,3665_CAM016516_d.JPG,major
+CAM016515,https://zenodo.org/record/3082688/files/CAM016515_d.JPG,1,3663,notabilis x lativitta,3663_CAM016515_d.JPG,major
+CAM016514,https://zenodo.org/record/3082688/files/CAM016514_d.JPG,1,3661,notabilis x lativitta,3661_CAM016514_d.JPG,major
+CAM016410,https://zenodo.org/record/3082688/files/CAM016410_d.JPG,1,3531,notabilis x lativitta,3531_CAM016410_d.JPG,major
+CAM016415,https://zenodo.org/record/3082688/files/CAM016415_d.JPG,1,3541,notabilis x lativitta,3541_CAM016415_d.JPG,major
+CAM016463,https://zenodo.org/record/3082688/files/CAM016463_d.JPG,1,3623,notabilis x lativitta,3623_CAM016463_d.JPG,major
+CAM016464,https://zenodo.org/record/3082688/files/CAM016464_d.JPG,1,3625,notabilis x lativitta,3625_CAM016464_d.JPG,major
+CAM016465,https://zenodo.org/record/3082688/files/CAM016465_d.JPG,0,3627,malleti,3627_CAM016465_d.JPG,mimic
+CAM016466,https://zenodo.org/record/3082688/files/CAM016466_d.JPG,1,3629,notabilis x lativitta,3629_CAM016466_d.JPG,major
+CAM016462,https://zenodo.org/record/3082688/files/CAM016462_d.JPG,1,3621,notabilis x lativitta,3621_CAM016462_d.JPG,major
+CAM016506,https://zenodo.org/record/3082688/files/CAM016506_d.JPG,0,3645,malleti,3645_CAM016506_d.JPG,mimic
+CAM016507,https://zenodo.org/record/3082688/files/CAM016507_d.JPG,1,3647,notabilis x lativitta,3647_CAM016507_d.JPG,major
+CAM016512,https://zenodo.org/record/3082688/files/CAM016512_d.JPG,1,3657,notabilis x lativitta,3657_CAM016512_d.JPG,major
+CAM016513,https://zenodo.org/record/3082688/files/CAM016513_d.JPG,1,3659,notabilis x lativitta,3659_CAM016513_d.JPG,major
+CAM016461,https://zenodo.org/record/3082688/files/CAM016461_d.JPG,1,3619,notabilis x lativitta,3619_CAM016461_d.JPG,major
+CAM016459,https://zenodo.org/record/3082688/files/CAM016459_d.JPG,1,3617,notabilis x lativitta,3617_CAM016459_d.JPG,major
+CAM016423,https://zenodo.org/record/3082688/files/CAM016423_d.JPG,1,3557,notabilis x lativitta,3557_CAM016423_d.JPG,major
+CAM016426,https://zenodo.org/record/3082688/files/CAM016426_d.JPG,0,3563,malleti,3563_CAM016426_d.JPG,mimic
+CAM016447,https://zenodo.org/record/3082688/files/CAM016447_d.JPG,1,3599,notabilis x lativitta,3599_CAM016447_d.JPG,major
+CAM016448,https://zenodo.org/record/3082688/files/CAM016448_d.JPG,1,3601,notabilis x lativitta,3601_CAM016448_d.JPG,major
+CAM016079,https://zenodo.org/record/3082688/files/CAM016079_d.JPG,1,3066,notabilis x lativitta,3066_CAM016079_d.JPG,major
+CAM016452,https://zenodo.org/record/3082688/files/CAM016452_d.JPG,1,3607,notabilis x lativitta,3607_CAM016452_d.JPG,major
+CAM016453,https://zenodo.org/record/3082688/files/CAM016453_d.JPG,1,3609,notabilis x lativitta,3609_CAM016453_d.JPG,major
+CAM016455,https://zenodo.org/record/3082688/files/CAM016455_d.JPG,1,3611,notabilis x lativitta,3611_CAM016455_d.JPG,major
+CAM016456,https://zenodo.org/record/3082688/files/CAM016456_d.JPG,1,3613,notabilis x lativitta,3613_CAM016456_d.JPG,major
+CAM016458,https://zenodo.org/record/3082688/files/CAM016458_d.JPG,1,3615,notabilis x lativitta,3615_CAM016458_d.JPG,major
+CAM017051,https://zenodo.org/record/3082688/files/CAM017051_d.JPG,1,4451,notabilis x lativitta,4451_CAM017051_d.JPG,major
+CAM016026,https://zenodo.org/record/3082688/files/CAM016026_d.JPG,1,2961,notabilis x lativitta,2961_CAM016026_d.JPG,major
+CAM016025,https://zenodo.org/record/3082688/files/CAM016025_d.JPG,1,2959,notabilis x lativitta,2959_CAM016025_d.JPG,major
+CAM016024,https://zenodo.org/record/3082688/files/CAM016024_d.JPG,1,2957,notabilis x lativitta,2957_CAM016024_d.JPG,major
+CAM016023,https://zenodo.org/record/3082688/files/CAM016023_d.JPG,1,2955,notabilis x lativitta,2955_CAM016023_d.JPG,major
+CAM016022,https://zenodo.org/record/3082688/files/CAM016022_d.JPG,1,2953,notabilis x lativitta,2953_CAM016022_d.JPG,major
+CAM016027,https://zenodo.org/record/3082688/files/CAM016027_d.JPG,1,2963,notabilis x lativitta,2963_CAM016027_d.JPG,major
+CAM017341,https://zenodo.org/record/3082688/files/CAM017341_d.JPG,1,4960,notabilis x lativitta,4960_CAM017341_d.JPG,major
+CAM017343,https://zenodo.org/record/3082688/files/CAM017343_d.JPG,1,4964,notabilis x lativitta,4964_CAM017343_d.JPG,major
+CAM017344,https://zenodo.org/record/3082688/files/CAM017344_d.JPG,1,4966,notabilis x lativitta,4966_CAM017344_d.JPG,major
+CAM017346,https://zenodo.org/record/3082688/files/CAM017346_d.JPG,1,4970,notabilis x lativitta,4970_CAM017346_d.JPG,major
+CAM017347,https://zenodo.org/record/3082688/files/CAM017347_d.JPG,1,4972,notabilis x lativitta,4972_CAM017347_d.JPG,major
+CAM017348,https://zenodo.org/record/3082688/files/CAM017348_d.JPG,1,4974,notabilis x lativitta,4974_CAM017348_d.JPG,major
+CAM017349,https://zenodo.org/record/3082688/files/CAM017349_d.JPG,1,4976,notabilis x lativitta,4976_CAM017349_d.JPG,major
+CAM017350,https://zenodo.org/record/3082688/files/CAM017350_d.JPG,1,4978,notabilis x lativitta,4978_CAM017350_d.JPG,major
+CAM016021,https://zenodo.org/record/3082688/files/CAM016021_d.JPG,1,2951,notabilis x lativitta,2951_CAM016021_d.JPG,major
+CAM016020,https://zenodo.org/record/3082688/files/CAM016020_d.JPG,1,2949,notabilis x lativitta,2949_CAM016020_d.JPG,major
+CAM017610,https://zenodo.org/record/3082688/files/CAM017610_d.JPG,1,5382,notabilis x lativitta,5382_CAM017610_d.JPG,major
+CAM017375,https://zenodo.org/record/3082688/files/CAM017375_d.JPG,0,5002,notabilis,5002_CAM017375_d.JPG,major
+CAM016014,https://zenodo.org/record/3082688/files/CAM016014_d.JPG,0,2937,notabilis,2937_CAM016014_d.JPG,major
+CAM017272,https://zenodo.org/record/3082688/files/CAM017272_d.JPG,0,4856,malleti,4856_CAM017272_d.JPG,mimic
+CAM017283,https://zenodo.org/record/3082688/files/CAM017283_d.JPG,0,4878,malleti,4878_CAM017283_d.JPG,mimic
+CAM017324,https://zenodo.org/record/3082688/files/CAM017324_d.JPG,0,4932,notabilis,4932_CAM017324_d.JPG,major
+CAM017320,https://zenodo.org/record/3082688/files/CAM017320_d.JPG,0,4924,notabilis,4924_CAM017320_d.JPG,major
+CAM017321,https://zenodo.org/record/3082688/files/CAM017321_d.JPG,0,4926,notabilis,4926_CAM017321_d.JPG,major
+CAM017322,https://zenodo.org/record/3082688/files/CAM017322_d.JPG,0,4928,notabilis,4928_CAM017322_d.JPG,major
+CAM017323,https://zenodo.org/record/3082688/files/CAM017323_d.JPG,0,4930,notabilis,4930_CAM017323_d.JPG,major
+CAM017381,https://zenodo.org/record/3082688/files/CAM017381_d.JPG,0,5012,malleti,5012_CAM017381_d.JPG,mimic
+CAM017400,https://zenodo.org/record/3082688/files/CAM017400_d.JPG,0,5043,malleti,5043_CAM017400_d.JPG,mimic
+CAM017385,https://zenodo.org/record/3082688/files/CAM017385_d.JPG,0,5020,malleti,5020_CAM017385_d.JPG,mimic
+CAM017387,https://zenodo.org/record/3082688/files/CAM017387_d.JPG,0,5024,malleti,5024_CAM017387_d.JPG,mimic
+CAM017412,https://zenodo.org/record/3082688/files/CAM017412_d.JPG,0,5061,malleti,5061_CAM017412_d.JPG,mimic
+CAM017269,https://zenodo.org/record/3082688/files/CAM017269_d.JPG,0,4850,malleti,4850_CAM017269_d.JPG,mimic
+CAM017126,https://zenodo.org/record/3082688/files/CAM017126_d.JPG,0,4581,malleti,4581_CAM017126_d.JPG,mimic
+CAM017117,https://zenodo.org/record/3082688/files/CAM017117_d.JPG,0,4563,malleti,4563_CAM017117_d.JPG,mimic
+CAM017120,https://zenodo.org/record/3082688/files/CAM017120_d.JPG,0,4569,malleti,4569_CAM017120_d.JPG,mimic
+CAM017121,https://zenodo.org/record/3082688/files/CAM017121_d.JPG,0,4571,malleti,4571_CAM017121_d.JPG,mimic
+CAM017134,https://zenodo.org/record/3082688/files/CAM017134_d.JPG,0,4597,malleti,4597_CAM017134_d.JPG,mimic
+CAM017156,https://zenodo.org/record/3082688/files/CAM017156_d.JPG,0,4637,malleti,4637_CAM017156_d.JPG,mimic
+CAM017136,https://zenodo.org/record/3082688/files/CAM017136_d.JPG,0,4601,malleti,4601_CAM017136_d.JPG,mimic
+CAM017137,https://zenodo.org/record/3082688/files/CAM017137_d.JPG,0,4603,malleti,4603_CAM017137_d.JPG,mimic
+CAM017138,https://zenodo.org/record/3082688/files/CAM017138_d.JPG,0,4605,malleti,4605_CAM017138_d.JPG,mimic
+CAM017069,https://zenodo.org/record/3082688/files/CAM017069_d.JPG,0,4487,malleti,4487_CAM017069_d.JPG,mimic
+CAM017070,https://zenodo.org/record/3082688/files/CAM017070_d.JPG,0,4489,malleti,4489_CAM017070_d.JPG,mimic
+CAM017071,https://zenodo.org/record/3082688/files/CAM017071_d.JPG,0,4491,malleti,4491_CAM017071_d.JPG,mimic
+CAM017073,https://zenodo.org/record/3082688/files/CAM017073_d.JPG,0,4495,malleti,4495_CAM017073_d.JPG,mimic
+CAM017064,https://zenodo.org/record/3082688/files/CAM017064_d.JPG,0,4477,malleti,4477_CAM017064_d.JPG,mimic
+CAM017093,https://zenodo.org/record/3082688/files/CAM017093_d.JPG,0,4527,malleti,4527_CAM017093_d.JPG,mimic
+CAM017099,https://zenodo.org/record/3082688/files/CAM017099_d.JPG,0,4537,malleti,4537_CAM017099_d.JPG,mimic
+CAM017100,https://zenodo.org/record/3082688/files/CAM017100_d.JPG,0,4539,malleti,4539_CAM017100_d.JPG,mimic
+CAM017103,https://zenodo.org/record/3082688/files/CAM017103_d.JPG,0,4543,malleti,4543_CAM017103_d.JPG,mimic
+CAM017104,https://zenodo.org/record/3082688/files/CAM017104_d.JPG,0,4545,malleti,4545_CAM017104_d.JPG,mimic
+CAM017092,https://zenodo.org/record/3082688/files/CAM017092_d.JPG,0,4525,malleti,4525_CAM017092_d.JPG,mimic
+CAM017091,https://zenodo.org/record/3082688/files/CAM017091_d.JPG,0,4523,malleti,4523_CAM017091_d.JPG,mimic
+CAM017081,https://zenodo.org/record/3082688/files/CAM017081_d.JPG,0,4503,malleti,4503_CAM017081_d.JPG,mimic
+CAM017083,https://zenodo.org/record/3082688/files/CAM017083_d.JPG,0,4507,malleti,4507_CAM017083_d.JPG,mimic
+CAM017089,https://zenodo.org/record/3082688/files/CAM017089_d.JPG,0,4519,malleti,4519_CAM017089_d.JPG,mimic
+CAM017154,https://zenodo.org/record/3082688/files/CAM017154_d.JPG,0,4633,malleti,4633_CAM017154_d.JPG,mimic
+CAM017236,https://zenodo.org/record/3082688/files/CAM017236_d.JPG,0,4789,notabilis,4789_CAM017236_d.JPG,major
+CAM017237,https://zenodo.org/record/3082688/files/CAM017237_d.JPG,0,4791,notabilis,4791_CAM017237_d.JPG,major
+CAM017238,https://zenodo.org/record/3082688/files/CAM017238_d.JPG,0,4793,notabilis,4793_CAM017238_d.JPG,major
+CAM017239,https://zenodo.org/record/3082688/files/CAM017239_d.JPG,0,4795,notabilis,4795_CAM017239_d.JPG,major
+CAM017216,https://zenodo.org/record/3082688/files/CAM017216_d.JPG,0,4749,notabilis,4749_CAM017216_d.JPG,major
+CAM017217,https://zenodo.org/record/3082688/files/CAM017217_d.JPG,0,4751,notabilis,4751_CAM017217_d.JPG,major
+CAM017219,https://zenodo.org/record/3082688/files/CAM017219_d.JPG,0,4755,notabilis,4755_CAM017219_d.JPG,major
+CAM017228,https://zenodo.org/record/3082688/files/CAM017228_d.JPG,0,4773,notabilis,4773_CAM017228_d.JPG,major
+CAM017221,https://zenodo.org/record/3082688/files/CAM017221_d.JPG,0,4759,notabilis,4759_CAM017221_d.JPG,major
+CAM017223,https://zenodo.org/record/3082688/files/CAM017223_d.JPG,0,4763,notabilis,4763_CAM017223_d.JPG,major
+CAM017227,https://zenodo.org/record/3082688/files/CAM017227_d.JPG,0,4771,notabilis,4771_CAM017227_d.JPG,major
+CAM017240,https://zenodo.org/record/3082688/files/CAM017240_d.JPG,0,4797,notabilis,4797_CAM017240_d.JPG,major
+CAM017241,https://zenodo.org/record/3082688/files/CAM017241_d.JPG,0,4799,notabilis,4799_CAM017241_d.JPG,major
+CAM017259,https://zenodo.org/record/3082688/files/CAM017259_d.JPG,0,4830,notabilis,4830_CAM017259_d.JPG,major
+CAM017260,https://zenodo.org/record/3082688/files/CAM017260_d.JPG,0,4832,notabilis,4832_CAM017260_d.JPG,major
+CAM017261,https://zenodo.org/record/3082688/files/CAM017261_d.JPG,0,4834,notabilis,4834_CAM017261_d.JPG,major
+CAM017262,https://zenodo.org/record/3082688/files/CAM017262_d.JPG,0,4836,notabilis,4836_CAM017262_d.JPG,major
+CAM017268,https://zenodo.org/record/3082688/files/CAM017268_d.JPG,0,4848,malleti,4848_CAM017268_d.JPG,mimic
+CAM017263,https://zenodo.org/record/3082688/files/CAM017263_d.JPG,0,4838,notabilis,4838_CAM017263_d.JPG,major
+CAM017254,https://zenodo.org/record/3082688/files/CAM017254_d.JPG,0,4825,notabilis,4825_CAM017254_d.JPG,major
+CAM017253,https://zenodo.org/record/3082688/files/CAM017253_d.JPG,0,4823,notabilis,4823_CAM017253_d.JPG,major
+CAM017242,https://zenodo.org/record/3082688/files/CAM017242_d.JPG,0,4801,notabilis,4801_CAM017242_d.JPG,major
+CAM017243,https://zenodo.org/record/3082688/files/CAM017243_d.JPG,0,4803,notabilis,4803_CAM017243_d.JPG,major
+CAM017244,https://zenodo.org/record/3082688/files/CAM017244_d.JPG,0,4805,notabilis,4805_CAM017244_d.JPG,major
+CAM017245,https://zenodo.org/record/3082688/files/CAM017245_d.JPG,0,4807,notabilis,4807_CAM017245_d.JPG,major
+CAM017247,https://zenodo.org/record/3082688/files/CAM017247_d.JPG,0,4811,notabilis,4811_CAM017247_d.JPG,major
+CAM017248,https://zenodo.org/record/3082688/files/CAM017248_d.JPG,0,4813,notabilis,4813_CAM017248_d.JPG,major
+CAM017249,https://zenodo.org/record/3082688/files/CAM017249_d.JPG,0,4815,notabilis,4815_CAM017249_d.JPG,major
+CAM017250,https://zenodo.org/record/3082688/files/CAM017250_d.JPG,0,4817,notabilis,4817_CAM017250_d.JPG,major
+CAM017251,https://zenodo.org/record/3082688/files/CAM017251_d.JPG,0,4819,notabilis,4819_CAM017251_d.JPG,major
+CAM017252,https://zenodo.org/record/3082688/files/CAM017252_d.JPG,0,4821,notabilis,4821_CAM017252_d.JPG,major
+CAM017246,https://zenodo.org/record/3082688/files/CAM017246_d.JPG,0,4809,notabilis,4809_CAM017246_d.JPG,major
+CAM017214,https://zenodo.org/record/3082688/files/CAM017214_d.JPG,0,4745,notabilis,4745_CAM017214_d.JPG,major
+CAM017212,https://zenodo.org/record/3082688/files/CAM017212_d.JPG,0,4741,notabilis,4741_CAM017212_d.JPG,major
+CAM017176,https://zenodo.org/record/3082688/files/CAM017176_d.JPG,0,4672,notabilis,4672_CAM017176_d.JPG,major
+CAM017177,https://zenodo.org/record/3082688/files/CAM017177_d.JPG,0,4674,notabilis,4674_CAM017177_d.JPG,major
+CAM017178,https://zenodo.org/record/3082688/files/CAM017178_d.JPG,0,4676,notabilis,4676_CAM017178_d.JPG,major
+19N0638,https://zenodo.org/record/4288311/files/19N0638_d.JPG,0,19932,malleti,19932_19N0638_d.JPG,mimic
+19N0336,https://zenodo.org/record/4288311/files/19N0336_d.JPG,0,19778,malleti,19778_19N0336_d.JPG,mimic
+19N0341,https://zenodo.org/record/4288311/files/19N0341_d.JPG,0,19780,malleti,19780_19N0341_d.JPG,mimic
+19N0372,https://zenodo.org/record/4288311/files/19N0372_d.JPG,0,19786,malleti,19786_19N0372_d.JPG,mimic
+19N0416,https://zenodo.org/record/4288311/files/19N0416_d.JPG,0,19811,malleti,19811_19N0416_d.JPG,mimic
+19N0437,https://zenodo.org/record/4288311/files/19N0437_d.JPG,0,19820,malleti,19820_19N0437_d.JPG,mimic
+19N0438,https://zenodo.org/record/4288311/files/19N0438_d.JPG,0,19822,malleti,19822_19N0438_d.JPG,mimic
+19N0330,https://zenodo.org/record/4288311/files/19N0330_d.JPG,0,19770,malleti,19770_19N0330_d.JPG,mimic
+19N0325,https://zenodo.org/record/4288311/files/19N0325_d.JPG,0,19766,malleti,19766_19N0325_d.JPG,mimic
+19N0288,https://zenodo.org/record/4288311/files/19N0288_d.JPG,0,19720,malleti,19720_19N0288_d.JPG,mimic
+19N0291,https://zenodo.org/record/4288311/files/19N0291_d.JPG,0,19722,malleti,19722_19N0291_d.JPG,mimic
+19N0298,https://zenodo.org/record/4288311/files/19N0298_d.JPG,0,19730,malleti,19730_19N0298_d.JPG,mimic
+19N0299,https://zenodo.org/record/4288311/files/19N0299_d.JPG,0,19732,malleti,19732_19N0299_d.JPG,mimic
+19N0301,https://zenodo.org/record/4288311/files/19N0301_d.JPG,0,19734,malleti,19734_19N0301_d.JPG,mimic
+19N0302,https://zenodo.org/record/4288311/files/19N0302_d.JPG,0,19736,malleti,19736_19N0302_d.JPG,mimic
+19N0439,https://zenodo.org/record/4288311/files/19N0439_d.JPG,0,19824,malleti,19824_19N0439_d.JPG,mimic
+19N0306,https://zenodo.org/record/4288311/files/19N0306_d.JPG,0,19744,malleti,19744_19N0306_d.JPG,mimic
+19N0314,https://zenodo.org/record/4288311/files/19N0314_d.JPG,0,19750,malleti,19750_19N0314_d.JPG,mimic
+19N0315,https://zenodo.org/record/4288311/files/19N0315_d.JPG,0,19752,malleti,19752_19N0315_d.JPG,mimic
+19N0317,https://zenodo.org/record/4288311/files/19N0317_d.JPG,0,19754,malleti,19754_19N0317_d.JPG,mimic
+19N0323,https://zenodo.org/record/4288311/files/19N0323_d.JPG,0,19762,malleti,19762_19N0323_d.JPG,mimic
+19N0324,https://zenodo.org/record/4288311/files/19N0324_d.JPG,0,19764,malleti,19764_19N0324_d.JPG,mimic
+19N0304,https://zenodo.org/record/4288311/files/19N0304_d.JPG,0,19740,malleti,19740_19N0304_d.JPG,mimic
+19N0575,https://zenodo.org/record/4288311/files/19N0575_d.JPG,0,19896,malleti,19896_19N0575_d.JPG,mimic
+19N0582,https://zenodo.org/record/4288311/files/19N0582_d.JPG,0,19898,malleti,19898_19N0582_d.JPG,mimic
+19N0583,https://zenodo.org/record/4288311/files/19N0583_d.JPG,0,19900,malleti,19900_19N0583_d.JPG,mimic
+19N0584,https://zenodo.org/record/4288311/files/19N0584_d.JPG,0,19902,malleti,19902_19N0584_d.JPG,mimic
+19N0599,https://zenodo.org/record/4288311/files/19N0599_d.JPG,0,19906,malleti,19906_19N0599_d.JPG,mimic
+19N0608,https://zenodo.org/record/4288311/files/19N0608_d.JPG,0,19908,malleti,19908_19N0608_d.JPG,mimic
+19N0613,https://zenodo.org/record/4288311/files/19N0613_d.JPG,0,19910,malleti,19910_19N0613_d.JPG,mimic
+19N0614,https://zenodo.org/record/4288311/files/19N0614_d.JPG,0,19912,malleti,19912_19N0614_d.JPG,mimic
+19N0615,https://zenodo.org/record/4288311/files/19N0615_d.JPG,0,19914,malleti,19914_19N0615_d.JPG,mimic
+19N0624,https://zenodo.org/record/4288311/files/19N0624_d.JPG,0,19916,malleti,19916_19N0624_d.JPG,mimic
+19N0630,https://zenodo.org/record/4288311/files/19N0630_d.JPG,0,19920,malleti,19920_19N0630_d.JPG,mimic
+19N0660,https://zenodo.org/record/4288311/files/19N0660_d.JPG,0,19950,malleti,19950_19N0660_d.JPG,mimic
+19N0659,https://zenodo.org/record/4288311/files/19N0659_d.JPG,0,19948,malleti,19948_19N0659_d.JPG,mimic
+19N0658,https://zenodo.org/record/4288311/files/19N0658_d.JPG,0,19946,malleti,19946_19N0658_d.JPG,mimic
+19N0657,https://zenodo.org/record/4288311/files/19N0657_d.JPG,0,19944,malleti,19944_19N0657_d.JPG,mimic
+19N0648,https://zenodo.org/record/4288311/files/19N0648_d.JPG,0,19942,malleti,19942_19N0648_d.JPG,mimic
+19N0646,https://zenodo.org/record/4288311/files/19N0646_d.JPG,0,19938,malleti,19938_19N0646_d.JPG,mimic
+19N0640,https://zenodo.org/record/4288311/files/19N0640_d.JPG,0,19936,malleti,19936_19N0640_d.JPG,mimic
+19N0639,https://zenodo.org/record/4288311/files/19N0639_d.JPG,0,19934,malleti,19934_19N0639_d.JPG,mimic
+19N0564,https://zenodo.org/record/4288311/files/19N0564_d.JPG,0,19890,malleti,19890_19N0564_d.JPG,mimic
+19N0635,https://zenodo.org/record/4288311/files/19N0635_d.JPG,0,19930,malleti,19930_19N0635_d.JPG,mimic
+19N0528,https://zenodo.org/record/4288311/files/19N0528_d.JPG,0,19882,malleti,19882_19N0528_d.JPG,mimic
+19N0647,https://zenodo.org/record/4288311/files/19N0647_d.JPG,0,19940,malleti,19940_19N0647_d.JPG,mimic
+19N0144,https://zenodo.org/record/4288311/files/19N0144_d.JPG,0,19433,malleti,19433_19N0144_d.JPG,mimic
+19N1063,https://zenodo.org/record/4288311/files/19N1063_d.JPG,0,20170,malleti,20170_19N1063_d.JPG,mimic
+19N1037,https://zenodo.org/record/4288311/files/19N1037_d.JPG,0,20166,malleti,20166_19N1037_d.JPG,mimic
+19N1034,https://zenodo.org/record/4288311/files/19N1034_d.JPG,0,20159,malleti,20159_19N1034_d.JPG,mimic
+19N1020,https://zenodo.org/record/4288311/files/19N1020_d.JPG,0,20155,malleti,20155_19N1020_d.JPG,mimic
+19N1018,https://zenodo.org/record/4288311/files/19N1018_d.JPG,0,20151,malleti,20151_19N1018_d.JPG,mimic
+19N1065,https://zenodo.org/record/4288311/files/19N1065_d.JPG,0,20174,malleti,20174_19N1065_d.JPG,mimic
+19N0982,https://zenodo.org/record/4288311/files/19N0982_d.JPG,0,20137,malleti,20137_19N0982_d.JPG,mimic
+19N0981,https://zenodo.org/record/4288311/files/19N0981_d.JPG,0,20135,malleti,20135_19N0981_d.JPG,mimic
+19N0957,https://zenodo.org/record/4288311/files/19N0957_d.JPG,0,20126,malleti,20126_19N0957_d.JPG,mimic
+19N0956,https://zenodo.org/record/4288311/files/19N0956_d.JPG,0,20124,malleti,20124_19N0956_d.JPG,mimic
+19N0955,https://zenodo.org/record/4288311/files/19N0955_d.JPG,0,20122,malleti,20122_19N0955_d.JPG,mimic
+19N0954,https://zenodo.org/record/4288311/files/19N0954_d.JPG,0,20120,malleti,20120_19N0954_d.JPG,mimic
+19N0953,https://zenodo.org/record/4288311/files/19N0953_d.JPG,0,20118,malleti,20118_19N0953_d.JPG,mimic
+19N0948,https://zenodo.org/record/4288311/files/19N0948_d.JPG,0,20116,malleti,20116_19N0948_d.JPG,mimic
+19N0946,https://zenodo.org/record/4288311/files/19N0946_d.JPG,0,20112,malleti,20112_19N0946_d.JPG,mimic
+19N0983,https://zenodo.org/record/4288311/files/19N0983_d.JPG,0,20139,malleti,20139_19N0983_d.JPG,mimic
+19N1095,https://zenodo.org/record/4288311/files/19N1095_d.JPG,0,20180,malleti,20180_19N1095_d.JPG,mimic
+19N1237,https://zenodo.org/record/4288311/files/19N1237_d.JPG,0,20247,malleti,20247_19N1237_d.JPG,mimic
+19N1236,https://zenodo.org/record/4288311/files/19N1236_d.JPG,0,20245,malleti,20245_19N1236_d.JPG,mimic
+15N309,https://zenodo.org/record/4289223/files/15N309_d.JPG,0,15228,venus,15228_15N309_d.JPG,minor
+15N323,https://zenodo.org/record/4289223/files/15N323_d.JPG,0,15232,venus,15232_15N323_d.JPG,minor
+15N320,https://zenodo.org/record/4289223/files/15N320_d.JPG,0,15230,venus,15230_15N320_d.JPG,minor
+15N104,https://zenodo.org/record/4289223/files/15N104_d.JPG,1,15165,venus x chestertonii,15165_15N104_d.JPG,minor
+CAM041538,https://zenodo.org/record/4291095/files/CAM041538_d.JPG,0,39124,lativitta,39124_CAM041538_d.JPG,major
+CAM041537,https://zenodo.org/record/4291095/files/CAM041537_d.JPG,0,39120,lativitta,39120_CAM041537_d.JPG,major
+CAM041536,https://zenodo.org/record/4291095/files/CAM041536_d.JPG,0,39116,lativitta,39116_CAM041536_d.JPG,major
+CAM041491,https://zenodo.org/record/4291095/files/CAM041491_d.JPG,0,38936,lativitta,38936_CAM041491_d.JPG,major
+CAM041479,https://zenodo.org/record/4291095/files/CAM041479_d.JPG,0,38888,lativitta,38888_CAM041479_d.JPG,major
+CAM041478,https://zenodo.org/record/4291095/files/CAM041478_d.JPG,0,38880,lativitta,38880_CAM041478_d.JPG,major
+CAM041476,https://zenodo.org/record/4291095/files/CAM041476_d.JPG,0,38872,lativitta,38872_CAM041476_d.JPG,major
+CAM041386,https://zenodo.org/record/4291095/files/CAM041386_d.JPG,0,38524,lativitta,38524_CAM041386_d.JPG,major
+CAM041385,https://zenodo.org/record/4291095/files/CAM041385_d.JPG,0,38520,lativitta,38520_CAM041385_d.JPG,major
+CAM041384,https://zenodo.org/record/4291095/files/CAM041384_d.JPG,0,38516,lativitta,38516_CAM041384_d.JPG,major
+CAM041383,https://zenodo.org/record/4291095/files/CAM041383_d.JPG,0,38512,lativitta,38512_CAM041383_d.JPG,major
+CAM041382,https://zenodo.org/record/4291095/files/CAM041382_d.JPG,0,38508,lativitta,38508_CAM041382_d.JPG,major
+CAM041381,https://zenodo.org/record/4291095/files/CAM041381_d.JPG,0,38504,lativitta,38504_CAM041381_d.JPG,major
+CAM041380,https://zenodo.org/record/4291095/files/CAM041380_d.JPG,0,38500,lativitta,38500_CAM041380_d.JPG,major
+CAM041379,https://zenodo.org/record/4291095/files/CAM041379_d.JPG,0,38496,lativitta,38496_CAM041379_d.JPG,major
+CAM041378,https://zenodo.org/record/4291095/files/CAM041378_d.JPG,0,38492,lativitta,38492_CAM041378_d.JPG,major
+CAM041698,https://zenodo.org/record/4291095/files/CAM041698_d.JPG,0,39759,lativitta,39759_CAM041698_d.JPG,major
+CAM041366,https://zenodo.org/record/4291095/files/CAM041366_d.JPG,0,38444,lativitta,38444_CAM041366_d.JPG,major
+CAM041365,https://zenodo.org/record/4291095/files/CAM041365_d.JPG,0,38440,lativitta,38440_CAM041365_d.JPG,major
+CAM041364,https://zenodo.org/record/4291095/files/CAM041364_d.JPG,0,38436,lativitta,38436_CAM041364_d.JPG,major
+CAM041363,https://zenodo.org/record/4291095/files/CAM041363_d.JPG,0,38432,lativitta,38432_CAM041363_d.JPG,major
+CAM041362,https://zenodo.org/record/4291095/files/CAM041362_d.JPG,0,38428,lativitta,38428_CAM041362_d.JPG,major
+CAM041361,https://zenodo.org/record/4291095/files/CAM041361_d.JPG,0,38424,lativitta,38424_CAM041361_d.JPG,major
+CAM041360,https://zenodo.org/record/4291095/files/CAM041360_d.JPG,0,38420,lativitta,38420_CAM041360_d.JPG,major
+CAM041359,https://zenodo.org/record/4291095/files/CAM041359_d.JPG,0,38416,lativitta,38416_CAM041359_d.JPG,major
+CAM041387,https://zenodo.org/record/4291095/files/CAM041387_d.JPG,0,38528,lativitta,38528_CAM041387_d.JPG,major
+CAM041586,https://zenodo.org/record/4291095/files/CAM041586_d.JPG,0,39311,lativitta,39311_CAM041586_d.JPG,major
+CAM041388,https://zenodo.org/record/4291095/files/CAM041388_d.JPG,0,38532,lativitta,38532_CAM041388_d.JPG,major
+CAM041393,https://zenodo.org/record/4291095/files/CAM041393_d.JPG,0,38544,lativitta,38544_CAM041393_d.JPG,major
+CAM041473,https://zenodo.org/record/4291095/files/CAM041473_d.JPG,0,38864,lativitta,38864_CAM041473_d.JPG,major
+CAM041472,https://zenodo.org/record/4291095/files/CAM041472_d.JPG,0,38860,lativitta,38860_CAM041472_d.JPG,major
+CAM041467,https://zenodo.org/record/4291095/files/CAM041467_d.JPG,0,38840,lativitta,38840_CAM041467_d.JPG,major
+CAM041442,https://zenodo.org/record/4291095/files/CAM041442_d.JPG,0,38740,lativitta,38740_CAM041442_d.JPG,major
+CAM041441,https://zenodo.org/record/4291095/files/CAM041441_d.JPG,0,38736,lativitta,38736_CAM041441_d.JPG,major
+CAM041440,https://zenodo.org/record/4291095/files/CAM041440_d.JPG,0,38732,lativitta,38732_CAM041440_d.JPG,major
+CAM041439,https://zenodo.org/record/4291095/files/CAM041439_d.JPG,0,38728,lativitta,38728_CAM041439_d.JPG,major
+CAM041438,https://zenodo.org/record/4291095/files/CAM041438_d.JPG,0,38724,lativitta,38724_CAM041438_d.JPG,major
+CAM041437,https://zenodo.org/record/4291095/files/CAM041437_d.JPG,0,38720,lativitta,38720_CAM041437_d.JPG,major
+CAM041436,https://zenodo.org/record/4291095/files/CAM041436_d.JPG,0,38716,lativitta,38716_CAM041436_d.JPG,major
+CAM041435,https://zenodo.org/record/4291095/files/CAM041435_d.JPG,0,38712,lativitta,38712_CAM041435_d.JPG,major
+CAM041434,https://zenodo.org/record/4291095/files/CAM041434_d.JPG,0,38708,lativitta,38708_CAM041434_d.JPG,major
+CAM041433,https://zenodo.org/record/4291095/files/CAM041433_d.JPG,0,38704,lativitta,38704_CAM041433_d.JPG,major
+CAM041432,https://zenodo.org/record/4291095/files/CAM041432_d.JPG,0,38700,lativitta,38700_CAM041432_d.JPG,major
+CAM041431,https://zenodo.org/record/4291095/files/CAM041431_d.JPG,0,38696,lativitta,38696_CAM041431_d.JPG,major
+CAM041430,https://zenodo.org/record/4291095/files/CAM041430_d.JPG,0,38692,lativitta,38692_CAM041430_d.JPG,major
+CAM041429,https://zenodo.org/record/4291095/files/CAM041429_d.JPG,0,38688,lativitta,38688_CAM041429_d.JPG,major
+CAM041428,https://zenodo.org/record/4291095/files/CAM041428_d.JPG,0,38684,lativitta,38684_CAM041428_d.JPG,major
+CAM041390,https://zenodo.org/record/4291095/files/CAM041390_d.JPG,0,38540,lativitta,38540_CAM041390_d.JPG,major
+CAM041358,https://zenodo.org/record/4291095/files/CAM041358_d.JPG,0,38412,lativitta,38412_CAM041358_d.JPG,major
+CAM041591,https://zenodo.org/record/4291095/files/CAM041591_d.JPG,0,39331,lativitta,39331_CAM041591_d.JPG,major
+CAM041667,https://zenodo.org/record/4291095/files/CAM041667_d.JPG,0,39635,lativitta,39635_CAM041667_d.JPG,major
+CAM041666,https://zenodo.org/record/4291095/files/CAM041666_d.JPG,0,39631,lativitta,39631_CAM041666_d.JPG,major
+CAM041665,https://zenodo.org/record/4291095/files/CAM041665_d.JPG,0,39627,lativitta,39627_CAM041665_d.JPG,major
+CAM041664,https://zenodo.org/record/4291095/files/CAM041664_d.JPG,0,39623,lativitta,39623_CAM041664_d.JPG,major
+CAM041663,https://zenodo.org/record/4291095/files/CAM041663_d.JPG,0,39619,lativitta,39619_CAM041663_d.JPG,major
+CAM041662,https://zenodo.org/record/4291095/files/CAM041662_d.JPG,0,39615,lativitta,39615_CAM041662_d.JPG,major
+CAM041661,https://zenodo.org/record/4291095/files/CAM041661_d.JPG,0,39611,lativitta,39611_CAM041661_d.JPG,major
+CAM041660,https://zenodo.org/record/4291095/files/CAM041660_d.JPG,0,39607,lativitta,39607_CAM041660_d.JPG,major
+CAM041659,https://zenodo.org/record/4291095/files/CAM041659_d.JPG,0,39603,lativitta,39603_CAM041659_d.JPG,major
+CAM041658,https://zenodo.org/record/4291095/files/CAM041658_d.JPG,0,39599,lativitta,39599_CAM041658_d.JPG,major
+CAM041668,https://zenodo.org/record/4291095/files/CAM041668_d.JPG,0,39639,lativitta,39639_CAM041668_d.JPG,major
+CAM041657,https://zenodo.org/record/4291095/files/CAM041657_d.JPG,0,39595,lativitta,39595_CAM041657_d.JPG,major
+CAM041655,https://zenodo.org/record/4291095/files/CAM041655_d.JPG,0,39587,lativitta,39587_CAM041655_d.JPG,major
+CAM041654,https://zenodo.org/record/4291095/files/CAM041654_d.JPG,0,39583,lativitta,39583_CAM041654_d.JPG,major
+CAM041653,https://zenodo.org/record/4291095/files/CAM041653_d.JPG,0,39579,lativitta,39579_CAM041653_d.JPG,major
+CAM041652,https://zenodo.org/record/4291095/files/CAM041652_d.JPG,0,39575,lativitta,39575_CAM041652_d.JPG,major
+CAM041651,https://zenodo.org/record/4291095/files/CAM041651_d.JPG,0,39571,lativitta,39571_CAM041651_d.JPG,major
+CAM041650,https://zenodo.org/record/4291095/files/CAM041650_d.JPG,0,39567,lativitta,39567_CAM041650_d.JPG,major
+CAM041649,https://zenodo.org/record/4291095/files/CAM041649_d.JPG,0,39563,lativitta,39563_CAM041649_d.JPG,major
+CAM041648,https://zenodo.org/record/4291095/files/CAM041648_d.JPG,0,39559,lativitta,39559_CAM041648_d.JPG,major
+CAM041647,https://zenodo.org/record/4291095/files/CAM041647_d.JPG,0,39555,lativitta,39555_CAM041647_d.JPG,major
+CAM041646,https://zenodo.org/record/4291095/files/CAM041646_d.JPG,0,39551,lativitta,39551_CAM041646_d.JPG,major
+CAM041656,https://zenodo.org/record/4291095/files/CAM041656_d.JPG,0,39591,lativitta,39591_CAM041656_d.JPG,major
+CAM041669,https://zenodo.org/record/4291095/files/CAM041669_d.JPG,0,39643,lativitta,39643_CAM041669_d.JPG,major
+CAM041670,https://zenodo.org/record/4291095/files/CAM041670_d.JPG,0,39647,lativitta,39647_CAM041670_d.JPG,major
+CAM041671,https://zenodo.org/record/4291095/files/CAM041671_d.JPG,0,39651,lativitta,39651_CAM041671_d.JPG,major
+CAM041699,https://zenodo.org/record/4291095/files/CAM041699_d.JPG,0,39763,lativitta,39763_CAM041699_d.JPG,major
+CAM041697,https://zenodo.org/record/4291095/files/CAM041697_d.JPG,0,39755,lativitta,39755_CAM041697_d.JPG,major
+CAM041696,https://zenodo.org/record/4291095/files/CAM041696_d.JPG,0,39751,lativitta,39751_CAM041696_d.JPG,major
+CAM041695,https://zenodo.org/record/4291095/files/CAM041695_d.JPG,0,39747,lativitta,39747_CAM041695_d.JPG,major
+CAM041694,https://zenodo.org/record/4291095/files/CAM041694_d.JPG,0,39743,lativitta,39743_CAM041694_d.JPG,major
+CAM041693,https://zenodo.org/record/4291095/files/CAM041693_d.JPG,0,39739,lativitta,39739_CAM041693_d.JPG,major
+CAM041692,https://zenodo.org/record/4291095/files/CAM041692_d.JPG,0,39735,lativitta,39735_CAM041692_d.JPG,major
+CAM041691,https://zenodo.org/record/4291095/files/CAM041691_d.JPG,0,39731,lativitta,39731_CAM041691_d.JPG,major
+CAM041690,https://zenodo.org/record/4291095/files/CAM041690_d.JPG,0,39727,lativitta,39727_CAM041690_d.JPG,major
+CAM041689,https://zenodo.org/record/4291095/files/CAM041689_d.JPG,0,39723,lativitta,39723_CAM041689_d.JPG,major
+CAM041685,https://zenodo.org/record/4291095/files/CAM041685_d.JPG,0,39707,lativitta,39707_CAM041685_d.JPG,major
+CAM041684,https://zenodo.org/record/4291095/files/CAM041684_d.JPG,0,39703,lativitta,39703_CAM041684_d.JPG,major
+CAM041683,https://zenodo.org/record/4291095/files/CAM041683_d.JPG,0,39699,lativitta,39699_CAM041683_d.JPG,major
+CAM041682,https://zenodo.org/record/4291095/files/CAM041682_d.JPG,0,39695,lativitta,39695_CAM041682_d.JPG,major
+CAM041680,https://zenodo.org/record/4291095/files/CAM041680_d.JPG,0,39687,lativitta,39687_CAM041680_d.JPG,major
+CAM041679,https://zenodo.org/record/4291095/files/CAM041679_d.JPG,0,39683,lativitta,39683_CAM041679_d.JPG,major
+CAM041678,https://zenodo.org/record/4291095/files/CAM041678_d.JPG,0,39679,lativitta,39679_CAM041678_d.JPG,major
+CAM041677,https://zenodo.org/record/4291095/files/CAM041677_d.JPG,0,39675,lativitta,39675_CAM041677_d.JPG,major
+CAM041676,https://zenodo.org/record/4291095/files/CAM041676_d.JPG,0,39671,lativitta,39671_CAM041676_d.JPG,major
+CAM041675,https://zenodo.org/record/4291095/files/CAM041675_d.JPG,0,39667,lativitta,39667_CAM041675_d.JPG,major
+CAM041674,https://zenodo.org/record/4291095/files/CAM041674_d.JPG,0,39663,lativitta,39663_CAM041674_d.JPG,major
+CAM041673,https://zenodo.org/record/4291095/files/CAM041673_d.JPG,0,39659,lativitta,39659_CAM041673_d.JPG,major
+CAM041672,https://zenodo.org/record/4291095/files/CAM041672_d.JPG,0,39655,lativitta,39655_CAM041672_d.JPG,major
+CAM041645,https://zenodo.org/record/4291095/files/CAM041645_d.JPG,0,39547,lativitta,39547_CAM041645_d.JPG,major
+CAM041644,https://zenodo.org/record/4291095/files/CAM041644_d.JPG,0,39543,lativitta,39543_CAM041644_d.JPG,major
+CAM041643,https://zenodo.org/record/4291095/files/CAM041643_d.JPG,0,39539,lativitta,39539_CAM041643_d.JPG,major
+CAM041642,https://zenodo.org/record/4291095/files/CAM041642_d.JPG,0,39535,lativitta,39535_CAM041642_d.JPG,major
+CAM041614,https://zenodo.org/record/4291095/files/CAM041614_d.JPG,0,39423,lativitta,39423_CAM041614_d.JPG,major
+CAM041613,https://zenodo.org/record/4291095/files/CAM041613_d.JPG,0,39419,lativitta,39419_CAM041613_d.JPG,major
+CAM041612,https://zenodo.org/record/4291095/files/CAM041612_d.JPG,0,39415,lativitta,39415_CAM041612_d.JPG,major
+CAM041611,https://zenodo.org/record/4291095/files/CAM041611_d.JPG,0,39411,lativitta,39411_CAM041611_d.JPG,major
+CAM041610,https://zenodo.org/record/4291095/files/CAM041610_d.JPG,0,39407,lativitta,39407_CAM041610_d.JPG,major
+CAM041609,https://zenodo.org/record/4291095/files/CAM041609_d.JPG,0,39403,lativitta,39403_CAM041609_d.JPG,major
+CAM041608,https://zenodo.org/record/4291095/files/CAM041608_d.JPG,0,39399,lativitta,39399_CAM041608_d.JPG,major
+CAM041607,https://zenodo.org/record/4291095/files/CAM041607_d.JPG,0,39395,lativitta,39395_CAM041607_d.JPG,major
+CAM041606,https://zenodo.org/record/4291095/files/CAM041606_d.JPG,0,39391,lativitta,39391_CAM041606_d.JPG,major
+CAM041605,https://zenodo.org/record/4291095/files/CAM041605_d.JPG,0,39387,lativitta,39387_CAM041605_d.JPG,major
+CAM041604,https://zenodo.org/record/4291095/files/CAM041604_d.JPG,0,39383,lativitta,39383_CAM041604_d.JPG,major
+CAM041603,https://zenodo.org/record/4291095/files/CAM041603_d.JPG,0,39379,lativitta,39379_CAM041603_d.JPG,major
+CAM041602,https://zenodo.org/record/4291095/files/CAM041602_d.JPG,0,39375,lativitta,39375_CAM041602_d.JPG,major
+CAM041601,https://zenodo.org/record/4291095/files/CAM041601_d.JPG,0,39371,lativitta,39371_CAM041601_d.JPG,major
+CAM041600,https://zenodo.org/record/4291095/files/CAM041600_d.JPG,0,39367,lativitta,39367_CAM041600_d.JPG,major
+CAM041599,https://zenodo.org/record/4291095/files/CAM041599_d.JPG,0,39363,lativitta,39363_CAM041599_d.JPG,major
+CAM041598,https://zenodo.org/record/4291095/files/CAM041598_d.JPG,0,39359,lativitta,39359_CAM041598_d.JPG,major
+CAM041597,https://zenodo.org/record/4291095/files/CAM041597_d.JPG,0,39355,lativitta,39355_CAM041597_d.JPG,major
+CAM041596,https://zenodo.org/record/4291095/files/CAM041596_d.JPG,0,39351,lativitta,39351_CAM041596_d.JPG,major
+CAM041595,https://zenodo.org/record/4291095/files/CAM041595_d.JPG,0,39347,lativitta,39347_CAM041595_d.JPG,major
+CAM041594,https://zenodo.org/record/4291095/files/CAM041594_d.JPG,0,39343,lativitta,39343_CAM041594_d.JPG,major
+CAM041593,https://zenodo.org/record/4291095/files/CAM041593_d.JPG,0,39339,lativitta,39339_CAM041593_d.JPG,major
+CAM041592,https://zenodo.org/record/4291095/files/CAM041592_d.JPG,0,39335,lativitta,39335_CAM041592_d.JPG,major
+CAM041615,https://zenodo.org/record/4291095/files/CAM041615_d.JPG,0,39427,lativitta,39427_CAM041615_d.JPG,major
+CAM041616,https://zenodo.org/record/4291095/files/CAM041616_d.JPG,0,39431,lativitta,39431_CAM041616_d.JPG,major
+CAM041618,https://zenodo.org/record/4291095/files/CAM041618_d.JPG,0,39439,lativitta,39439_CAM041618_d.JPG,major
+CAM041641,https://zenodo.org/record/4291095/files/CAM041641_d.JPG,0,39531,lativitta,39531_CAM041641_d.JPG,major
+CAM041640,https://zenodo.org/record/4291095/files/CAM041640_d.JPG,0,39527,lativitta,39527_CAM041640_d.JPG,major
+CAM041639,https://zenodo.org/record/4291095/files/CAM041639_d.JPG,0,39523,lativitta,39523_CAM041639_d.JPG,major
+CAM041638,https://zenodo.org/record/4291095/files/CAM041638_d.JPG,0,39519,lativitta,39519_CAM041638_d.JPG,major
+CAM041637,https://zenodo.org/record/4291095/files/CAM041637_d.JPG,0,39515,lativitta,39515_CAM041637_d.JPG,major
+CAM041636,https://zenodo.org/record/4291095/files/CAM041636_d.JPG,0,39511,lativitta,39511_CAM041636_d.JPG,major
+CAM041635,https://zenodo.org/record/4291095/files/CAM041635_d.JPG,0,39507,lativitta,39507_CAM041635_d.JPG,major
+CAM041634,https://zenodo.org/record/4291095/files/CAM041634_d.JPG,0,39503,lativitta,39503_CAM041634_d.JPG,major
+CAM041633,https://zenodo.org/record/4291095/files/CAM041633_d.JPG,0,39499,lativitta,39499_CAM041633_d.JPG,major
+CAM041632,https://zenodo.org/record/4291095/files/CAM041632_d.JPG,0,39495,lativitta,39495_CAM041632_d.JPG,major
+CAM041631,https://zenodo.org/record/4291095/files/CAM041631_d.JPG,0,39491,lativitta,39491_CAM041631_d.JPG,major
+CAM041630,https://zenodo.org/record/4291095/files/CAM041630_d.JPG,0,39487,lativitta,39487_CAM041630_d.JPG,major
+CAM041629,https://zenodo.org/record/4291095/files/CAM041629_d.JPG,0,39483,lativitta,39483_CAM041629_d.JPG,major
+CAM041628,https://zenodo.org/record/4291095/files/CAM041628_d.JPG,0,39479,lativitta,39479_CAM041628_d.JPG,major
+CAM041627,https://zenodo.org/record/4291095/files/CAM041627_d.JPG,0,39475,lativitta,39475_CAM041627_d.JPG,major
+CAM041626,https://zenodo.org/record/4291095/files/CAM041626_d.JPG,0,39471,lativitta,39471_CAM041626_d.JPG,major
+CAM041625,https://zenodo.org/record/4291095/files/CAM041625_d.JPG,0,39467,lativitta,39467_CAM041625_d.JPG,major
+CAM041624,https://zenodo.org/record/4291095/files/CAM041624_d.JPG,0,39463,lativitta,39463_CAM041624_d.JPG,major
+CAM041623,https://zenodo.org/record/4291095/files/CAM041623_d.JPG,0,39459,lativitta,39459_CAM041623_d.JPG,major
+CAM041622,https://zenodo.org/record/4291095/files/CAM041622_d.JPG,0,39455,lativitta,39455_CAM041622_d.JPG,major
+CAM041621,https://zenodo.org/record/4291095/files/CAM041621_d.JPG,0,39451,lativitta,39451_CAM041621_d.JPG,major
+CAM041620,https://zenodo.org/record/4291095/files/CAM041620_d.JPG,0,39447,lativitta,39447_CAM041620_d.JPG,major
+CAM041619,https://zenodo.org/record/4291095/files/CAM041619_d.JPG,0,39443,lativitta,39443_CAM041619_d.JPG,major
+CAM041617,https://zenodo.org/record/4291095/files/CAM041617_d.JPG,0,39435,lativitta,39435_CAM041617_d.JPG,major
+CAM041357,https://zenodo.org/record/4291095/files/CAM041357_d.JPG,0,38408,lativitta,38408_CAM041357_d.JPG,major
+CAM041389,https://zenodo.org/record/4291095/files/CAM041389_d.JPG,0,38536,lativitta,38536_CAM041389_d.JPG,major
+CAM041355,https://zenodo.org/record/4291095/files/CAM041355_d.JPG,0,38400,lativitta,38400_CAM041355_d.JPG,major
+CAM041777,https://zenodo.org/record/4291095/files/CAM041777_d.JPG,0,40075,lativitta,40075_CAM041777_d.JPG,major
+CAM041776,https://zenodo.org/record/4291095/files/CAM041776_d.JPG,0,40071,lativitta,40071_CAM041776_d.JPG,major
+CAM041775,https://zenodo.org/record/4291095/files/CAM041775_d.JPG,0,40067,lativitta,40067_CAM041775_d.JPG,major
+CAM041774,https://zenodo.org/record/4291095/files/CAM041774_d.JPG,0,40063,lativitta,40063_CAM041774_d.JPG,major
+CAM041773,https://zenodo.org/record/4291095/files/CAM041773_d.JPG,0,40059,lativitta,40059_CAM041773_d.JPG,major
+CAM041772,https://zenodo.org/record/4291095/files/CAM041772_d.JPG,0,40055,lativitta,40055_CAM041772_d.JPG,major
+CAM041771,https://zenodo.org/record/4291095/files/CAM041771_d.JPG,0,40051,lativitta,40051_CAM041771_d.JPG,major
+CAM041770,https://zenodo.org/record/4291095/files/CAM041770_d.JPG,0,40047,lativitta,40047_CAM041770_d.JPG,major
+CAM041769,https://zenodo.org/record/4291095/files/CAM041769_d.JPG,0,40043,lativitta,40043_CAM041769_d.JPG,major
+CAM041768,https://zenodo.org/record/4291095/files/CAM041768_d.JPG,0,40039,lativitta,40039_CAM041768_d.JPG,major
+CAM041767,https://zenodo.org/record/4291095/files/CAM041767_d.JPG,0,40035,lativitta,40035_CAM041767_d.JPG,major
+CAM041766,https://zenodo.org/record/4291095/files/CAM041766_d.JPG,0,40031,lativitta,40031_CAM041766_d.JPG,major
+CAM041765,https://zenodo.org/record/4291095/files/CAM041765_d.JPG,0,40027,lativitta,40027_CAM041765_d.JPG,major
+CAM041764,https://zenodo.org/record/4291095/files/CAM041764_d.JPG,0,40023,lativitta,40023_CAM041764_d.JPG,major
+CAM041763,https://zenodo.org/record/4291095/files/CAM041763_d.JPG,0,40019,lativitta,40019_CAM041763_d.JPG,major
+CAM041762,https://zenodo.org/record/4291095/files/CAM041762_d.JPG,0,40015,lativitta,40015_CAM041762_d.JPG,major
+CAM041761,https://zenodo.org/record/4291095/files/CAM041761_d.JPG,0,40011,lativitta,40011_CAM041761_d.JPG,major
+CAM041760,https://zenodo.org/record/4291095/files/CAM041760_d.JPG,0,40007,lativitta,40007_CAM041760_d.JPG,major
+CAM041759,https://zenodo.org/record/4291095/files/CAM041759_d.JPG,0,40003,lativitta,40003_CAM041759_d.JPG,major
+CAM041758,https://zenodo.org/record/4291095/files/CAM041758_d.JPG,0,39999,lativitta,39999_CAM041758_d.JPG,major
+CAM041757,https://zenodo.org/record/4291095/files/CAM041757_d.JPG,0,39995,lativitta,39995_CAM041757_d.JPG,major
+CAM041756,https://zenodo.org/record/4291095/files/CAM041756_d.JPG,0,39991,lativitta,39991_CAM041756_d.JPG,major
+CAM041755,https://zenodo.org/record/4291095/files/CAM041755_d.JPG,0,39987,lativitta,39987_CAM041755_d.JPG,major
+CAM041778,https://zenodo.org/record/4291095/files/CAM041778_d.JPG,0,40079,lativitta,40079_CAM041778_d.JPG,major
+CAM041754,https://zenodo.org/record/4291095/files/CAM041754_d.JPG,0,39983,lativitta,39983_CAM041754_d.JPG,major
+CAM041356,https://zenodo.org/record/4291095/files/CAM041356_d.JPG,0,38404,lativitta,38404_CAM041356_d.JPG,major
+CAM041781,https://zenodo.org/record/4291095/files/CAM041781_d.JPG,0,40091,lativitta,40091_CAM041781_d.JPG,major
+CAM041804,https://zenodo.org/record/4291095/files/CAM041804_d.JPG,0,40183,lativitta,40183_CAM041804_d.JPG,major
+CAM045107,https://zenodo.org/record/5526257/files/CAM045107_d.JPG,0,42993,cyrbia,42993_CAM045107_d.JPG,minor
+CAM045106,https://zenodo.org/record/5526257/files/CAM045106_d.JPG,0,42989,cyrbia,42989_CAM045106_d.JPG,minor
+CAM045105,https://zenodo.org/record/5526257/files/CAM045105_d.JPG,0,42985,cyrbia,42985_CAM045105_d.JPG,minor
+CAM045104,https://zenodo.org/record/5526257/files/CAM045104_d.JPG,0,42981,cyrbia,42981_CAM045104_d.JPG,minor
+CAM045118,https://zenodo.org/record/5526257/files/CAM045118_d.JPG,0,43039,cyrbia,43039_CAM045118_d.JPG,minor
+CAM045069,https://zenodo.org/record/5526257/files/CAM045069_d.JPG,0,42841,cyrbia,42841_CAM045069_d.JPG,minor
+CAM045068,https://zenodo.org/record/5526257/files/CAM045068_d.JPG,0,42837,cyrbia,42837_CAM045068_d.JPG,minor
+CAM045067,https://zenodo.org/record/5526257/files/CAM045067_d.JPG,0,42833,cyrbia,42833_CAM045067_d.JPG,minor
+CAM045031,https://zenodo.org/record/5526257/files/CAM045031_d.JPG,0,42689,cyrbia,42689_CAM045031_d.JPG,minor
+CAM045030,https://zenodo.org/record/5526257/files/CAM045030_d.JPG,0,42685,cyrbia,42685_CAM045030_d.JPG,minor
+CAM045029,https://zenodo.org/record/5526257/files/CAM045029_d.JPG,0,42681,cyrbia,42681_CAM045029_d.JPG,minor
+CAM045028,https://zenodo.org/record/5526257/files/CAM045028_d.JPG,0,42677,cyrbia,42677_CAM045028_d.JPG,minor
+CAM045027,https://zenodo.org/record/5526257/files/CAM045027_d.JPG,0,42673,cyrbia,42673_CAM045027_d.JPG,minor
+CAM045026,https://zenodo.org/record/5526257/files/CAM045026_d.JPG,0,42669,cyrbia,42669_CAM045026_d.JPG,minor
+CAM045025,https://zenodo.org/record/5526257/files/CAM045025_d.JPG,0,42665,cyrbia,42665_CAM045025_d.JPG,minor
+CAM045024,https://zenodo.org/record/5526257/files/CAM045024_d.JPG,0,42661,cyrbia,42661_CAM045024_d.JPG,minor
+CAM045023,https://zenodo.org/record/5526257/files/CAM045023_d.JPG,0,42657,cyrbia,42657_CAM045023_d.JPG,minor
+CAM045022,https://zenodo.org/record/5526257/files/CAM045022_d.JPG,0,42653,cyrbia,42653_CAM045022_d.JPG,minor
+CAM045021,https://zenodo.org/record/5526257/files/CAM045021_d.JPG,0,42649,cyrbia,42649_CAM045021_d.JPG,minor
+CAM045020,https://zenodo.org/record/5526257/files/CAM045020_d.JPG,0,42645,cyrbia,42645_CAM045020_d.JPG,minor
+CAM045018,https://zenodo.org/record/5526257/files/CAM045018_d.JPG,0,42637,cyrbia,42637_CAM045018_d.JPG,minor
+CAM045017,https://zenodo.org/record/5526257/files/CAM045017_d.JPG,0,42633,cyrbia,42633_CAM045017_d.JPG,minor
+CAM045032,https://zenodo.org/record/5526257/files/CAM045032_d.JPG,0,42693,cyrbia,42693_CAM045032_d.JPG,minor
+CAM045016,https://zenodo.org/record/5526257/files/CAM045016_d.JPG,0,42629,cyrbia,42629_CAM045016_d.JPG,minor
+CAM045014,https://zenodo.org/record/5526257/files/CAM045014_d.JPG,0,42621,cyrbia,42621_CAM045014_d.JPG,minor
+CAM045013,https://zenodo.org/record/5526257/files/CAM045013_d.JPG,0,42617,cyrbia,42617_CAM045013_d.JPG,minor
+CAM045012,https://zenodo.org/record/5526257/files/CAM045012_d.JPG,0,42613,cyrbia,42613_CAM045012_d.JPG,minor
+CAM045011,https://zenodo.org/record/5526257/files/CAM045011_d.JPG,0,42609,cyrbia,42609_CAM045011_d.JPG,minor
+CAM045010,https://zenodo.org/record/5526257/files/CAM045010_d.JPG,0,42605,cyrbia,42605_CAM045010_d.JPG,minor
+CAM045009,https://zenodo.org/record/5526257/files/CAM045009_d.JPG,0,42598,cyrbia,42598_CAM045009_d.JPG,minor
+CAM045008,https://zenodo.org/record/5526257/files/CAM045008_d.JPG,0,42595,cyrbia,42595_CAM045008_d.JPG,minor
+CAM045007,https://zenodo.org/record/5526257/files/CAM045007_d.JPG,0,42591,cyrbia,42591_CAM045007_d.JPG,minor
+CAM045006,https://zenodo.org/record/5526257/files/CAM045006_d.JPG,0,42584,cyrbia,42584_CAM045006_d.JPG,minor
+CAM045005,https://zenodo.org/record/5526257/files/CAM045005_d.JPG,0,42579,cyrbia,42579_CAM045005_d.JPG,minor
+CAM045004,https://zenodo.org/record/5526257/files/CAM045004_d.JPG,0,42575,cyrbia,42575_CAM045004_d.JPG,minor
+CAM045003,https://zenodo.org/record/5526257/files/CAM045003_d.JPG,0,42571,cyrbia,42571_CAM045003_d.JPG,minor
+CAM045002,https://zenodo.org/record/5526257/files/CAM045002_d.JPG,0,42567,cyrbia,42567_CAM045002_d.JPG,minor
+CAM045001,https://zenodo.org/record/5526257/files/CAM045001_d.JPG,0,42563,cyrbia,42563_CAM045001_d.JPG,minor
+CAM045015,https://zenodo.org/record/5526257/files/CAM045015_d.JPG,0,42625,cyrbia,42625_CAM045015_d.JPG,minor
+CAM045033,https://zenodo.org/record/5526257/files/CAM045033_d.JPG,0,42697,cyrbia,42697_CAM045033_d.JPG,minor
+CAM045034,https://zenodo.org/record/5526257/files/CAM045034_d.JPG,0,42701,cyrbia,42701_CAM045034_d.JPG,minor
+CAM045035,https://zenodo.org/record/5526257/files/CAM045035_d.JPG,0,42705,cyrbia,42705_CAM045035_d.JPG,minor
+CAM045066,https://zenodo.org/record/5526257/files/CAM045066_d.JPG,0,42829,cyrbia,42829_CAM045066_d.JPG,minor
+CAM045065,https://zenodo.org/record/5526257/files/CAM045065_d.JPG,0,42825,cyrbia,42825_CAM045065_d.JPG,minor
+CAM045064,https://zenodo.org/record/5526257/files/CAM045064_d.JPG,0,42821,cyrbia,42821_CAM045064_d.JPG,minor
+CAM045063,https://zenodo.org/record/5526257/files/CAM045063_d.JPG,0,42817,cyrbia,42817_CAM045063_d.JPG,minor
+CAM045062,https://zenodo.org/record/5526257/files/CAM045062_d.JPG,0,42813,cyrbia,42813_CAM045062_d.JPG,minor
+CAM045061,https://zenodo.org/record/5526257/files/CAM045061_d.JPG,0,42809,cyrbia,42809_CAM045061_d.JPG,minor
+CAM045060,https://zenodo.org/record/5526257/files/CAM045060_d.JPG,0,42805,cyrbia,42805_CAM045060_d.JPG,minor
+CAM045059,https://zenodo.org/record/5526257/files/CAM045059_d.JPG,0,42801,cyrbia,42801_CAM045059_d.JPG,minor
+CAM045058,https://zenodo.org/record/5526257/files/CAM045058_d.JPG,0,42797,cyrbia,42797_CAM045058_d.JPG,minor
+CAM045057,https://zenodo.org/record/5526257/files/CAM045057_d.JPG,0,42793,cyrbia,42793_CAM045057_d.JPG,minor
+CAM045056,https://zenodo.org/record/5526257/files/CAM045056_d.JPG,0,42789,cyrbia,42789_CAM045056_d.JPG,minor
+CAM045055,https://zenodo.org/record/5526257/files/CAM045055_d.JPG,0,42785,cyrbia,42785_CAM045055_d.JPG,minor
+CAM045054,https://zenodo.org/record/5526257/files/CAM045054_d.JPG,0,42781,cyrbia,42781_CAM045054_d.JPG,minor
+CAM045053,https://zenodo.org/record/5526257/files/CAM045053_d.JPG,0,42777,cyrbia,42777_CAM045053_d.JPG,minor
+CAM045052,https://zenodo.org/record/5526257/files/CAM045052_d.JPG,0,42773,cyrbia,42773_CAM045052_d.JPG,minor
+CAM045051,https://zenodo.org/record/5526257/files/CAM045051_d.JPG,0,42769,cyrbia,42769_CAM045051_d.JPG,minor
+CAM045050,https://zenodo.org/record/5526257/files/CAM045050_d.JPG,0,42765,cyrbia,42765_CAM045050_d.JPG,minor
+CAM045036,https://zenodo.org/record/5526257/files/CAM045036_d.JPG,0,42709,cyrbia,42709_CAM045036_d.JPG,minor
+CAM045037,https://zenodo.org/record/5526257/files/CAM045037_d.JPG,0,42713,cyrbia,42713_CAM045037_d.JPG,minor
+CAM045038,https://zenodo.org/record/5526257/files/CAM045038_d.JPG,0,42717,cyrbia,42717_CAM045038_d.JPG,minor
+CAM045039,https://zenodo.org/record/5526257/files/CAM045039_d.JPG,0,42721,cyrbia,42721_CAM045039_d.JPG,minor
+CAM045040,https://zenodo.org/record/5526257/files/CAM045040_d.JPG,0,42725,cyrbia,42725_CAM045040_d.JPG,minor
+CAM045041,https://zenodo.org/record/5526257/files/CAM045041_d.JPG,0,42729,cyrbia,42729_CAM045041_d.JPG,minor
+CAM045134,https://zenodo.org/record/5526257/files/CAM045134_d.JPG,0,43103,cyrbia,43103_CAM045134_d.JPG,minor
+CAM045042,https://zenodo.org/record/5526257/files/CAM045042_d.JPG,0,42733,cyrbia,42733_CAM045042_d.JPG,minor
+CAM045044,https://zenodo.org/record/5526257/files/CAM045044_d.JPG,0,42741,cyrbia,42741_CAM045044_d.JPG,minor
+CAM045045,https://zenodo.org/record/5526257/files/CAM045045_d.JPG,0,42745,cyrbia,42745_CAM045045_d.JPG,minor
+CAM045046,https://zenodo.org/record/5526257/files/CAM045046_d.JPG,0,42749,cyrbia,42749_CAM045046_d.JPG,minor
+CAM045047,https://zenodo.org/record/5526257/files/CAM045047_d.JPG,0,42753,cyrbia,42753_CAM045047_d.JPG,minor
+CAM045048,https://zenodo.org/record/5526257/files/CAM045048_d.JPG,0,42757,cyrbia,42757_CAM045048_d.JPG,minor
+CAM045049,https://zenodo.org/record/5526257/files/CAM045049_d.JPG,0,42761,cyrbia,42761_CAM045049_d.JPG,minor
+CAM045043,https://zenodo.org/record/5526257/files/CAM045043_d.JPG,0,42737,cyrbia,42737_CAM045043_d.JPG,minor
+CAM045135,https://zenodo.org/record/5526257/files/CAM045135_d.JPG,0,43107,cyrbia,43107_CAM045135_d.JPG,minor
+CAM045019,https://zenodo.org/record/5526257/files/CAM045019_d.JPG,0,42641,cyrbia,42641_CAM045019_d.JPG,minor
+CAM045137,https://zenodo.org/record/5526257/files/CAM045137_d.JPG,0,43115,cyrbia,43115_CAM045137_d.JPG,minor
+CAM045232,https://zenodo.org/record/5526257/files/CAM045232_d.JPG,0,43491,cyrbia,43491_CAM045232_d.JPG,minor
+CAM045233,https://zenodo.org/record/5526257/files/CAM045233_d.JPG,0,43495,cyrbia,43495_CAM045233_d.JPG,minor
+CAM045234,https://zenodo.org/record/5526257/files/CAM045234_d.JPG,0,43499,cyrbia,43499_CAM045234_d.JPG,minor
+CAM045236,https://zenodo.org/record/5526257/files/CAM045236_d.JPG,0,43507,cyrbia,43507_CAM045236_d.JPG,minor
+CAM045237,https://zenodo.org/record/5526257/files/CAM045237_d.JPG,0,43511,cyrbia,43511_CAM045237_d.JPG,minor
+CAM045238,https://zenodo.org/record/5526257/files/CAM045238_d.JPG,0,43515,cyrbia,43515_CAM045238_d.JPG,minor
+CAM045239,https://zenodo.org/record/5526257/files/CAM045239_d.JPG,0,43519,cyrbia,43519_CAM045239_d.JPG,minor
+CAM045240,https://zenodo.org/record/5526257/files/CAM045240_d.JPG,0,43523,cyrbia,43523_CAM045240_d.JPG,minor
+CAM045241,https://zenodo.org/record/5526257/files/CAM045241_d.JPG,0,43527,cyrbia,43527_CAM045241_d.JPG,minor
+CAM045242,https://zenodo.org/record/5526257/files/CAM045242_d.JPG,0,43531,cyrbia,43531_CAM045242_d.JPG,minor
+CAM045243,https://zenodo.org/record/5526257/files/CAM045243_d.JPG,0,43535,cyrbia,43535_CAM045243_d.JPG,minor
+CAM045244,https://zenodo.org/record/5526257/files/CAM045244_d.JPG,0,43539,cyrbia,43539_CAM045244_d.JPG,minor
+CAM045245,https://zenodo.org/record/5526257/files/CAM045245_d.JPG,0,43543,cyrbia,43543_CAM045245_d.JPG,minor
+CAM045246,https://zenodo.org/record/5526257/files/CAM045246_d.JPG,0,43547,cyrbia,43547_CAM045246_d.JPG,minor
+CAM045231,https://zenodo.org/record/5526257/files/CAM045231_d.JPG,0,43487,cyrbia,43487_CAM045231_d.JPG,minor
+CAM045247,https://zenodo.org/record/5526257/files/CAM045247_d.JPG,0,43551,cyrbia,43551_CAM045247_d.JPG,minor
+CAM045249,https://zenodo.org/record/5526257/files/CAM045249_d.JPG,0,43559,cyrbia,43559_CAM045249_d.JPG,minor
+CAM045250,https://zenodo.org/record/5526257/files/CAM045250_d.JPG,0,43563,cyrbia,43563_CAM045250_d.JPG,minor
+CAM045252,https://zenodo.org/record/5526257/files/CAM045252_d.JPG,0,43571,cyrbia,43571_CAM045252_d.JPG,minor
+CAM045253,https://zenodo.org/record/5526257/files/CAM045253_d.JPG,0,43575,cyrbia,43575_CAM045253_d.JPG,minor
+CAM045254,https://zenodo.org/record/5526257/files/CAM045254_d.JPG,0,43579,cyrbia,43579_CAM045254_d.JPG,minor
+CAM045255,https://zenodo.org/record/5526257/files/CAM045255_d.JPG,0,43583,cyrbia,43583_CAM045255_d.JPG,minor
+CAM045256,https://zenodo.org/record/5526257/files/CAM045256_d.JPG,0,43587,cyrbia,43587_CAM045256_d.JPG,minor
+CAM045257,https://zenodo.org/record/5526257/files/CAM045257_d.JPG,0,43591,cyrbia,43591_CAM045257_d.JPG,minor
+CAM045258,https://zenodo.org/record/5526257/files/CAM045258_d.JPG,0,43595,cyrbia,43595_CAM045258_d.JPG,minor
+CAM045259,https://zenodo.org/record/5526257/files/CAM045259_d.JPG,0,43599,cyrbia,43599_CAM045259_d.JPG,minor
+CAM045260,https://zenodo.org/record/5526257/files/CAM045260_d.JPG,0,43603,cyrbia,43603_CAM045260_d.JPG,minor
+CAM045261,https://zenodo.org/record/5526257/files/CAM045261_d.JPG,0,43607,cyrbia,43607_CAM045261_d.JPG,minor
+CAM036188,https://zenodo.org/record/5561246/files/CAM036188_d.JPG,0,41483,phyllis,41483_CAM036188_d.JPG,minor
+CAM036184,https://zenodo.org/record/5561246/files/CAM036184_d.JPG,0,41471,phyllis,41471_CAM036184_d.JPG,minor
+CAM036172,https://zenodo.org/record/5561246/files/CAM036172_d.JPG,0,41459,phyllis,41459_CAM036172_d.JPG,minor
+CAM036168,https://zenodo.org/record/5561246/files/CAM036168_d.JPG,0,41443,phyllis,41443_CAM036168_d.JPG,minor
+CAM036165,https://zenodo.org/record/5561246/files/CAM036165_d.JPG,0,41431,phyllis,41431_CAM036165_d.JPG,minor
+CAM036164,https://zenodo.org/record/5561246/files/CAM036164_d.JPG,0,41427,phyllis,41427_CAM036164_d.JPG,minor
+CAM036214,https://zenodo.org/record/5561246/files/CAM036214_d.JPG,0,41571,phyllis,41571_CAM036214_d.JPG,minor
+CAM036215,https://zenodo.org/record/5561246/files/CAM036215_d.JPG,0,41575,phyllis,41575_CAM036215_d.JPG,minor
+CAM036216,https://zenodo.org/record/5561246/files/CAM036216_d.JPG,0,41579,phyllis,41579_CAM036216_d.JPG,minor
+CAM036293,https://zenodo.org/record/5561246/files/CAM036293_d.JPG,0,41827,phyllis,41827_CAM036293_d.JPG,minor
+CAM036292,https://zenodo.org/record/5561246/files/CAM036292_d.JPG,0,41823,phyllis,41823_CAM036292_d.JPG,minor
+CAM036291,https://zenodo.org/record/5561246/files/CAM036291_d.JPG,0,41819,phyllis,41819_CAM036291_d.JPG,minor
+CAM036290,https://zenodo.org/record/5561246/files/CAM036290_d.JPG,0,41815,phyllis,41815_CAM036290_d.JPG,minor
+CAM036277,https://zenodo.org/record/5561246/files/CAM036277_d.JPG,0,41763,phyllis,41763_CAM036277_d.JPG,minor
+CAM036276,https://zenodo.org/record/5561246/files/CAM036276_d.JPG,0,41759,phyllis,41759_CAM036276_d.JPG,minor

--- a/reference_data/ref_test.csv
+++ b/reference_data/ref_test.csv
@@ -1,0 +1,2351 @@
+CAMID,file_url,hybrid_stat,split,X,subspecies_ref,filename,ssp_indicator
+F809,https://zenodo.org/record/2555086/files/F809_d.JPG,0,test,38048,demophoon,38048_F809_d.JPG,minor
+F866,https://zenodo.org/record/2555086/files/F866_d.JPG,0,test,38112,demophoon,38112_F866_d.JPG,minor
+F824,https://zenodo.org/record/2555086/files/F824_d.JPG,0,test,38052,demophoon,38052_F824_d.JPG,minor
+F844,https://zenodo.org/record/2555086/files/F844_d.JPG,0,test,38064,demophoon,38064_F844_d.JPG,minor
+F846,https://zenodo.org/record/2555086/files/F846_d.JPG,0,test,38068,demophoon,38068_F846_d.JPG,minor
+F848,https://zenodo.org/record/2555086/files/F848_d.JPG,0,test,38072,demophoon,38072_F848_d.JPG,minor
+F849,https://zenodo.org/record/2555086/files/F849_d.JPG,0,test,38076,demophoon,38076_F849_d.JPG,minor
+F837,https://zenodo.org/record/2555086/files/F837_d.JPG,0,test,38060,demophoon,38060_F837_d.JPG,minor
+F852,https://zenodo.org/record/2555086/files/F852_d.JPG,0,test,38084,demophoon,38084_F852_d.JPG,minor
+F853,https://zenodo.org/record/2555086/files/F853_d.JPG,0,test,38088,demophoon,38088_F853_d.JPG,minor
+F854,https://zenodo.org/record/2555086/files/F854_d.JPG,0,test,38092,demophoon,38092_F854_d.JPG,minor
+F858,https://zenodo.org/record/2555086/files/F858_d.JPG,0,test,38096,demophoon,38096_F858_d.JPG,minor
+F864,https://zenodo.org/record/2555086/files/F864_d.JPG,0,test,38104,demophoon,38104_F864_d.JPG,minor
+F862,https://zenodo.org/record/2555086/files/F862_d.JPG,0,test,38100,demophoon,38100_F862_d.JPG,minor
+F851,https://zenodo.org/record/2555086/files/F851_d.JPG,0,test,38080,demophoon,38080_F851_d.JPG,minor
+F8621,https://zenodo.org/record/2555086/files/F8621_d.JPG,0,test,38392,demophoon,38392_F8621_d.JPG,minor
+CAM000255,https://zenodo.org/record/2677821/files/CAM000255_d.JPG,0,test,6336,demophoon,6336_CAM000255_d.JPG,minor
+CAM000242,https://zenodo.org/record/2677821/files/CAM000242_d.JPG,0,test,6310,chestertonii,6310_CAM000242_d.JPG,minor
+CAM000241,https://zenodo.org/record/2677821/files/CAM000241_d.JPG,0,test,6308,chestertonii,6308_CAM000241_d.JPG,minor
+CAM000240,https://zenodo.org/record/2677821/files/CAM000240_d.JPG,0,test,6306,chestertonii,6306_CAM000240_d.JPG,minor
+CAM000239,https://zenodo.org/record/2677821/files/CAM000239_d.JPG,0,test,6304,chestertonii,6304_CAM000239_d.JPG,minor
+CAM000238,https://zenodo.org/record/2677821/files/CAM000238_d.JPG,0,test,6302,chestertonii,6302_CAM000238_d.JPG,minor
+CAM000237,https://zenodo.org/record/2677821/files/CAM000237_d.JPG,0,test,6300,chestertonii,6300_CAM000237_d.JPG,minor
+CAM000236,https://zenodo.org/record/2677821/files/CAM000236_d.JPG,0,test,6298,chestertonii,6298_CAM000236_d.JPG,minor
+CAM000235,https://zenodo.org/record/2677821/files/CAM000235_d.JPG,0,test,6296,chestertonii,6296_CAM000235_d.JPG,minor
+CAM000234,https://zenodo.org/record/2677821/files/CAM000234_d.JPG,0,test,6294,chestertonii,6294_CAM000234_d.JPG,minor
+CAM009553,https://zenodo.org/record/2686762/files/CAM009553_d.JPG,1,test,10848,hydara x petiverana,10848_CAM009553_d.JPG,minor
+CAM009568,https://zenodo.org/record/2686762/files/CAM009568_d.JPG,1,test,10878,hydara x petiverana,10878_CAM009568_d.JPG,minor
+CAM009574,https://zenodo.org/record/2686762/files/CAM009574_d.JPG,1,test,10890,hydara x petiverana,10890_CAM009574_d.JPG,minor
+CAM009510,https://zenodo.org/record/2686762/files/CAM009510_d.JPG,1,test,10762,hydara x petiverana,10762_CAM009510_d.JPG,minor
+CAM009513,https://zenodo.org/record/2686762/files/CAM009513_d.JPG,1,test,10768,hydara x petiverana,10768_CAM009513_d.JPG,minor
+CAM009518,https://zenodo.org/record/2686762/files/CAM009518_d.JPG,1,test,10778,hydara x petiverana,10778_CAM009518_d.JPG,minor
+CAM009520,https://zenodo.org/record/2686762/files/CAM009520_d.JPG,1,test,10782,hydara x petiverana,10782_CAM009520_d.JPG,minor
+CAM009523,https://zenodo.org/record/2686762/files/CAM009523_d.JPG,1,test,10788,hydara x petiverana,10788_CAM009523_d.JPG,minor
+CAM009526,https://zenodo.org/record/2686762/files/CAM009526_d.JPG,1,test,10794,hydara x petiverana,10794_CAM009526_d.JPG,minor
+CAM009534,https://zenodo.org/record/2686762/files/CAM009534_d.JPG,0,test,10810,petiverana,10810_CAM009534_d.JPG,minor
+CAM009503,https://zenodo.org/record/2686762/files/CAM009503_d.JPG,0,test,10748,petiverana,10748_CAM009503_d.JPG,minor
+CAM009304,https://zenodo.org/record/2686762/files/CAM009304_d.JPG,0,test,10460,hydara,10460_CAM009304_d.JPG,minor
+CAM009305,https://zenodo.org/record/2686762/files/CAM009305_d.JPG,0,test,10462,hydara,10462_CAM009305_d.JPG,minor
+CAM009306,https://zenodo.org/record/2686762/files/CAM009306_d.JPG,0,test,10464,hydara,10464_CAM009306_d.JPG,minor
+CAM009307,https://zenodo.org/record/2686762/files/CAM009307_d.JPG,0,test,10466,hydara,10466_CAM009307_d.JPG,minor
+CAM009328,https://zenodo.org/record/2686762/files/CAM009328_d.JPG,0,test,10508,hydara,10508_CAM009328_d.JPG,minor
+CAM009327,https://zenodo.org/record/2686762/files/CAM009327_d.JPG,0,test,10506,hydara,10506_CAM009327_d.JPG,minor
+CAM009326,https://zenodo.org/record/2686762/files/CAM009326_d.JPG,0,test,10504,hydara,10504_CAM009326_d.JPG,minor
+CAM009322,https://zenodo.org/record/2686762/files/CAM009322_d.JPG,0,test,10496,hydara,10496_CAM009322_d.JPG,minor
+CAM009321,https://zenodo.org/record/2686762/files/CAM009321_d.JPG,0,test,10494,hydara,10494_CAM009321_d.JPG,minor
+CAM009320,https://zenodo.org/record/2686762/files/CAM009320_d.JPG,0,test,10492,hydara,10492_CAM009320_d.JPG,minor
+CAM009313,https://zenodo.org/record/2686762/files/CAM009313_d.JPG,0,test,10478,hydara,10478_CAM009313_d.JPG,minor
+CAM009312,https://zenodo.org/record/2686762/files/CAM009312_d.JPG,0,test,10476,hydara,10476_CAM009312_d.JPG,minor
+CAM009311,https://zenodo.org/record/2686762/files/CAM009311_d.JPG,0,test,10474,hydara,10474_CAM009311_d.JPG,minor
+CAM009310,https://zenodo.org/record/2686762/files/CAM009310_d.JPG,0,test,10472,hydara,10472_CAM009310_d.JPG,minor
+CAM009309,https://zenodo.org/record/2686762/files/CAM009309_d.JPG,0,test,10470,hydara,10470_CAM009309_d.JPG,minor
+CAM009308,https://zenodo.org/record/2686762/files/CAM009308_d.JPG,0,test,10468,hydara,10468_CAM009308_d.JPG,minor
+CAM009014,https://zenodo.org/record/2686762/files/CAM009014_d.JPG,0,test,10133,hydara,10133_CAM009014_d.JPG,minor
+CAM009018,https://zenodo.org/record/2686762/files/CAM009018_d.JPG,0,test,10141,hydara,10141_CAM009018_d.JPG,minor
+CAM009017,https://zenodo.org/record/2686762/files/CAM009017_d.JPG,0,test,10139,hydara,10139_CAM009017_d.JPG,minor
+CAM021240,https://zenodo.org/record/2702457/files/CAM021240_d.JPG,0,test,11690,hydara,11690_CAM021240_d.JPG,minor
+CAM021239,https://zenodo.org/record/2702457/files/CAM021239_d.JPG,0,test,11688,hydara,11688_CAM021239_d.JPG,minor
+CAM021053,https://zenodo.org/record/2702457/files/CAM021053_d.JPG,0,test,11538,erato,11538_CAM021053_d.JPG,minor
+CAM021033,https://zenodo.org/record/2702457/files/CAM021033_d.JPG,1,test,11500,hydara x amalfreda,11500_CAM021033_d.JPG,minor
+CAM021034,https://zenodo.org/record/2702457/files/CAM021034_d.JPG,1,test,11502,hydara x amalfreda,11502_CAM021034_d.JPG,minor
+CAM021035,https://zenodo.org/record/2702457/files/CAM021035_d.JPG,1,test,11504,hydara x amalfreda,11504_CAM021035_d.JPG,minor
+CAM021038,https://zenodo.org/record/2702457/files/CAM021038_d.JPG,0,test,11508,amalfreda,11508_CAM021038_d.JPG,minor
+CAM021039,https://zenodo.org/record/2702457/files/CAM021039_d.JPG,0,test,11510,amalfreda,11510_CAM021039_d.JPG,minor
+CAM021040,https://zenodo.org/record/2702457/files/CAM021040_d.JPG,0,test,11512,amalfreda,11512_CAM021040_d.JPG,minor
+CAM021041,https://zenodo.org/record/2702457/files/CAM021041_d.JPG,0,test,11514,amalfreda,11514_CAM021041_d.JPG,minor
+CAM021042,https://zenodo.org/record/2702457/files/CAM021042_d.JPG,0,test,11516,amalfreda,11516_CAM021042_d.JPG,minor
+CAM021032,https://zenodo.org/record/2702457/files/CAM021032_d.JPG,1,test,11498,hydara x amalfreda,11498_CAM021032_d.JPG,minor
+CAM021067,https://zenodo.org/record/2702457/files/CAM021067_d.JPG,0,test,11563,erato,11563_CAM021067_d.JPG,minor
+CAM021063,https://zenodo.org/record/2702457/files/CAM021063_d.JPG,0,test,11555,erato,11555_CAM021063_d.JPG,minor
+CAM040078,https://zenodo.org/record/2707828/files/CAM040078_d.JPG,0,test,11820,dignus,11820_CAM040078_d.JPG,minor
+CAM040077,https://zenodo.org/record/2707828/files/CAM040077_d.JPG,0,test,11818,dignus,11818_CAM040077_d.JPG,minor
+CAM040066,https://zenodo.org/record/2707828/files/CAM040066_d.JPG,0,test,11812,dignus,11812_CAM040066_d.JPG,minor
+CAM040039,https://zenodo.org/record/2707828/files/CAM040039_d.JPG,0,test,11758,dignus,11758_CAM040039_d.JPG,minor
+CS004059,https://zenodo.org/record/2813153/files/CS004059_d.JPG,0,test,14384,reductimacula,14384_CS004059_d.JPG,minor
+CAM016323,https://zenodo.org/record/3082688/files/CAM016323_d.JPG,0,test-2,3420,plesseni,3420_CAM016323_d.JPG,mimic
+CAM016324,https://zenodo.org/record/3082688/files/CAM016324_d.JPG,0,test-2,3422,plesseni,3422_CAM016324_d.JPG,mimic
+CAM016341,https://zenodo.org/record/3082688/files/CAM016341_d.JPG,1,test-2,3430,plesseni x malleti,3430_CAM016341_d.JPG,mimic
+CAM016092,https://zenodo.org/record/3082688/files/CAM016092_d.JPG,1,test-2,3092,plesseni x malleti,3092_CAM016092_d.JPG,mimic
+CAM016141,https://zenodo.org/record/3082688/files/CAM016141_d.JPG,1,test-2,3190,plesseni x malleti,3190_CAM016141_d.JPG,mimic
+CAM016142,https://zenodo.org/record/3082688/files/CAM016142_d.JPG,1,test-2,3192,plesseni x malleti,3192_CAM016142_d.JPG,mimic
+CAM016143,https://zenodo.org/record/3082688/files/CAM016143_d.JPG,1,test-2,3194,plesseni x malleti,3194_CAM016143_d.JPG,mimic
+CAM016235,https://zenodo.org/record/3082688/files/CAM016235_d.JPG,1,test-2,3346,plesseni x malleti,3346_CAM016235_d.JPG,mimic
+CAM016230,https://zenodo.org/record/3082688/files/CAM016230_d.JPG,1,test-2,3342,plesseni x malleti,3342_CAM016230_d.JPG,mimic
+CAM016228,https://zenodo.org/record/3082688/files/CAM016228_d.JPG,1,test-2,3340,plesseni x malleti,3340_CAM016228_d.JPG,mimic
+CAM016227,https://zenodo.org/record/3082688/files/CAM016227_d.JPG,1,test-2,3338,plesseni x malleti,3338_CAM016227_d.JPG,mimic
+CAM016225,https://zenodo.org/record/3082688/files/CAM016225_d.JPG,1,test-2,3336,plesseni x malleti,3336_CAM016225_d.JPG,mimic
+CAM016196,https://zenodo.org/record/3082688/files/CAM016196_d.JPG,1,test-2,3300,plesseni x malleti,3300_CAM016196_d.JPG,mimic
+CAM016195,https://zenodo.org/record/3082688/files/CAM016195_d.JPG,1,test-2,3298,plesseni x malleti,3298_CAM016195_d.JPG,mimic
+CAM016191,https://zenodo.org/record/3082688/files/CAM016191_d.JPG,1,test-2,3290,plesseni x malleti,3290_CAM016191_d.JPG,mimic
+CAM016237,https://zenodo.org/record/3082688/files/CAM016237_d.JPG,1,test-2,3348,plesseni x malleti,3348_CAM016237_d.JPG,mimic
+CAM016239,https://zenodo.org/record/3082688/files/CAM016239_d.JPG,1,test-2,3350,plesseni x malleti,3350_CAM016239_d.JPG,mimic
+CAM016242,https://zenodo.org/record/3082688/files/CAM016242_d.JPG,1,test-2,3352,plesseni x malleti,3352_CAM016242_d.JPG,mimic
+CAM016244,https://zenodo.org/record/3082688/files/CAM016244_d.JPG,1,test-2,3354,plesseni x malleti,3354_CAM016244_d.JPG,mimic
+CAM016285,https://zenodo.org/record/3082688/files/CAM016285_d.JPG,0,test-2,3398,plesseni,3398_CAM016285_d.JPG,mimic
+CAM016287,https://zenodo.org/record/3082688/files/CAM016287_d.JPG,0,test-2,3400,plesseni,3400_CAM016287_d.JPG,mimic
+CAM016290,https://zenodo.org/record/3082688/files/CAM016290_d.JPG,0,test-2,3402,plesseni,3402_CAM016290_d.JPG,mimic
+CAM016294,https://zenodo.org/record/3082688/files/CAM016294_d.JPG,0,test-2,3404,plesseni,3404_CAM016294_d.JPG,mimic
+CAM016295,https://zenodo.org/record/3082688/files/CAM016295_d.JPG,0,test-2,3406,plesseni,3406_CAM016295_d.JPG,mimic
+CAM016272,https://zenodo.org/record/3082688/files/CAM016272_d.JPG,1,test-2,3388,plesseni x malleti,3388_CAM016272_d.JPG,mimic
+CAM016189,https://zenodo.org/record/3082688/files/CAM016189_d.JPG,1,test-2,3286,plesseni x malleti,3286_CAM016189_d.JPG,mimic
+CAM016270,https://zenodo.org/record/3082688/files/CAM016270_d.JPG,1,test-2,3386,plesseni x malleti,3386_CAM016270_d.JPG,mimic
+CAM016254,https://zenodo.org/record/3082688/files/CAM016254_d.JPG,1,test-2,3368,plesseni x malleti,3368_CAM016254_d.JPG,mimic
+CAM016253,https://zenodo.org/record/3082688/files/CAM016253_d.JPG,1,test-2,3366,plesseni x malleti,3366_CAM016253_d.JPG,mimic
+CAM016251,https://zenodo.org/record/3082688/files/CAM016251_d.JPG,1,test-2,3362,plesseni x malleti,3362_CAM016251_d.JPG,mimic
+CAM016250,https://zenodo.org/record/3082688/files/CAM016250_d.JPG,1,test-2,3360,plesseni x malleti,3360_CAM016250_d.JPG,mimic
+CAM016249,https://zenodo.org/record/3082688/files/CAM016249_d.JPG,1,test-2,3358,plesseni x malleti,3358_CAM016249_d.JPG,mimic
+CAM016247,https://zenodo.org/record/3082688/files/CAM016247_d.JPG,0,test-2,3356,plesseni,3356_CAM016247_d.JPG,mimic
+CAM016161,https://zenodo.org/record/3082688/files/CAM016161_d.JPG,1,test-2,3230,plesseni x malleti,3230_CAM016161_d.JPG,mimic
+CAM016160,https://zenodo.org/record/3082688/files/CAM016160_d.JPG,1,test-2,3228,plesseni x malleti,3228_CAM016160_d.JPG,mimic
+CAM016159,https://zenodo.org/record/3082688/files/CAM016159_d.JPG,1,test-2,3226,plesseni x malleti,3226_CAM016159_d.JPG,mimic
+CAM016158,https://zenodo.org/record/3082688/files/CAM016158_d.JPG,1,test-2,3224,plesseni x malleti,3224_CAM016158_d.JPG,mimic
+CAM016374,https://zenodo.org/record/3082688/files/CAM016374_d.JPG,0,test-2,3462,plesseni,3462_CAM016374_d.JPG,mimic
+CAM016165,https://zenodo.org/record/3082688/files/CAM016165_d.JPG,1,test-2,3238,plesseni x malleti,3238_CAM016165_d.JPG,mimic
+CAM016166,https://zenodo.org/record/3082688/files/CAM016166_d.JPG,1,test-2,3240,plesseni x malleti,3240_CAM016166_d.JPG,mimic
+CAM016073,https://zenodo.org/record/3082688/files/CAM016073_d.JPG,0,test-2,3054,plesseni,3054_CAM016073_d.JPG,mimic
+CAM016602,https://zenodo.org/record/3082688/files/CAM016602_d.JPG,1,test-2,3791,plesseni x malleti,3791_CAM016602_d.JPG,mimic
+CAM016608,https://zenodo.org/record/3082688/files/CAM016608_d.JPG,1,test-2,3801,plesseni x malleti,3801_CAM016608_d.JPG,mimic
+CAM016404,https://zenodo.org/record/3082688/files/CAM016404_d.JPG,0,test-2,3519,plesseni,3519_CAM016404_d.JPG,mimic
+CAM016406,https://zenodo.org/record/3082688/files/CAM016406_d.JPG,1,test-2,3523,plesseni x malleti,3523_CAM016406_d.JPG,mimic
+CAM016407,https://zenodo.org/record/3082688/files/CAM016407_d.JPG,1,test-2,3525,plesseni x malleti,3525_CAM016407_d.JPG,mimic
+CAM016408,https://zenodo.org/record/3082688/files/CAM016408_d.JPG,1,test-2,3527,plesseni x malleti,3527_CAM016408_d.JPG,mimic
+CAM016409,https://zenodo.org/record/3082688/files/CAM016409_d.JPG,1,test-2,3529,plesseni x malleti,3529_CAM016409_d.JPG,mimic
+CAM016378,https://zenodo.org/record/3082688/files/CAM016378_d.JPG,0,test-2,3470,plesseni,3470_CAM016378_d.JPG,mimic
+CAM016393,https://zenodo.org/record/3082688/files/CAM016393_d.JPG,1,test-2,3499,plesseni x malleti,3499_CAM016393_d.JPG,mimic
+CAM016394,https://zenodo.org/record/3082688/files/CAM016394_d.JPG,1,test-2,3501,plesseni x malleti,3501_CAM016394_d.JPG,mimic
+CAM016500,https://zenodo.org/record/3082688/files/CAM016500_d.JPG,1,test-2,3633,plesseni x malleti,3633_CAM016500_d.JPG,mimic
+CAM016503,https://zenodo.org/record/3082688/files/CAM016503_d.JPG,1,test-2,3639,plesseni x malleti,3639_CAM016503_d.JPG,mimic
+CAM016504,https://zenodo.org/record/3082688/files/CAM016504_d.JPG,1,test-2,3641,plesseni x malleti,3641_CAM016504_d.JPG,mimic
+CAM016508,https://zenodo.org/record/3082688/files/CAM016508_d.JPG,1,test-2,3649,plesseni x malleti,3649_CAM016508_d.JPG,mimic
+CAM016509,https://zenodo.org/record/3082688/files/CAM016509_d.JPG,1,test-2,3651,plesseni x malleti,3651_CAM016509_d.JPG,mimic
+CAM016510,https://zenodo.org/record/3082688/files/CAM016510_d.JPG,1,test-2,3653,plesseni x malleti,3653_CAM016510_d.JPG,mimic
+CAM016511,https://zenodo.org/record/3082688/files/CAM016511_d.JPG,1,test-2,3655,plesseni x malleti,3655_CAM016511_d.JPG,mimic
+CAM016505,https://zenodo.org/record/3082688/files/CAM016505_d.JPG,1,test-2,3643,plesseni x malleti,3643_CAM016505_d.JPG,mimic
+CAM016422,https://zenodo.org/record/3082688/files/CAM016422_d.JPG,1,test-2,3555,plesseni x malleti,3555_CAM016422_d.JPG,mimic
+CAM016424,https://zenodo.org/record/3082688/files/CAM016424_d.JPG,1,test-2,3559,plesseni x malleti,3559_CAM016424_d.JPG,mimic
+CAM016428,https://zenodo.org/record/3082688/files/CAM016428_d.JPG,1,test-2,3567,plesseni x malleti,3567_CAM016428_d.JPG,mimic
+CAM016082,https://zenodo.org/record/3082688/files/CAM016082_d.JPG,0,test-2,3072,plesseni,3072_CAM016082_d.JPG,mimic
+CAM017668,https://zenodo.org/record/3082688/files/CAM017668_d.JPG,1,test-2,5414,malleti x plesseni,5414_CAM017668_d.JPG,mimic
+CAM017351,https://zenodo.org/record/3082688/files/CAM017351_d.JPG,1,test-2,4980,plesseni x malleti,4980_CAM017351_d.JPG,mimic
+CAM017345,https://zenodo.org/record/3082688/files/CAM017345_d.JPG,1,test-2,4968,plesseni x malleti,4968_CAM017345_d.JPG,mimic
+CAM017614,https://zenodo.org/record/3082688/files/CAM017614_d.JPG,0,test-2,5388,plesseni,5388_CAM017614_d.JPG,mimic
+CAM017612,https://zenodo.org/record/3082688/files/CAM017612_d.JPG,1,test-2,5386,plesseni x malleti,5386_CAM017612_d.JPG,mimic
+CAM017611,https://zenodo.org/record/3082688/files/CAM017611_d.JPG,1,test-2,5384,plesseni x malleti,5384_CAM017611_d.JPG,mimic
+CAM017609,https://zenodo.org/record/3082688/files/CAM017609_d.JPG,1,test,5380,notabilis x lativitta,5380_CAM017609_d.JPG,major
+CAM017608,https://zenodo.org/record/3082688/files/CAM017608_d.JPG,1,test,5378,notabilis x lativitta,5378_CAM017608_d.JPG,major
+CAM017607,https://zenodo.org/record/3082688/files/CAM017607_d.JPG,1,test,5376,notabilis x lativitta,5376_CAM017607_d.JPG,major
+CAM017606,https://zenodo.org/record/3082688/files/CAM017606_d.JPG,1,test,5374,notabilis x lativitta,5374_CAM017606_d.JPG,major
+CAM017605,https://zenodo.org/record/3082688/files/CAM017605_d.JPG,1,test-2,5372,plesseni x malleti,5372_CAM017605_d.JPG,mimic
+CAM017604,https://zenodo.org/record/3082688/files/CAM017604_d.JPG,1,test,5370,notabilis x lativitta,5370_CAM017604_d.JPG,major
+CAM017603,https://zenodo.org/record/3082688/files/CAM017603_d.JPG,1,test,5368,notabilis x lativitta,5368_CAM017603_d.JPG,major
+CAM017602,https://zenodo.org/record/3082688/files/CAM017602_d.JPG,1,test,5366,notabilis x lativitta,5366_CAM017602_d.JPG,major
+CAM017601,https://zenodo.org/record/3082688/files/CAM017601_d.JPG,1,test,5364,notabilis x lativitta,5364_CAM017601_d.JPG,major
+CAM016009,https://zenodo.org/record/3082688/files/CAM016009_d.JPG,0,test-2,2927,plesseni,2927_CAM016009_d.JPG,mimic
+CAM016012,https://zenodo.org/record/3082688/files/CAM016012_d.JPG,1,test-2,2933,plesseni x malleti,2933_CAM016012_d.JPG,mimic
+CAM016019,https://zenodo.org/record/3082688/files/CAM016019_d.JPG,1,test,2947,notabilis x lativitta,2947_CAM016019_d.JPG,major
+CAM017658,https://zenodo.org/record/3082688/files/CAM017658_d.JPG,1,test-2,5396,malleti x plesseni,5396_CAM017658_d.JPG,mimic
+CAM016016,https://zenodo.org/record/3082688/files/CAM016016_d.JPG,1,test,2941,notabilis x lativitta,2941_CAM016016_d.JPG,major
+CAM016015,https://zenodo.org/record/3082688/files/CAM016015_d.JPG,1,test-2,2939,plesseni x malleti,2939_CAM016015_d.JPG,mimic
+CAM016017,https://zenodo.org/record/3082688/files/CAM016017_d.JPG,1,test,2943,notabilis x lativitta,2943_CAM016017_d.JPG,major
+CAM017340,https://zenodo.org/record/3082688/files/CAM017340_d.JPG,1,test,4958,notabilis x lativitta,4958_CAM017340_d.JPG,major
+CAM017339,https://zenodo.org/record/3082688/files/CAM017339_d.JPG,1,test,4956,notabilis x lativitta,4956_CAM017339_d.JPG,major
+CAM017298,https://zenodo.org/record/3082688/files/CAM017298_d.JPG,1,test,4888,notabilis x lativitta,4888_CAM017298_d.JPG,major
+CAM017300,https://zenodo.org/record/3082688/files/CAM017300_d.JPG,1,test,4890,notabilis x lativitta,4890_CAM017300_d.JPG,major
+CAM017301,https://zenodo.org/record/3082688/files/CAM017301_d.JPG,1,test,4892,notabilis x lativitta,4892_CAM017301_d.JPG,major
+CAM017302,https://zenodo.org/record/3082688/files/CAM017302_d.JPG,1,test,4894,notabilis x lativitta,4894_CAM017302_d.JPG,major
+CAM017303,https://zenodo.org/record/3082688/files/CAM017303_d.JPG,1,test,4896,notabilis x lativitta,4896_CAM017303_d.JPG,major
+CAM017306,https://zenodo.org/record/3082688/files/CAM017306_d.JPG,1,test,4898,notabilis x lativitta,4898_CAM017306_d.JPG,major
+CAM017307,https://zenodo.org/record/3082688/files/CAM017307_d.JPG,1,test,4900,notabilis x lativitta,4900_CAM017307_d.JPG,major
+CAM017308,https://zenodo.org/record/3082688/files/CAM017308_d.JPG,1,test,4902,notabilis x lativitta,4902_CAM017308_d.JPG,major
+CAM017297,https://zenodo.org/record/3082688/files/CAM017297_d.JPG,1,test,4886,notabilis x lativitta,4886_CAM017297_d.JPG,major
+CAM017296,https://zenodo.org/record/3082688/files/CAM017296_d.JPG,1,test,4884,notabilis x lativitta,4884_CAM017296_d.JPG,major
+CAM017287,https://zenodo.org/record/3082688/files/CAM017287_d.JPG,1,test,4882,notabilis x lativitta,4882_CAM017287_d.JPG,major
+CAM017274,https://zenodo.org/record/3082688/files/CAM017274_d.JPG,1,test,4860,notabilis x lativitta,4860_CAM017274_d.JPG,major
+CAM017275,https://zenodo.org/record/3082688/files/CAM017275_d.JPG,1,test,4862,notabilis x lativitta,4862_CAM017275_d.JPG,major
+CAM017276,https://zenodo.org/record/3082688/files/CAM017276_d.JPG,1,test,4864,notabilis x lativitta,4864_CAM017276_d.JPG,major
+CAM017309,https://zenodo.org/record/3082688/files/CAM017309_d.JPG,1,test,4904,notabilis x lativitta,4904_CAM017309_d.JPG,major
+CAM017277,https://zenodo.org/record/3082688/files/CAM017277_d.JPG,1,test,4866,notabilis x lativitta,4866_CAM017277_d.JPG,major
+CAM017280,https://zenodo.org/record/3082688/files/CAM017280_d.JPG,1,test,4872,notabilis x lativitta,4872_CAM017280_d.JPG,major
+CAM017732,https://zenodo.org/record/3082688/files/CAM017732_d.JPG,1,test-2,5494,plesseni x malleti,5494_CAM017732_d.JPG,mimic
+CAM017281,https://zenodo.org/record/3082688/files/CAM017281_d.JPG,1,test,4874,notabilis x lativitta,4874_CAM017281_d.JPG,major
+CAM017282,https://zenodo.org/record/3082688/files/CAM017282_d.JPG,1,test-2,4876,plesseni x malleti,4876_CAM017282_d.JPG,mimic
+CAM017050,https://zenodo.org/record/3082688/files/CAM017050_d.JPG,1,test,4449,notabilis x lativitta,4449_CAM017050_d.JPG,major
+CAM016028,https://zenodo.org/record/3082688/files/CAM016028_d.JPG,1,test,2965,notabilis x lativitta,2965_CAM016028_d.JPG,major
+CAM017328,https://zenodo.org/record/3082688/files/CAM017328_d.JPG,1,test,4934,notabilis x lativitta,4934_CAM017328_d.JPG,major
+CAM017329,https://zenodo.org/record/3082688/files/CAM017329_d.JPG,1,test-2,4936,plesseni x malleti,4936_CAM017329_d.JPG,mimic
+CAM017330,https://zenodo.org/record/3082688/files/CAM017330_d.JPG,1,test,4938,notabilis x lativitta,4938_CAM017330_d.JPG,major
+CAM017331,https://zenodo.org/record/3082688/files/CAM017331_d.JPG,1,test,4940,notabilis x lativitta,4940_CAM017331_d.JPG,major
+CAM017332,https://zenodo.org/record/3082688/files/CAM017332_d.JPG,1,test,4942,notabilis x lativitta,4942_CAM017332_d.JPG,major
+CAM017333,https://zenodo.org/record/3082688/files/CAM017333_d.JPG,1,test,4944,notabilis x lativitta,4944_CAM017333_d.JPG,major
+CAM017334,https://zenodo.org/record/3082688/files/CAM017334_d.JPG,1,test,4946,notabilis x lativitta,4946_CAM017334_d.JPG,major
+CAM017692,https://zenodo.org/record/3082688/files/CAM017692_d.JPG,1,test-2,5448,malleti x plesseni,5448_CAM017692_d.JPG,mimic
+CAM017335,https://zenodo.org/record/3082688/files/CAM017335_d.JPG,1,test-2,4948,plesseni x malleti,4948_CAM017335_d.JPG,mimic
+CAM017336,https://zenodo.org/record/3082688/files/CAM017336_d.JPG,1,test-2,4950,plesseni x malleti,4950_CAM017336_d.JPG,mimic
+CAM017337,https://zenodo.org/record/3082688/files/CAM017337_d.JPG,1,test,4952,notabilis x lativitta,4952_CAM017337_d.JPG,major
+CAM017338,https://zenodo.org/record/3082688/files/CAM017338_d.JPG,1,test,4954,notabilis x lativitta,4954_CAM017338_d.JPG,major
+CAM016029,https://zenodo.org/record/3082688/files/CAM016029_d.JPG,1,test,2967,notabilis x lativitta,2967_CAM016029_d.JPG,major
+CAM017311,https://zenodo.org/record/3082688/files/CAM017311_d.JPG,1,test,4908,notabilis x lativitta,4908_CAM017311_d.JPG,major
+CAM017312,https://zenodo.org/record/3082688/files/CAM017312_d.JPG,1,test,4910,notabilis x lativitta,4910_CAM017312_d.JPG,major
+CAM017713,https://zenodo.org/record/3082688/files/CAM017713_d.JPG,1,test,5466,lativitta x notabilis,5466_CAM017713_d.JPG,major
+CAM016030,https://zenodo.org/record/3082688/files/CAM016030_d.JPG,1,test,2969,notabilis x lativitta,2969_CAM016030_d.JPG,major
+CAM017314,https://zenodo.org/record/3082688/files/CAM017314_d.JPG,1,test,4912,notabilis x lativitta,4912_CAM017314_d.JPG,major
+CAM017315,https://zenodo.org/record/3082688/files/CAM017315_d.JPG,1,test,4914,notabilis x lativitta,4914_CAM017315_d.JPG,major
+CAM017316,https://zenodo.org/record/3082688/files/CAM017316_d.JPG,1,test,4916,notabilis x lativitta,4916_CAM017316_d.JPG,major
+CAM017310,https://zenodo.org/record/3082688/files/CAM017310_d.JPG,1,test,4906,notabilis x lativitta,4906_CAM017310_d.JPG,major
+CAM017317,https://zenodo.org/record/3082688/files/CAM017317_d.JPG,1,test,4918,notabilis x lativitta,4918_CAM017317_d.JPG,major
+CAM017318,https://zenodo.org/record/3082688/files/CAM017318_d.JPG,1,test,4920,notabilis x lativitta,4920_CAM017318_d.JPG,major
+CAM017319,https://zenodo.org/record/3082688/files/CAM017319_d.JPG,1,test,4922,notabilis x lativitta,4922_CAM017319_d.JPG,major
+CAM017703,https://zenodo.org/record/3082688/files/CAM017703_d.JPG,1,test,5458,lativitta x notabilis,5458_CAM017703_d.JPG,major
+CAM017456,https://zenodo.org/record/3082688/files/CAM017456_d.JPG,1,test-2,5140,malleti x plesseni,5140_CAM017456_d.JPG,mimic
+CAM017459,https://zenodo.org/record/3082688/files/CAM017459_d.JPG,1,test-2,5142,malleti x plesseni,5142_CAM017459_d.JPG,mimic
+CAM017440,https://zenodo.org/record/3082688/files/CAM017440_d.JPG,1,test-2,5115,plesseni x malleti,5115_CAM017440_d.JPG,mimic
+CAM017441,https://zenodo.org/record/3082688/files/CAM017441_d.JPG,1,test,5117,notabilis x lativitta,5117_CAM017441_d.JPG,major
+CAM017442,https://zenodo.org/record/3082688/files/CAM017442_d.JPG,1,test,5119,notabilis x lativitta,5119_CAM017442_d.JPG,major
+CAM017443,https://zenodo.org/record/3082688/files/CAM017443_d.JPG,1,test,5121,notabilis x lativitta,5121_CAM017443_d.JPG,major
+CAM017444,https://zenodo.org/record/3082688/files/CAM017444_d.JPG,1,test,5122,notabilis x lativitta,5122_CAM017444_d.JPG,major
+CAM017445,https://zenodo.org/record/3082688/files/CAM017445_d.JPG,1,test,5124,notabilis x lativitta,5124_CAM017445_d.JPG,major
+CAM017446,https://zenodo.org/record/3082688/files/CAM017446_d.JPG,1,test,5126,notabilis x lativitta,5126_CAM017446_d.JPG,major
+CAM017447,https://zenodo.org/record/3082688/files/CAM017447_d.JPG,1,test,5128,notabilis x lativitta,5128_CAM017447_d.JPG,major
+CAM017450,https://zenodo.org/record/3082688/files/CAM017450_d.JPG,1,test-2,5132,malleti x plesseni,5132_CAM017450_d.JPG,mimic
+CAM017451,https://zenodo.org/record/3082688/files/CAM017451_d.JPG,1,test-2,5134,malleti x plesseni,5134_CAM017451_d.JPG,mimic
+CAM017452,https://zenodo.org/record/3082688/files/CAM017452_d.JPG,1,test-2,5136,malleti x plesseni,5136_CAM017452_d.JPG,mimic
+CAM017454,https://zenodo.org/record/3082688/files/CAM017454_d.JPG,1,test-2,5138,plesseni x malleti,5138_CAM017454_d.JPG,mimic
+CAM017508,https://zenodo.org/record/3082688/files/CAM017508_d.JPG,1,test-2,5218,plesseni x malleti,5218_CAM017508_d.JPG,mimic
+CAM017507,https://zenodo.org/record/3082688/files/CAM017507_d.JPG,1,test-2,5216,malleti x plesseni,5216_CAM017507_d.JPG,mimic
+CAM017439,https://zenodo.org/record/3082688/files/CAM017439_d.JPG,1,test,5113,notabilis x lativitta,5113_CAM017439_d.JPG,major
+CAM017438,https://zenodo.org/record/3082688/files/CAM017438_d.JPG,1,test,5111,notabilis x lativitta,5111_CAM017438_d.JPG,major
+CAM017398,https://zenodo.org/record/3082688/files/CAM017398_d.JPG,1,test,5039,notabilis x lativitta,5039_CAM017398_d.JPG,major
+CAM017578,https://zenodo.org/record/3082688/files/CAM017578_d.JPG,1,test-2,5330,plesseni x malleti,5330_CAM017578_d.JPG,mimic
+CAM017407,https://zenodo.org/record/3082688/files/CAM017407_d.JPG,1,test,5055,notabilis x lativitta,5055_CAM017407_d.JPG,major
+CAM017408,https://zenodo.org/record/3082688/files/CAM017408_d.JPG,1,test,5057,notabilis x lativitta,5057_CAM017408_d.JPG,major
+CAM017574,https://zenodo.org/record/3082688/files/CAM017574_d.JPG,1,test-2,5322,malleti x plesseni,5322_CAM017574_d.JPG,mimic
+CAM017384,https://zenodo.org/record/3082688/files/CAM017384_d.JPG,1,test-2,5018,plesseni x malleti,5018_CAM017384_d.JPG,mimic
+CAM017393,https://zenodo.org/record/3082688/files/CAM017393_d.JPG,1,test,5035,notabilis x lativitta,5035_CAM017393_d.JPG,major
+CAM017410,https://zenodo.org/record/3082688/files/CAM017410_d.JPG,1,test,5059,notabilis x lativitta,5059_CAM017410_d.JPG,major
+CAM017426,https://zenodo.org/record/3082688/files/CAM017426_d.JPG,1,test,5089,notabilis x lativitta,5089_CAM017426_d.JPG,major
+CAM017427,https://zenodo.org/record/3082688/files/CAM017427_d.JPG,1,test,5091,notabilis x lativitta,5091_CAM017427_d.JPG,major
+CAM017429,https://zenodo.org/record/3082688/files/CAM017429_d.JPG,1,test,5095,notabilis x lativitta,5095_CAM017429_d.JPG,major
+CAM017431,https://zenodo.org/record/3082688/files/CAM017431_d.JPG,1,test-2,5099,plesseni x malleti,5099_CAM017431_d.JPG,mimic
+CAM017432,https://zenodo.org/record/3082688/files/CAM017432_d.JPG,1,test,5101,notabilis x lativitta,5101_CAM017432_d.JPG,major
+CAM017552,https://zenodo.org/record/3082688/files/CAM017552_d.JPG,1,test-2,5294,malleti x plesseni,5294_CAM017552_d.JPG,mimic
+CAM017433,https://zenodo.org/record/3082688/files/CAM017433_d.JPG,1,test,5103,notabilis x lativitta,5103_CAM017433_d.JPG,major
+CAM017551,https://zenodo.org/record/3082688/files/CAM017551_d.JPG,1,test-2,5292,malleti x plesseni,5292_CAM017551_d.JPG,mimic
+CAM017435,https://zenodo.org/record/3082688/files/CAM017435_d.JPG,1,test,5105,notabilis x lativitta,5105_CAM017435_d.JPG,major
+CAM017550,https://zenodo.org/record/3082688/files/CAM017550_d.JPG,1,test-2,5290,malleti x plesseni,5290_CAM017550_d.JPG,mimic
+CAM017436,https://zenodo.org/record/3082688/files/CAM017436_d.JPG,1,test,5107,notabilis x lativitta,5107_CAM017436_d.JPG,major
+CAM017549,https://zenodo.org/record/3082688/files/CAM017549_d.JPG,1,test-2,5288,malleti x plesseni,5288_CAM017549_d.JPG,mimic
+CAM017437,https://zenodo.org/record/3082688/files/CAM017437_d.JPG,1,test-2,5109,plesseni x malleti,5109_CAM017437_d.JPG,mimic
+CAM017425,https://zenodo.org/record/3082688/files/CAM017425_d.JPG,1,test,5087,notabilis x lativitta,5087_CAM017425_d.JPG,major
+CAM017424,https://zenodo.org/record/3082688/files/CAM017424_d.JPG,1,test,5085,notabilis x lativitta,5085_CAM017424_d.JPG,major
+CAM017417,https://zenodo.org/record/3082688/files/CAM017417_d.JPG,1,test-2,5071,plesseni x malleti,5071_CAM017417_d.JPG,mimic
+CAM017564,https://zenodo.org/record/3082688/files/CAM017564_d.JPG,1,test-2,5308,malleti x plesseni,5308_CAM017564_d.JPG,mimic
+CAM017419,https://zenodo.org/record/3082688/files/CAM017419_d.JPG,1,test,5075,notabilis x lativitta,5075_CAM017419_d.JPG,major
+CAM017420,https://zenodo.org/record/3082688/files/CAM017420_d.JPG,1,test,5077,notabilis x lativitta,5077_CAM017420_d.JPG,major
+CAM017421,https://zenodo.org/record/3082688/files/CAM017421_d.JPG,1,test,5079,notabilis x lativitta,5079_CAM017421_d.JPG,major
+CAM017422,https://zenodo.org/record/3082688/files/CAM017422_d.JPG,1,test,5081,notabilis x lativitta,5081_CAM017422_d.JPG,major
+CAM017423,https://zenodo.org/record/3082688/files/CAM017423_d.JPG,1,test-2,5083,plesseni x malleti,5083_CAM017423_d.JPG,mimic
+CAM017418,https://zenodo.org/record/3082688/files/CAM017418_d.JPG,1,test,5073,notabilis x lativitta,5073_CAM017418_d.JPG,major
+CAM017125,https://zenodo.org/record/3082688/files/CAM017125_d.JPG,1,test-2,4579,plesseni x malleti,4579_CAM017125_d.JPG,mimic
+CAM017127,https://zenodo.org/record/3082688/files/CAM017127_d.JPG,1,test,4583,notabilis x lativitta,4583_CAM017127_d.JPG,major
+CAM017128,https://zenodo.org/record/3082688/files/CAM017128_d.JPG,1,test-2,4585,plesseni x malleti,4585_CAM017128_d.JPG,mimic
+CAM017129,https://zenodo.org/record/3082688/files/CAM017129_d.JPG,1,test,4587,notabilis x lativitta,4587_CAM017129_d.JPG,major
+CAM017130,https://zenodo.org/record/3082688/files/CAM017130_d.JPG,1,test,4589,notabilis x lativitta,4589_CAM017130_d.JPG,major
+CAM017131,https://zenodo.org/record/3082688/files/CAM017131_d.JPG,1,test-2,4591,plesseni x malleti,4591_CAM017131_d.JPG,mimic
+CAM017132,https://zenodo.org/record/3082688/files/CAM017132_d.JPG,1,test,4593,notabilis x lativitta,4593_CAM017132_d.JPG,major
+CAM017133,https://zenodo.org/record/3082688/files/CAM017133_d.JPG,1,test,4595,notabilis x lativitta,4595_CAM017133_d.JPG,major
+CAM017123,https://zenodo.org/record/3082688/files/CAM017123_d.JPG,1,test-2,4575,plesseni x malleti,4575_CAM017123_d.JPG,mimic
+CAM017114,https://zenodo.org/record/3082688/files/CAM017114_d.JPG,1,test,4557,notabilis x lativitta,4557_CAM017114_d.JPG,major
+CAM017116,https://zenodo.org/record/3082688/files/CAM017116_d.JPG,1,test,4561,notabilis x lativitta,4561_CAM017116_d.JPG,major
+CAM017118,https://zenodo.org/record/3082688/files/CAM017118_d.JPG,1,test,4565,notabilis x lativitta,4565_CAM017118_d.JPG,major
+CAM017119,https://zenodo.org/record/3082688/files/CAM017119_d.JPG,1,test,4567,notabilis x lativitta,4567_CAM017119_d.JPG,major
+CAM017122,https://zenodo.org/record/3082688/files/CAM017122_d.JPG,1,test,4573,notabilis x lativitta,4573_CAM017122_d.JPG,major
+CAM017150,https://zenodo.org/record/3082688/files/CAM017150_d.JPG,1,test,4625,notabilis x lativitta,4625_CAM017150_d.JPG,major
+CAM017151,https://zenodo.org/record/3082688/files/CAM017151_d.JPG,1,test,4627,notabilis x lativitta,4627_CAM017151_d.JPG,major
+CAM017152,https://zenodo.org/record/3082688/files/CAM017152_d.JPG,1,test-2,4629,plesseni x malleti,4629_CAM017152_d.JPG,mimic
+CAM017153,https://zenodo.org/record/3082688/files/CAM017153_d.JPG,1,test-2,4631,plesseni x malleti,4631_CAM017153_d.JPG,mimic
+CAM017270,https://zenodo.org/record/3082688/files/CAM017270_d.JPG,1,test,4852,notabilis x lativitta,4852_CAM017270_d.JPG,major
+CAM017155,https://zenodo.org/record/3082688/files/CAM017155_d.JPG,1,test-2,4635,plesseni x malleti,4635_CAM017155_d.JPG,mimic
+CAM017157,https://zenodo.org/record/3082688/files/CAM017157_d.JPG,1,test,4639,notabilis x lativitta,4639_CAM017157_d.JPG,major
+CAM017158,https://zenodo.org/record/3082688/files/CAM017158_d.JPG,1,test,4641,notabilis x lativitta,4641_CAM017158_d.JPG,major
+CAM017159,https://zenodo.org/record/3082688/files/CAM017159_d.JPG,1,test,4643,notabilis x lativitta,4643_CAM017159_d.JPG,major
+CAM017149,https://zenodo.org/record/3082688/files/CAM017149_d.JPG,1,test,4623,notabilis x lativitta,4623_CAM017149_d.JPG,major
+CAM017148,https://zenodo.org/record/3082688/files/CAM017148_d.JPG,1,test,4621,notabilis x lativitta,4621_CAM017148_d.JPG,major
+CAM017141,https://zenodo.org/record/3082688/files/CAM017141_d.JPG,1,test,4607,notabilis x lativitta,4607_CAM017141_d.JPG,major
+CAM017142,https://zenodo.org/record/3082688/files/CAM017142_d.JPG,1,test,4609,notabilis x lativitta,4609_CAM017142_d.JPG,major
+CAM017144,https://zenodo.org/record/3082688/files/CAM017144_d.JPG,1,test,4613,notabilis x lativitta,4613_CAM017144_d.JPG,major
+CAM017145,https://zenodo.org/record/3082688/files/CAM017145_d.JPG,1,test,4615,notabilis x lativitta,4615_CAM017145_d.JPG,major
+CAM017146,https://zenodo.org/record/3082688/files/CAM017146_d.JPG,1,test,4617,notabilis x lativitta,4617_CAM017146_d.JPG,major
+CAM017867,https://zenodo.org/record/3082688/files/CAM017867_d.JPG,1,test-2,5661,malleti x plesseni,5661_CAM017867_d.JPG,mimic
+CAM017147,https://zenodo.org/record/3082688/files/CAM017147_d.JPG,1,test,4619,notabilis x lativitta,4619_CAM017147_d.JPG,major
+CAM017143,https://zenodo.org/record/3082688/files/CAM017143_d.JPG,1,test,4611,notabilis x lativitta,4611_CAM017143_d.JPG,major
+CAM017066,https://zenodo.org/record/3082688/files/CAM017066_d.JPG,1,test-2,4481,plesseni x malleti,4481_CAM017066_d.JPG,mimic
+CAM017067,https://zenodo.org/record/3082688/files/CAM017067_d.JPG,1,test-2,4483,plesseni x malleti,4483_CAM017067_d.JPG,mimic
+CAM017068,https://zenodo.org/record/3082688/files/CAM017068_d.JPG,1,test-2,4485,plesseni x malleti,4485_CAM017068_d.JPG,mimic
+CAM017072,https://zenodo.org/record/3082688/files/CAM017072_d.JPG,1,test-2,4493,plesseni x malleti,4493_CAM017072_d.JPG,mimic
+CAM017074,https://zenodo.org/record/3082688/files/CAM017074_d.JPG,1,test,4497,notabilis x lativitta,4497_CAM017074_d.JPG,major
+CAM017065,https://zenodo.org/record/3082688/files/CAM017065_d.JPG,1,test,4479,notabilis x lativitta,4479_CAM017065_d.JPG,major
+CAM017063,https://zenodo.org/record/3082688/files/CAM017063_d.JPG,1,test,4475,notabilis x lativitta,4475_CAM017063_d.JPG,major
+CAM017052,https://zenodo.org/record/3082688/files/CAM017052_d.JPG,1,test,4453,notabilis x lativitta,4453_CAM017052_d.JPG,major
+CAM017053,https://zenodo.org/record/3082688/files/CAM017053_d.JPG,1,test-2,4455,plesseni x malleti,4455_CAM017053_d.JPG,mimic
+CAM017054,https://zenodo.org/record/3082688/files/CAM017054_d.JPG,1,test,4457,notabilis x lativitta,4457_CAM017054_d.JPG,major
+CAM017055,https://zenodo.org/record/3082688/files/CAM017055_d.JPG,1,test,4459,notabilis x lativitta,4459_CAM017055_d.JPG,major
+CAM017056,https://zenodo.org/record/3082688/files/CAM017056_d.JPG,1,test,4461,notabilis x lativitta,4461_CAM017056_d.JPG,major
+CAM017057,https://zenodo.org/record/3082688/files/CAM017057_d.JPG,1,test,4463,notabilis x lativitta,4463_CAM017057_d.JPG,major
+CAM017059,https://zenodo.org/record/3082688/files/CAM017059_d.JPG,1,test,4467,notabilis x lativitta,4467_CAM017059_d.JPG,major
+CAM017062,https://zenodo.org/record/3082688/files/CAM017062_d.JPG,1,test,4473,notabilis x lativitta,4473_CAM017062_d.JPG,major
+CAM017058,https://zenodo.org/record/3082688/files/CAM017058_d.JPG,1,test,4465,notabilis x lativitta,4465_CAM017058_d.JPG,major
+CAM017094,https://zenodo.org/record/3082688/files/CAM017094_d.JPG,1,test-2,4529,plesseni x malleti,4529_CAM017094_d.JPG,mimic
+CAM017095,https://zenodo.org/record/3082688/files/CAM017095_d.JPG,1,test-2,4531,plesseni x malleti,4531_CAM017095_d.JPG,mimic
+CAM017096,https://zenodo.org/record/3082688/files/CAM017096_d.JPG,1,test-2,4533,plesseni x malleti,4533_CAM017096_d.JPG,mimic
+CAM017102,https://zenodo.org/record/3082688/files/CAM017102_d.JPG,1,test-2,4541,plesseni x malleti,4541_CAM017102_d.JPG,mimic
+CAM017109,https://zenodo.org/record/3082688/files/CAM017109_d.JPG,1,test,4547,notabilis x lativitta,4547_CAM017109_d.JPG,major
+CAM017110,https://zenodo.org/record/3082688/files/CAM017110_d.JPG,1,test,4549,notabilis x lativitta,4549_CAM017110_d.JPG,major
+CAM017080,https://zenodo.org/record/3082688/files/CAM017080_d.JPG,1,test-2,4501,plesseni x malleti,4501_CAM017080_d.JPG,mimic
+CAM017084,https://zenodo.org/record/3082688/files/CAM017084_d.JPG,1,test-2,4509,plesseni x malleti,4509_CAM017084_d.JPG,mimic
+CAM017085,https://zenodo.org/record/3082688/files/CAM017085_d.JPG,1,test,4511,notabilis x lativitta,4511_CAM017085_d.JPG,major
+CAM017087,https://zenodo.org/record/3082688/files/CAM017087_d.JPG,1,test,4515,notabilis x lativitta,4515_CAM017087_d.JPG,major
+CAM017088,https://zenodo.org/record/3082688/files/CAM017088_d.JPG,1,test,4517,notabilis x lativitta,4517_CAM017088_d.JPG,major
+CAM017090,https://zenodo.org/record/3082688/files/CAM017090_d.JPG,1,test-2,4521,plesseni x malleti,4521_CAM017090_d.JPG,mimic
+CAM017160,https://zenodo.org/record/3082688/files/CAM017160_d.JPG,1,test,4645,notabilis x lativitta,4645_CAM017160_d.JPG,major
+CAM017230,https://zenodo.org/record/3082688/files/CAM017230_d.JPG,1,test,4777,notabilis x lativitta,4777_CAM017230_d.JPG,major
+CAM017231,https://zenodo.org/record/3082688/files/CAM017231_d.JPG,1,test-2,4779,plesseni x malleti,4779_CAM017231_d.JPG,mimic
+CAM017232,https://zenodo.org/record/3082688/files/CAM017232_d.JPG,1,test-2,4781,plesseni x malleti,4781_CAM017232_d.JPG,mimic
+CAM017233,https://zenodo.org/record/3082688/files/CAM017233_d.JPG,1,test-2,4783,plesseni x malleti,4783_CAM017233_d.JPG,mimic
+CAM017234,https://zenodo.org/record/3082688/files/CAM017234_d.JPG,1,test,4785,notabilis x lativitta,4785_CAM017234_d.JPG,major
+CAM017778,https://zenodo.org/record/3082688/files/CAM017778_d.JPG,1,test-2,5544,plesseni x malleti,5544_CAM017778_d.JPG,mimic
+CAM017776,https://zenodo.org/record/3082688/files/CAM017776_d.JPG,1,test-2,5540,malleti x plesseni,5540_CAM017776_d.JPG,mimic
+CAM017235,https://zenodo.org/record/3082688/files/CAM017235_d.JPG,1,test,4787,notabilis x lativitta,4787_CAM017235_d.JPG,major
+CAM017773,https://zenodo.org/record/3082688/files/CAM017773_d.JPG,1,test,5534,lativitta x notabilis,5534_CAM017773_d.JPG,major
+CAM017229,https://zenodo.org/record/3082688/files/CAM017229_d.JPG,1,test,4775,notabilis x lativitta,4775_CAM017229_d.JPG,major
+CAM017218,https://zenodo.org/record/3082688/files/CAM017218_d.JPG,1,test,4753,notabilis x lativitta,4753_CAM017218_d.JPG,major
+CAM017161,https://zenodo.org/record/3082688/files/CAM017161_d.JPG,1,test,4647,notabilis x lativitta,4647_CAM017161_d.JPG,major
+CAM017224,https://zenodo.org/record/3082688/files/CAM017224_d.JPG,1,test,4765,notabilis x lativitta,4765_CAM017224_d.JPG,major
+CAM017225,https://zenodo.org/record/3082688/files/CAM017225_d.JPG,1,test,4767,notabilis x lativitta,4767_CAM017225_d.JPG,major
+CAM017226,https://zenodo.org/record/3082688/files/CAM017226_d.JPG,1,test,4769,notabilis x lativitta,4769_CAM017226_d.JPG,major
+CAM017222,https://zenodo.org/record/3082688/files/CAM017222_d.JPG,1,test,4761,notabilis x lativitta,4761_CAM017222_d.JPG,major
+CAM017215,https://zenodo.org/record/3082688/files/CAM017215_d.JPG,1,test,4747,notabilis x lativitta,4747_CAM017215_d.JPG,major
+CAM017257,https://zenodo.org/record/3082688/files/CAM017257_d.JPG,1,test-2,4828,plesseni x malleti,4828_CAM017257_d.JPG,mimic
+CAM016031,https://zenodo.org/record/3082688/files/CAM016031_d.JPG,1,test,2971,notabilis x lativitta,2971_CAM016031_d.JPG,major
+CAM017754,https://zenodo.org/record/3082688/files/CAM017754_d.JPG,1,test,5514,lativitta x notabilis,5514_CAM017754_d.JPG,major
+CAM017753,https://zenodo.org/record/3082688/files/CAM017753_d.JPG,1,test-2,5512,plesseni x malleti,5512_CAM017753_d.JPG,mimic
+CAM017752,https://zenodo.org/record/3082688/files/CAM017752_d.JPG,1,test-2,5510,plesseni x malleti,5510_CAM017752_d.JPG,mimic
+CAM016032,https://zenodo.org/record/3082688/files/CAM016032_d.JPG,1,test,2973,notabilis x lativitta,2973_CAM016032_d.JPG,major
+CAM017264,https://zenodo.org/record/3082688/files/CAM017264_d.JPG,1,test-2,4840,plesseni x malleti,4840_CAM017264_d.JPG,mimic
+CAM017748,https://zenodo.org/record/3082688/files/CAM017748_d.JPG,1,test,5506,lativitta x notabilis,5506_CAM017748_d.JPG,major
+CAM017265,https://zenodo.org/record/3082688/files/CAM017265_d.JPG,1,test,4842,notabilis x lativitta,4842_CAM017265_d.JPG,major
+CAM017266,https://zenodo.org/record/3082688/files/CAM017266_d.JPG,1,test,4844,notabilis x lativitta,4844_CAM017266_d.JPG,major
+CAM017747,https://zenodo.org/record/3082688/files/CAM017747_d.JPG,1,test-2,5504,malleti x plesseni,5504_CAM017747_d.JPG,mimic
+CAM017267,https://zenodo.org/record/3082688/files/CAM017267_d.JPG,1,test-2,4846,plesseni x malleti,4846_CAM017267_d.JPG,mimic
+CAM017758,https://zenodo.org/record/3082688/files/CAM017758_d.JPG,1,test-2,5516,plesseni x malleti,5516_CAM017758_d.JPG,mimic
+CAM017760,https://zenodo.org/record/3082688/files/CAM017760_d.JPG,1,test-2,5520,plesseni x malleti,5520_CAM017760_d.JPG,mimic
+CAM017759,https://zenodo.org/record/3082688/files/CAM017759_d.JPG,1,test,5518,lativitta x notabilis,5518_CAM017759_d.JPG,major
+CAM017220,https://zenodo.org/record/3082688/files/CAM017220_d.JPG,1,test,4757,notabilis x lativitta,4757_CAM017220_d.JPG,major
+CAM017835,https://zenodo.org/record/3082688/files/CAM017835_d.JPG,1,test-2,5615,plesseni x malleti,5615_CAM017835_d.JPG,mimic
+CAM017179,https://zenodo.org/record/3082688/files/CAM017179_d.JPG,0,test,4678,notabilis,4678_CAM017179_d.JPG,major
+CAM017175,https://zenodo.org/record/3082688/files/CAM017175_d.JPG,0,test,4670,notabilis,4670_CAM017175_d.JPG,major
+CAM017213,https://zenodo.org/record/3082688/files/CAM017213_d.JPG,0,test,4743,notabilis,4743_CAM017213_d.JPG,major
+CAM017181,https://zenodo.org/record/3082688/files/CAM017181_d.JPG,0,test,4682,notabilis,4682_CAM017181_d.JPG,major
+CAM017182,https://zenodo.org/record/3082688/files/CAM017182_d.JPG,0,test,4684,notabilis,4684_CAM017182_d.JPG,major
+CAM017183,https://zenodo.org/record/3082688/files/CAM017183_d.JPG,0,test,4686,notabilis,4686_CAM017183_d.JPG,major
+CAM017180,https://zenodo.org/record/3082688/files/CAM017180_d.JPG,0,test,4680,notabilis,4680_CAM017180_d.JPG,major
+CAM017174,https://zenodo.org/record/3082688/files/CAM017174_d.JPG,0,test,4669,notabilis,4669_CAM017174_d.JPG,major
+CAM017163,https://zenodo.org/record/3082688/files/CAM017163_d.JPG,1,test,4649,notabilis x lativitta,4649_CAM017163_d.JPG,major
+CAM017165,https://zenodo.org/record/3082688/files/CAM017165_d.JPG,1,test,4651,notabilis x lativitta,4651_CAM017165_d.JPG,major
+CAM017172,https://zenodo.org/record/3082688/files/CAM017172_d.JPG,0,test,4665,notabilis,4665_CAM017172_d.JPG,major
+CAM017173,https://zenodo.org/record/3082688/files/CAM017173_d.JPG,0,test,4667,notabilis,4667_CAM017173_d.JPG,major
+CAM017826,https://zenodo.org/record/3082688/files/CAM017826_d.JPG,1,test,5599,lativitta x notabilis,5599_CAM017826_d.JPG,major
+CAM017184,https://zenodo.org/record/3082688/files/CAM017184_d.JPG,1,test-2,4688,plesseni x malleti,4688_CAM017184_d.JPG,mimic
+CAM017185,https://zenodo.org/record/3082688/files/CAM017185_d.JPG,0,test-2,4690,plesseni,4690_CAM017185_d.JPG,mimic
+CAM017198,https://zenodo.org/record/3082688/files/CAM017198_d.JPG,0,test,4715,notabilis,4715_CAM017198_d.JPG,major
+CAM017199,https://zenodo.org/record/3082688/files/CAM017199_d.JPG,0,test,4717,notabilis,4717_CAM017199_d.JPG,major
+CAM017200,https://zenodo.org/record/3082688/files/CAM017200_d.JPG,0,test,4719,notabilis,4719_CAM017200_d.JPG,major
+CAM017201,https://zenodo.org/record/3082688/files/CAM017201_d.JPG,1,test,4721,notabilis x lativitta,4721_CAM017201_d.JPG,major
+CAM017202,https://zenodo.org/record/3082688/files/CAM017202_d.JPG,0,test,4723,notabilis,4723_CAM017202_d.JPG,major
+CAM017196,https://zenodo.org/record/3082688/files/CAM017196_d.JPG,0,test,4711,notabilis,4711_CAM017196_d.JPG,major
+CAM017203,https://zenodo.org/record/3082688/files/CAM017203_d.JPG,0,test,4725,notabilis,4725_CAM017203_d.JPG,major
+CAM017206,https://zenodo.org/record/3082688/files/CAM017206_d.JPG,1,test,4729,notabilis x lativitta,4729_CAM017206_d.JPG,major
+CAM017207,https://zenodo.org/record/3082688/files/CAM017207_d.JPG,0,test,4731,notabilis,4731_CAM017207_d.JPG,major
+CAM017208,https://zenodo.org/record/3082688/files/CAM017208_d.JPG,1,test-2,4733,plesseni x malleti,4733_CAM017208_d.JPG,mimic
+CAM017209,https://zenodo.org/record/3082688/files/CAM017209_d.JPG,1,test-2,4735,plesseni x malleti,4735_CAM017209_d.JPG,mimic
+CAM017211,https://zenodo.org/record/3082688/files/CAM017211_d.JPG,0,test,4739,notabilis,4739_CAM017211_d.JPG,major
+CAM017204,https://zenodo.org/record/3082688/files/CAM017204_d.JPG,0,test,4727,notabilis,4727_CAM017204_d.JPG,major
+CAM017197,https://zenodo.org/record/3082688/files/CAM017197_d.JPG,0,test,4713,notabilis,4713_CAM017197_d.JPG,major
+CAM017195,https://zenodo.org/record/3082688/files/CAM017195_d.JPG,0,test,4710,notabilis,4710_CAM017195_d.JPG,major
+CAM017186,https://zenodo.org/record/3082688/files/CAM017186_d.JPG,0,test-2,4692,plesseni,4692_CAM017186_d.JPG,mimic
+CAM017187,https://zenodo.org/record/3082688/files/CAM017187_d.JPG,0,test-2,4694,plesseni,4694_CAM017187_d.JPG,mimic
+CAM017188,https://zenodo.org/record/3082688/files/CAM017188_d.JPG,0,test,4696,notabilis,4696_CAM017188_d.JPG,major
+CAM017189,https://zenodo.org/record/3082688/files/CAM017189_d.JPG,0,test,4698,notabilis,4698_CAM017189_d.JPG,major
+CAM017190,https://zenodo.org/record/3082688/files/CAM017190_d.JPG,0,test,4700,notabilis,4700_CAM017190_d.JPG,major
+CAM017191,https://zenodo.org/record/3082688/files/CAM017191_d.JPG,1,test,4702,notabilis x lativitta,4702_CAM017191_d.JPG,major
+CAM017192,https://zenodo.org/record/3082688/files/CAM017192_d.JPG,1,test,4704,notabilis x lativitta,4704_CAM017192_d.JPG,major
+CAM017193,https://zenodo.org/record/3082688/files/CAM017193_d.JPG,0,test,4706,notabilis,4706_CAM017193_d.JPG,major
+CAM016280,https://zenodo.org/record/3082688/files/CAM016280_d.JPG,0,test-2,3394,plesseni,3394_CAM016280_d.JPG,mimic
+CAM017194,https://zenodo.org/record/3082688/files/CAM017194_d.JPG,0,test,4708,notabilis,4708_CAM017194_d.JPG,major
+CAM016208,https://zenodo.org/record/4153502/files/CAM016208_D.JPG,1,test,19072,notabilis x lativitta,19072_CAM016208_D.JPG,major
+CAM016004,https://zenodo.org/record/4153502/files/CAM016004_d.JPG,0,test-2,18849,plesseni,18849_CAM016004_d.JPG,mimic
+CAM016229,https://zenodo.org/record/4153502/files/CAM016229_D.JPG,1,test,19082,notabilis x lativitta,19082_CAM016229_D.JPG,major
+CAM016002,https://zenodo.org/record/4153502/files/CAM016002_d.JPG,0,test-2,18845,plesseni,18845_CAM016002_d.JPG,mimic
+CAM016231,https://zenodo.org/record/4153502/files/CAM016231_D.JPG,1,test,19084,notabilis x lativitta,19084_CAM016231_D.JPG,major
+CAM016232,https://zenodo.org/record/4153502/files/CAM016232_D.JPG,1,test,19086,notabilis x lativitta,19086_CAM016232_D.JPG,major
+CAM016000,https://zenodo.org/record/4153502/files/CAM016000_d.JPG,0,test-2,18841,plesseni,18841_CAM016000_d.JPG,mimic
+CAM016233,https://zenodo.org/record/4153502/files/CAM016233_D.JPG,1,test,19088,notabilis x lativitta,19088_CAM016233_D.JPG,major
+CAM016271,https://zenodo.org/record/4153502/files/CAM016271_D.JPG,1,test,19104,notabilis x lativitta,19104_CAM016271_D.JPG,major
+CAM016221,https://zenodo.org/record/4153502/files/CAM016221_D.JPG,1,test,19080,notabilis x lativitta,19080_CAM016221_D.JPG,major
+CAM016236,https://zenodo.org/record/4153502/files/CAM016236_D.JPG,1,test,19090,notabilis x lativitta,19090_CAM016236_D.JPG,major
+CAM016003,https://zenodo.org/record/4153502/files/CAM016003_d.JPG,0,test-2,18847,plesseni,18847_CAM016003_d.JPG,mimic
+CAM016265,https://zenodo.org/record/4153502/files/CAM016265_D.JPG,1,test,19102,notabilis x lativitta,19102_CAM016265_D.JPG,major
+CAM016262,https://zenodo.org/record/4153502/files/CAM016262_D.JPG,1,test,19100,notabilis x lativitta,19100_CAM016262_D.JPG,major
+CAM016261,https://zenodo.org/record/4153502/files/CAM016261_D.JPG,1,test,19098,notabilis x lativitta,19098_CAM016261_D.JPG,major
+CAM016258,https://zenodo.org/record/4153502/files/CAM016258_D.JPG,1,test,19094,notabilis x lativitta,19094_CAM016258_D.JPG,major
+CAM016001,https://zenodo.org/record/4153502/files/CAM016001_d.JPG,0,test-2,18843,plesseni,18843_CAM016001_d.JPG,mimic
+CAM016213,https://zenodo.org/record/4153502/files/CAM016213_D.JPG,1,test,19076,notabilis x lativitta,19076_CAM016213_D.JPG,major
+CAM016005,https://zenodo.org/record/4153502/files/CAM016005_d.JPG,0,test-2,18851,plesseni,18851_CAM016005_d.JPG,mimic
+CAM016212,https://zenodo.org/record/4153502/files/CAM016212_D.JPG,1,test,19074,notabilis x lativitta,19074_CAM016212_D.JPG,major
+CAM016215,https://zenodo.org/record/4153502/files/CAM016215_D.JPG,1,test,19078,notabilis x lativitta,19078_CAM016215_D.JPG,major
+CAM016256,https://zenodo.org/record/4153502/files/CAM016256_D.JPG,1,test,19092,notabilis x lativitta,19092_CAM016256_D.JPG,major
+CAM016698,https://zenodo.org/record/4153502/files/CAM016698_d.JPG,0,test-2,18940,plesseni,18940_CAM016698_d.JPG,mimic
+CAM016690,https://zenodo.org/record/4153502/files/CAM016690_d.JPG,0,test-2,18924,plesseni,18924_CAM016690_d.JPG,mimic
+CAM016303,https://zenodo.org/record/4153502/files/CAM016303_D.JPG,1,test,19108,notabilis x lativitta,19108_CAM016303_D.JPG,major
+CAM016305,https://zenodo.org/record/4153502/files/CAM016305_d.JPG,0,test,18864,notabilis,18864_CAM016305_d.JPG,major
+CAM016307,https://zenodo.org/record/4153502/files/CAM016307_d.JPG,1,test,18866,notabilis x lativitta,18866_CAM016307_d.JPG,major
+CAM016308,https://zenodo.org/record/4153502/files/CAM016308_D.JPG,1,test,19110,notabilis x lativitta,19110_CAM016308_D.JPG,major
+CAM016310,https://zenodo.org/record/4153502/files/CAM016310_D.JPG,1,test,19112,notabilis x lativitta,19112_CAM016310_D.JPG,major
+CAM016311,https://zenodo.org/record/4153502/files/CAM016311_D.JPG,1,test,19114,notabilis x lativitta,19114_CAM016311_D.JPG,major
+CAM016314,https://zenodo.org/record/4153502/files/CAM016314_d.JPG,1,test,18868,notabilis x lativitta,18868_CAM016314_d.JPG,major
+CAM016315,https://zenodo.org/record/4153502/files/CAM016315_D.JPG,0,test,19116,notabilis,19116_CAM016315_D.JPG,major
+CAM016316,https://zenodo.org/record/4153502/files/CAM016316_D.JPG,1,test,19118,notabilis x lativitta,19118_CAM016316_D.JPG,major
+CAM016317,https://zenodo.org/record/4153502/files/CAM016317_D.JPG,1,test,19120,notabilis x lativitta,19120_CAM016317_D.JPG,major
+CAM016322,https://zenodo.org/record/4153502/files/CAM016322_d.JPG,0,test,18870,notabilis,18870_CAM016322_d.JPG,major
+CAM016352,https://zenodo.org/record/4153502/files/CAM016352_D.JPG,0,test,19122,notabilis,19122_CAM016352_D.JPG,major
+CAM016353,https://zenodo.org/record/4153502/files/CAM016353_D.JPG,0,test,19124,notabilis,19124_CAM016353_D.JPG,major
+CAM016356,https://zenodo.org/record/4153502/files/CAM016356_D.JPG,0,test,19126,notabilis,19126_CAM016356_D.JPG,major
+CAM016361,https://zenodo.org/record/4153502/files/CAM016361_D.JPG,0,test,19128,notabilis,19128_CAM016361_D.JPG,major
+CAM016362,https://zenodo.org/record/4153502/files/CAM016362_D.JPG,0,test,19130,notabilis,19130_CAM016362_D.JPG,major
+CAM016363,https://zenodo.org/record/4153502/files/CAM016363_D.JPG,0,test,19132,notabilis,19132_CAM016363_D.JPG,major
+CAM016451,https://zenodo.org/record/4153502/files/CAM016451_d.JPG,1,test,18878,notabilis x lativitta,18878_CAM016451_d.JPG,major
+CAM016457,https://zenodo.org/record/4153502/files/CAM016457_d.JPG,1,test,18882,notabilis x lativitta,18882_CAM016457_d.JPG,major
+CAM016302,https://zenodo.org/record/4153502/files/CAM016302_d.JPG,1,test,18862,notabilis x lativitta,18862_CAM016302_d.JPG,major
+CAM016460,https://zenodo.org/record/4153502/files/CAM016460_d.JPG,1,test,18884,notabilis x lativitta,18884_CAM016460_d.JPG,major
+CAM016301,https://zenodo.org/record/4153502/files/CAM016301_d.JPG,0,test,18860,notabilis,18860_CAM016301_d.JPG,major
+CAM017357,https://zenodo.org/record/4153502/files/CAM017357_d.JPG,0,test-2,19020,plesseni,19020_CAM017357_d.JPG,mimic
+CAM017376,https://zenodo.org/record/4153502/files/CAM017376_d.JPG,0,test-2,19038,plesseni,19038_CAM017376_d.JPG,mimic
+CAM017613,https://zenodo.org/record/4153502/files/CAM017613_d.JPG,0,test-2,19054,plesseni,19054_CAM017613_d.JPG,mimic
+CAM017615,https://zenodo.org/record/4153502/files/CAM017615_d.JPG,0,test-2,19056,plesseni,19056_CAM017615_d.JPG,mimic
+CAM017616,https://zenodo.org/record/4153502/files/CAM017616_d.JPG,0,test-2,19058,plesseni,19058_CAM017616_d.JPG,mimic
+CAM017617,https://zenodo.org/record/4153502/files/CAM017617_d.JPG,0,test-2,19060,plesseni,19060_CAM017617_d.JPG,mimic
+CAM017618,https://zenodo.org/record/4153502/files/CAM017618_d.JPG,0,test-2,19062,plesseni,19062_CAM017618_d.JPG,mimic
+CAM017619,https://zenodo.org/record/4153502/files/CAM017619_d.JPG,0,test-2,19064,plesseni,19064_CAM017619_d.JPG,mimic
+CAM017620,https://zenodo.org/record/4153502/files/CAM017620_d.JPG,0,test-2,19066,plesseni,19066_CAM017620_d.JPG,mimic
+CAM017621,https://zenodo.org/record/4153502/files/CAM017621_d.JPG,0,test-2,19068,plesseni,19068_CAM017621_d.JPG,mimic
+CAM017622,https://zenodo.org/record/4153502/files/CAM017622_d.JPG,0,test-2,19070,plesseni,19070_CAM017622_d.JPG,mimic
+CAM017373,https://zenodo.org/record/4153502/files/CAM017373_d.JPG,0,test-2,19036,plesseni,19036_CAM017373_d.JPG,mimic
+CAM017372,https://zenodo.org/record/4153502/files/CAM017372_d.JPG,0,test-2,19034,plesseni,19034_CAM017372_d.JPG,mimic
+CAM017371,https://zenodo.org/record/4153502/files/CAM017371_d.JPG,0,test-2,19032,plesseni,19032_CAM017371_d.JPG,mimic
+CAM017368,https://zenodo.org/record/4153502/files/CAM017368_d.JPG,0,test-2,19030,plesseni,19030_CAM017368_d.JPG,mimic
+CAM017367,https://zenodo.org/record/4153502/files/CAM017367_d.JPG,0,test-2,19028,plesseni,19028_CAM017367_d.JPG,mimic
+CAM017365,https://zenodo.org/record/4153502/files/CAM017365_d.JPG,0,test-2,19026,plesseni,19026_CAM017365_d.JPG,mimic
+CAM017364,https://zenodo.org/record/4153502/files/CAM017364_d.JPG,0,test-2,19024,plesseni,19024_CAM017364_d.JPG,mimic
+CAM017363,https://zenodo.org/record/4153502/files/CAM017363_d.JPG,0,test-2,19022,plesseni,19022_CAM017363_d.JPG,mimic
+CAM016297,https://zenodo.org/record/4153502/files/CAM016297_D.JPG,0,test,19106,notabilis,19106_CAM016297_D.JPG,major
+CAM016705,https://zenodo.org/record/4153502/files/CAM016705_d.JPG,0,test,18954,notabilis,18954_CAM016705_d.JPG,major
+CAM016707,https://zenodo.org/record/4153502/files/CAM016707_d.JPG,0,test,18956,notabilis,18956_CAM016707_d.JPG,major
+CAM016709,https://zenodo.org/record/4153502/files/CAM016709_d.JPG,0,test,18958,notabilis,18958_CAM016709_d.JPG,major
+CAM016712,https://zenodo.org/record/4153502/files/CAM016712_d.JPG,0,test,18960,notabilis,18960_CAM016712_d.JPG,major
+CAM016734,https://zenodo.org/record/4153502/files/CAM016734_d.JPG,0,test-2,18962,plesseni,18962_CAM016734_d.JPG,mimic
+CAM016737,https://zenodo.org/record/4153502/files/CAM016737_d.JPG,0,test-2,18964,plesseni,18964_CAM016737_d.JPG,mimic
+CAM016738,https://zenodo.org/record/4153502/files/CAM016738_d.JPG,0,test-2,18966,plesseni,18966_CAM016738_d.JPG,mimic
+CAM016739,https://zenodo.org/record/4153502/files/CAM016739_d.JPG,0,test-2,18968,plesseni,18968_CAM016739_d.JPG,mimic
+CAM016905,https://zenodo.org/record/4153502/files/CAM016905_d.JPG,0,test-2,18974,plesseni,18974_CAM016905_d.JPG,mimic
+CAM016906,https://zenodo.org/record/4153502/files/CAM016906_d.JPG,0,test-2,18976,plesseni,18976_CAM016906_d.JPG,mimic
+CAM016907,https://zenodo.org/record/4153502/files/CAM016907_d.JPG,0,test-2,18978,plesseni,18978_CAM016907_d.JPG,mimic
+CAM016908,https://zenodo.org/record/4153502/files/CAM016908_d.JPG,0,test-2,18980,plesseni,18980_CAM016908_d.JPG,mimic
+CAM016909,https://zenodo.org/record/4153502/files/CAM016909_d.JPG,0,test-2,18982,plesseni,18982_CAM016909_d.JPG,mimic
+CAM016910,https://zenodo.org/record/4153502/files/CAM016910_d.JPG,0,test-2,18984,plesseni,18984_CAM016910_d.JPG,mimic
+CAM016911,https://zenodo.org/record/4153502/files/CAM016911_d.JPG,0,test-2,18986,plesseni,18986_CAM016911_d.JPG,mimic
+CAM016913,https://zenodo.org/record/4153502/files/CAM016913_d.JPG,0,test-2,18988,plesseni,18988_CAM016913_d.JPG,mimic
+CAM017256,https://zenodo.org/record/4153502/files/CAM017256_d.JPG,0,test-2,19002,plesseni,19002_CAM017256_d.JPG,mimic
+CAM017258,https://zenodo.org/record/4153502/files/CAM017258_d.JPG,0,test-2,19004,plesseni,19004_CAM017258_d.JPG,mimic
+CAM017313,https://zenodo.org/record/4153502/files/CAM017313_d.JPG,1,test-2,19006,plesseni x malleti,19006_CAM017313_d.JPG,mimic
+CAM017325,https://zenodo.org/record/4153502/files/CAM017325_d.JPG,0,test-2,19008,plesseni,19008_CAM017325_d.JPG,mimic
+CAM017327,https://zenodo.org/record/4153502/files/CAM017327_d.JPG,0,test-2,19010,plesseni,19010_CAM017327_d.JPG,mimic
+CAM016704,https://zenodo.org/record/4153502/files/CAM016704_d.JPG,0,test,18952,notabilis,18952_CAM016704_d.JPG,major
+CAM016703,https://zenodo.org/record/4153502/files/CAM016703_d.JPG,0,test,18950,notabilis,18950_CAM016703_d.JPG,major
+CAM016702,https://zenodo.org/record/4153502/files/CAM016702_d.JPG,0,test,18948,notabilis,18948_CAM016702_d.JPG,major
+CAM016701,https://zenodo.org/record/4153502/files/CAM016701_d.JPG,0,test-2,18946,plesseni,18946_CAM016701_d.JPG,mimic
+CAM016634,https://zenodo.org/record/4153502/files/CAM016634_d.JPG,1,test,18902,notabilis x lativitta,18902_CAM016634_d.JPG,major
+CAM016638,https://zenodo.org/record/4153502/files/CAM016638_d.JPG,1,test,18904,notabilis x lativitta,18904_CAM016638_d.JPG,major
+CAM016640,https://zenodo.org/record/4153502/files/CAM016640_d.JPG,1,test,18906,notabilis x lativitta,18906_CAM016640_d.JPG,major
+CAM016642,https://zenodo.org/record/4153502/files/CAM016642_d.JPG,1,test,18908,notabilis x lativitta,18908_CAM016642_d.JPG,major
+CAM016683,https://zenodo.org/record/4153502/files/CAM016683_d.JPG,0,test-2,18910,plesseni,18910_CAM016683_d.JPG,mimic
+CAM016684,https://zenodo.org/record/4153502/files/CAM016684_d.JPG,0,test-2,18912,plesseni,18912_CAM016684_d.JPG,mimic
+CAM016685,https://zenodo.org/record/4153502/files/CAM016685_d.JPG,0,test-2,18914,plesseni,18914_CAM016685_d.JPG,mimic
+CAM016686,https://zenodo.org/record/4153502/files/CAM016686_d.JPG,0,test-2,18916,plesseni,18916_CAM016686_d.JPG,mimic
+CAM016687,https://zenodo.org/record/4153502/files/CAM016687_d.JPG,0,test-2,18918,plesseni,18918_CAM016687_d.JPG,mimic
+CAM016688,https://zenodo.org/record/4153502/files/CAM016688_d.JPG,0,test-2,18920,plesseni,18920_CAM016688_d.JPG,mimic
+CAM016689,https://zenodo.org/record/4153502/files/CAM016689_d.JPG,0,test-2,18922,plesseni,18922_CAM016689_d.JPG,mimic
+CAM016691,https://zenodo.org/record/4153502/files/CAM016691_d.JPG,0,test-2,18926,plesseni,18926_CAM016691_d.JPG,mimic
+CAM016692,https://zenodo.org/record/4153502/files/CAM016692_d.JPG,0,test-2,18928,plesseni,18928_CAM016692_d.JPG,mimic
+CAM016693,https://zenodo.org/record/4153502/files/CAM016693_d.JPG,0,test-2,18930,plesseni,18930_CAM016693_d.JPG,mimic
+CAM016694,https://zenodo.org/record/4153502/files/CAM016694_d.JPG,0,test-2,18932,plesseni,18932_CAM016694_d.JPG,mimic
+CAM016695,https://zenodo.org/record/4153502/files/CAM016695_d.JPG,0,test-2,18934,plesseni,18934_CAM016695_d.JPG,mimic
+CAM016696,https://zenodo.org/record/4153502/files/CAM016696_d.JPG,0,test-2,18936,plesseni,18936_CAM016696_d.JPG,mimic
+CAM016697,https://zenodo.org/record/4153502/files/CAM016697_d.JPG,0,test-2,18938,plesseni,18938_CAM016697_d.JPG,mimic
+CAM017355,https://zenodo.org/record/4153502/files/CAM017355_d.JPG,0,test-2,19016,plesseni,19016_CAM017355_d.JPG,mimic
+CAM016699,https://zenodo.org/record/4153502/files/CAM016699_d.JPG,0,test-2,18942,plesseni,18942_CAM016699_d.JPG,mimic
+CAM016700,https://zenodo.org/record/4153502/files/CAM016700_d.JPG,0,test-2,18944,plesseni,18944_CAM016700_d.JPG,mimic
+CAM017356,https://zenodo.org/record/4153502/files/CAM017356_d.JPG,0,test-2,19018,plesseni,19018_CAM017356_d.JPG,mimic
+CAM017352,https://zenodo.org/record/4153502/files/CAM017352_d.JPG,0,test-2,19012,plesseni,19012_CAM017352_d.JPG,mimic
+CAM017353,https://zenodo.org/record/4153502/files/CAM017353_d.JPG,0,test-2,19014,plesseni,19014_CAM017353_d.JPG,mimic
+19N0332,https://zenodo.org/record/4288311/files/19N0332_d.JPG,0,test,19774,erato,19774_19N0332_d.JPG,minor
+19N1223,https://zenodo.org/record/4288311/files/19N1223_d.JPG,0,test-2,20235,malleti,20235_19N1223_d.JPG,mimic
+19N1212,https://zenodo.org/record/4288311/files/19N1212_d.JPG,0,test-2,20231,malleti,20231_19N1212_d.JPG,mimic
+19N1196,https://zenodo.org/record/4288311/files/19N1196_d.JPG,0,test-2,20225,malleti,20225_19N1196_d.JPG,mimic
+19N1195,https://zenodo.org/record/4288311/files/19N1195_d.JPG,0,test-2,20223,malleti,20223_19N1195_d.JPG,mimic
+19N1194,https://zenodo.org/record/4288311/files/19N1194_d.JPG,0,test-2,20221,malleti,20221_19N1194_d.JPG,mimic
+19N1158,https://zenodo.org/record/4288311/files/19N1158_d.JPG,0,test-2,20204,malleti,20204_19N1158_d.JPG,mimic
+19N1124,https://zenodo.org/record/4288311/files/19N1124_d.JPG,0,test-2,20198,malleti,20198_19N1124_d.JPG,mimic
+19N1112,https://zenodo.org/record/4288311/files/19N1112_d.JPG,0,test-2,20190,malleti,20190_19N1112_d.JPG,mimic
+19N1111,https://zenodo.org/record/4288311/files/19N1111_d.JPG,0,test-2,20188,malleti,20188_19N1111_d.JPG,mimic
+19N1110,https://zenodo.org/record/4288311/files/19N1110_d.JPG,0,test-2,20186,malleti,20186_19N1110_d.JPG,mimic
+19N1109,https://zenodo.org/record/4288311/files/19N1109_d.JPG,0,test-2,20184,malleti,20184_19N1109_d.JPG,mimic
+19N1179,https://zenodo.org/record/4288311/files/19N1179_d.JPG,0,test-2,20213,malleti,20213_19N1179_d.JPG,mimic
+19N0901,https://zenodo.org/record/4288311/files/19N0901_d.JPG,0,test-2,20098,malleti,20098_19N0901_d.JPG,mimic
+19N0746,https://zenodo.org/record/4288311/files/19N0746_d.JPG,0,test-2,20022,malleti,20022_19N0746_d.JPG,mimic
+19N0745,https://zenodo.org/record/4288311/files/19N0745_d.JPG,0,test-2,20020,malleti,20020_19N0745_d.JPG,mimic
+19N0738,https://zenodo.org/record/4288311/files/19N0738_d.JPG,0,test-2,20016,malleti,20016_19N0738_d.JPG,mimic
+19N0727,https://zenodo.org/record/4288311/files/19N0727_d.JPG,0,test-2,20012,malleti,20012_19N0727_d.JPG,mimic
+19N0715,https://zenodo.org/record/4288311/files/19N0715_d.JPG,0,test-2,20008,malleti,20008_19N0715_d.JPG,mimic
+19N0713,https://zenodo.org/record/4288311/files/19N0713_d.JPG,0,test-2,20004,malleti,20004_19N0713_d.JPG,mimic
+19N0712,https://zenodo.org/record/4288311/files/19N0712_d.JPG,0,test-2,20002,malleti,20002_19N0712_d.JPG,mimic
+19N0708,https://zenodo.org/record/4288311/files/19N0708_d.JPG,0,test-2,20000,malleti,20000_19N0708_d.JPG,mimic
+19N0700,https://zenodo.org/record/4288311/files/19N0700_d.JPG,0,test-2,19996,malleti,19996_19N0700_d.JPG,mimic
+19N0698,https://zenodo.org/record/4288311/files/19N0698_d.JPG,0,test-2,19992,malleti,19992_19N0698_d.JPG,mimic
+19N0759,https://zenodo.org/record/4288311/files/19N0759_d.JPG,0,test-2,20024,malleti,20024_19N0759_d.JPG,mimic
+19N0691,https://zenodo.org/record/4288311/files/19N0691_d.JPG,0,test-2,19984,malleti,19984_19N0691_d.JPG,mimic
+19N0690,https://zenodo.org/record/4288311/files/19N0690_d.JPG,0,test-2,19982,malleti,19982_19N0690_d.JPG,mimic
+19N0683,https://zenodo.org/record/4288311/files/19N0683_d.JPG,0,test-2,19976,malleti,19976_19N0683_d.JPG,mimic
+19N0682,https://zenodo.org/record/4288311/files/19N0682_d.JPG,0,test-2,19974,malleti,19974_19N0682_d.JPG,mimic
+19N0680,https://zenodo.org/record/4288311/files/19N0680_d.JPG,0,test-2,19972,malleti,19972_19N0680_d.JPG,mimic
+19N0674,https://zenodo.org/record/4288311/files/19N0674_d.JPG,0,test-2,19970,malleti,19970_19N0674_d.JPG,mimic
+19N0673,https://zenodo.org/record/4288311/files/19N0673_d.JPG,0,test-2,19968,malleti,19968_19N0673_d.JPG,mimic
+19N0672,https://zenodo.org/record/4288311/files/19N0672_d.JPG,0,test-2,19966,malleti,19966_19N0672_d.JPG,mimic
+19N0671,https://zenodo.org/record/4288311/files/19N0671_d.JPG,0,test-2,19964,malleti,19964_19N0671_d.JPG,mimic
+19N0667,https://zenodo.org/record/4288311/files/19N0667_d.JPG,0,test-2,19958,malleti,19958_19N0667_d.JPG,mimic
+19N0666,https://zenodo.org/record/4288311/files/19N0666_d.JPG,0,test-2,19956,malleti,19956_19N0666_d.JPG,mimic
+19N0899,https://zenodo.org/record/4288311/files/19N0899_d.JPG,0,test-2,20094,malleti,20094_19N0899_d.JPG,mimic
+19N0897,https://zenodo.org/record/4288311/files/19N0897_d.JPG,0,test-2,20090,malleti,20090_19N0897_d.JPG,mimic
+19N0868,https://zenodo.org/record/4288311/files/19N0868_d.JPG,0,test-2,20076,malleti,20076_19N0868_d.JPG,mimic
+19N0867,https://zenodo.org/record/4288311/files/19N0867_d.JPG,0,test-2,20074,malleti,20074_19N0867_d.JPG,mimic
+19N0866,https://zenodo.org/record/4288311/files/19N0866_d.JPG,0,test-2,20072,malleti,20072_19N0866_d.JPG,mimic
+19N0864,https://zenodo.org/record/4288311/files/19N0864_d.JPG,0,test-2,20068,malleti,20068_19N0864_d.JPG,mimic
+19N0863,https://zenodo.org/record/4288311/files/19N0863_d.JPG,0,test-2,20066,malleti,20066_19N0863_d.JPG,mimic
+19N0809,https://zenodo.org/record/4288311/files/19N0809_d.JPG,0,test-2,20034,malleti,20034_19N0809_d.JPG,mimic
+19N0812,https://zenodo.org/record/4288311/files/19N0812_d.JPG,0,test-2,20040,malleti,20040_19N0812_d.JPG,mimic
+19N0813,https://zenodo.org/record/4288311/files/19N0813_d.JPG,0,test-2,20042,malleti,20042_19N0813_d.JPG,mimic
+19N0833,https://zenodo.org/record/4288311/files/19N0833_d.JPG,0,test-2,20048,malleti,20048_19N0833_d.JPG,mimic
+19N0281,https://zenodo.org/record/4288311/files/19N0281_d.JPG,0,test-2,19708,malleti,19708_19N0281_d.JPG,mimic
+19N0056,https://zenodo.org/record/4288311/files/19N0056_d.JPG,0,test-2,19254,malleti,19254_19N0056_d.JPG,mimic
+19N0058,https://zenodo.org/record/4288311/files/19N0058_d.JPG,0,test-2,19260,malleti,19260_19N0058_d.JPG,mimic
+19N0061,https://zenodo.org/record/4288311/files/19N0061_d.JPG,0,test-2,19267,malleti,19267_19N0061_d.JPG,mimic
+19N0063,https://zenodo.org/record/4288311/files/19N0063_d.JPG,0,test-2,19271,malleti,19271_19N0063_d.JPG,mimic
+19N0068,https://zenodo.org/record/4288311/files/19N0068_d.JPG,0,test-2,19281,malleti,19281_19N0068_d.JPG,mimic
+19N0073,https://zenodo.org/record/4288311/files/19N0073_d.JPG,0,test-2,19291,malleti,19291_19N0073_d.JPG,mimic
+19N0074,https://zenodo.org/record/4288311/files/19N0074_d.JPG,0,test-2,19293,malleti,19293_19N0074_d.JPG,mimic
+19N0075,https://zenodo.org/record/4288311/files/19N0075_d.JPG,0,test-2,19295,malleti,19295_19N0075_d.JPG,mimic
+19N0076,https://zenodo.org/record/4288311/files/19N0076_d.JPG,0,test-2,19297,malleti,19297_19N0076_d.JPG,mimic
+19N0013,https://zenodo.org/record/4288311/files/19N0013_d.JPG,0,test-2,19165,malleti,19165_19N0013_d.JPG,mimic
+19N0014,https://zenodo.org/record/4288311/files/19N0014_d.JPG,0,test-2,19167,malleti,19167_19N0014_d.JPG,mimic
+19N0015,https://zenodo.org/record/4288311/files/19N0015_d.JPG,0,test-2,19169,malleti,19169_19N0015_d.JPG,mimic
+19N0026,https://zenodo.org/record/4288311/files/19N0026_d.JPG,0,test-2,19191,malleti,19191_19N0026_d.JPG,mimic
+19N0027,https://zenodo.org/record/4288311/files/19N0027_d.JPG,0,test-2,19194,malleti,19194_19N0027_d.JPG,mimic
+19N0029,https://zenodo.org/record/4288311/files/19N0029_d.JPG,0,test-2,19198,malleti,19198_19N0029_d.JPG,mimic
+19N0031,https://zenodo.org/record/4288311/files/19N0031_d.JPG,0,test-2,19202,malleti,19202_19N0031_d.JPG,mimic
+19N0033,https://zenodo.org/record/4288311/files/19N0033_d.JPG,0,test-2,19206,malleti,19206_19N0033_d.JPG,mimic
+19N0034,https://zenodo.org/record/4288311/files/19N0034_d.JPG,0,test-2,19208,malleti,19208_19N0034_d.JPG,mimic
+19N0035,https://zenodo.org/record/4288311/files/19N0035_d.JPG,0,test-2,19210,malleti,19210_19N0035_d.JPG,mimic
+19N0012,https://zenodo.org/record/4288311/files/19N0012_d.JPG,0,test-2,19163,malleti,19163_19N0012_d.JPG,mimic
+19N0114,https://zenodo.org/record/4288311/files/19N0114_d.JPG,0,test-2,19373,malleti,19373_19N0114_d.JPG,mimic
+19N0115,https://zenodo.org/record/4288311/files/19N0115_d.JPG,0,test-2,19375,malleti,19375_19N0115_d.JPG,mimic
+19N0116,https://zenodo.org/record/4288311/files/19N0116_d.JPG,0,test-2,19377,malleti,19377_19N0116_d.JPG,mimic
+19N0118,https://zenodo.org/record/4288311/files/19N0118_d.JPG,0,test-2,19381,malleti,19381_19N0118_d.JPG,mimic
+19N0123,https://zenodo.org/record/4288311/files/19N0123_d.JPG,0,test-2,19391,malleti,19391_19N0123_d.JPG,mimic
+19N0126,https://zenodo.org/record/4288311/files/19N0126_d.JPG,0,test-2,19397,malleti,19397_19N0126_d.JPG,mimic
+19N0127,https://zenodo.org/record/4288311/files/19N0127_d.JPG,0,test-2,19399,malleti,19399_19N0127_d.JPG,mimic
+19N0128,https://zenodo.org/record/4288311/files/19N0128_d.JPG,0,test-2,19401,malleti,19401_19N0128_d.JPG,mimic
+19N0130,https://zenodo.org/record/4288311/files/19N0130_d.JPG,0,test-2,19405,malleti,19405_19N0130_d.JPG,mimic
+19N0131,https://zenodo.org/record/4288311/files/19N0131_d.JPG,0,test-2,19407,malleti,19407_19N0131_d.JPG,mimic
+19N0133,https://zenodo.org/record/4288311/files/19N0133_d.JPG,0,test-2,19411,malleti,19411_19N0133_d.JPG,mimic
+19N0134,https://zenodo.org/record/4288311/files/19N0134_d.JPG,0,test-2,19413,malleti,19413_19N0134_d.JPG,mimic
+19N0135,https://zenodo.org/record/4288311/files/19N0135_d.JPG,0,test-2,19415,malleti,19415_19N0135_d.JPG,mimic
+19N0136,https://zenodo.org/record/4288311/files/19N0136_d.JPG,0,test-2,19417,malleti,19417_19N0136_d.JPG,mimic
+19N0137,https://zenodo.org/record/4288311/files/19N0137_d.JPG,0,test-2,19419,malleti,19419_19N0137_d.JPG,mimic
+19N0140,https://zenodo.org/record/4288311/files/19N0140_d.JPG,0,test-2,19425,malleti,19425_19N0140_d.JPG,mimic
+19N0141,https://zenodo.org/record/4288311/files/19N0141_d.JPG,0,test-2,19427,malleti,19427_19N0141_d.JPG,mimic
+19N0112,https://zenodo.org/record/4288311/files/19N0112_d.JPG,0,test-2,19369,malleti,19369_19N0112_d.JPG,mimic
+19N0110,https://zenodo.org/record/4288311/files/19N0110_d.JPG,0,test-2,19365,malleti,19365_19N0110_d.JPG,mimic
+19N0084,https://zenodo.org/record/4288311/files/19N0084_d.JPG,0,test-2,19313,malleti,19313_19N0084_d.JPG,mimic
+19N0086,https://zenodo.org/record/4288311/files/19N0086_d.JPG,0,test-2,19317,malleti,19317_19N0086_d.JPG,mimic
+19N0088,https://zenodo.org/record/4288311/files/19N0088_d.JPG,0,test-2,19321,malleti,19321_19N0088_d.JPG,mimic
+19N0089,https://zenodo.org/record/4288311/files/19N0089_d.JPG,0,test-2,19323,malleti,19323_19N0089_d.JPG,mimic
+19N0091,https://zenodo.org/record/4288311/files/19N0091_d.JPG,0,test-2,19327,malleti,19327_19N0091_d.JPG,mimic
+19N0094,https://zenodo.org/record/4288311/files/19N0094_d.JPG,0,test-2,19333,malleti,19333_19N0094_d.JPG,mimic
+19N0095,https://zenodo.org/record/4288311/files/19N0095_d.JPG,0,test-2,19335,malleti,19335_19N0095_d.JPG,mimic
+19N0097,https://zenodo.org/record/4288311/files/19N0097_d.JPG,0,test-2,19339,malleti,19339_19N0097_d.JPG,mimic
+19N0098,https://zenodo.org/record/4288311/files/19N0098_d.JPG,0,test-2,19341,malleti,19341_19N0098_d.JPG,mimic
+19N0100,https://zenodo.org/record/4288311/files/19N0100_d.JPG,0,test-2,19345,malleti,19345_19N0100_d.JPG,mimic
+19N0101,https://zenodo.org/record/4288311/files/19N0101_d.JPG,0,test-2,19347,malleti,19347_19N0101_d.JPG,mimic
+19N0102,https://zenodo.org/record/4288311/files/19N0102_d.JPG,0,test-2,19349,malleti,19349_19N0102_d.JPG,mimic
+19N0103,https://zenodo.org/record/4288311/files/19N0103_d.JPG,0,test-2,19351,malleti,19351_19N0103_d.JPG,mimic
+19N0105,https://zenodo.org/record/4288311/files/19N0105_d.JPG,0,test-2,19355,malleti,19355_19N0105_d.JPG,mimic
+19N0106,https://zenodo.org/record/4288311/files/19N0106_d.JPG,0,test-2,19357,malleti,19357_19N0106_d.JPG,mimic
+19N0107,https://zenodo.org/record/4288311/files/19N0107_d.JPG,0,test-2,19359,malleti,19359_19N0107_d.JPG,mimic
+19N0111,https://zenodo.org/record/4288311/files/19N0111_d.JPG,0,test-2,19367,malleti,19367_19N0111_d.JPG,mimic
+19N0226,https://zenodo.org/record/4288311/files/19N0226_d.JPG,0,test-2,19597,malleti,19597_19N0226_d.JPG,mimic
+19N0225,https://zenodo.org/record/4288311/files/19N0225_d.JPG,0,test-2,19595,malleti,19595_19N0225_d.JPG,mimic
+19N0212,https://zenodo.org/record/4288311/files/19N0212_d.JPG,0,test-2,19569,malleti,19569_19N0212_d.JPG,mimic
+19N0205,https://zenodo.org/record/4288311/files/19N0205_d.JPG,0,test-2,19555,malleti,19555_19N0205_d.JPG,mimic
+19N0242,https://zenodo.org/record/4288311/files/19N0242_d.JPG,0,test-2,19629,malleti,19629_19N0242_d.JPG,mimic
+19N0246,https://zenodo.org/record/4288311/files/19N0246_d.JPG,0,test-2,19637,malleti,19637_19N0246_d.JPG,mimic
+19N0280,https://zenodo.org/record/4288311/files/19N0280_d.JPG,0,test-2,19706,malleti,19706_19N0280_d.JPG,mimic
+19N0279,https://zenodo.org/record/4288311/files/19N0279_d.JPG,0,test-2,19704,malleti,19704_19N0279_d.JPG,mimic
+19N0278,https://zenodo.org/record/4288311/files/19N0278_d.JPG,0,test-2,19702,malleti,19702_19N0278_d.JPG,mimic
+19N0275,https://zenodo.org/record/4288311/files/19N0275_d.JPG,0,test-2,19696,malleti,19696_19N0275_d.JPG,mimic
+19N0267,https://zenodo.org/record/4288311/files/19N0267_d.JPG,0,test-2,19679,malleti,19679_19N0267_d.JPG,mimic
+19N0261,https://zenodo.org/record/4288311/files/19N0261_d.JPG,0,test-2,19667,malleti,19667_19N0261_d.JPG,mimic
+19N0257,https://zenodo.org/record/4288311/files/19N0257_d.JPG,0,test-2,19659,malleti,19659_19N0257_d.JPG,mimic
+19N0255,https://zenodo.org/record/4288311/files/19N0255_d.JPG,0,test-2,19655,malleti,19655_19N0255_d.JPG,mimic
+19N0010,https://zenodo.org/record/4288311/files/19N0010_d.JPG,0,test-2,19159,malleti,19159_19N0010_d.JPG,mimic
+19N0162,https://zenodo.org/record/4288311/files/19N0162_d.JPG,0,test-2,19469,malleti,19469_19N0162_d.JPG,mimic
+19N0160,https://zenodo.org/record/4288311/files/19N0160_d.JPG,0,test-2,19465,malleti,19465_19N0160_d.JPG,mimic
+19N0158,https://zenodo.org/record/4288311/files/19N0158_d.JPG,0,test-2,19461,malleti,19461_19N0158_d.JPG,mimic
+19N0153,https://zenodo.org/record/4288311/files/19N0153_d.JPG,0,test-2,19451,malleti,19451_19N0153_d.JPG,mimic
+19N0152,https://zenodo.org/record/4288311/files/19N0152_d.JPG,0,test-2,19449,malleti,19449_19N0152_d.JPG,mimic
+19N0150,https://zenodo.org/record/4288311/files/19N0150_d.JPG,0,test-2,19445,malleti,19445_19N0150_d.JPG,mimic
+19N0148,https://zenodo.org/record/4288311/files/19N0148_d.JPG,0,test-2,19441,malleti,19441_19N0148_d.JPG,mimic
+19N0147,https://zenodo.org/record/4288311/files/19N0147_d.JPG,0,test-2,19439,malleti,19439_19N0147_d.JPG,mimic
+19N1238,https://zenodo.org/record/4288311/files/19N1238_d.JPG,0,test,20249,erato,20249_19N1238_d.JPG,minor
+19N0000,https://zenodo.org/record/4288311/files/19N0000_d.JPG,0,test-2,19139,malleti,19139_19N0000_d.JPG,mimic
+19N0163,https://zenodo.org/record/4288311/files/19N0163_d.JPG,0,test-2,19471,malleti,19471_19N0163_d.JPG,mimic
+19N0196,https://zenodo.org/record/4288311/files/19N0196_d.JPG,0,test-2,19537,malleti,19537_19N0196_d.JPG,mimic
+19N0164,https://zenodo.org/record/4288311/files/19N0164_d.JPG,0,test-2,19473,malleti,19473_19N0164_d.JPG,mimic
+19N0190,https://zenodo.org/record/4288311/files/19N0190_d.JPG,0,test-2,19525,malleti,19525_19N0190_d.JPG,mimic
+19N0187,https://zenodo.org/record/4288311/files/19N0187_d.JPG,0,test-2,19519,malleti,19519_19N0187_d.JPG,mimic
+19N0186,https://zenodo.org/record/4288311/files/19N0186_d.JPG,0,test-2,19517,malleti,19517_19N0186_d.JPG,mimic
+19N0185,https://zenodo.org/record/4288311/files/19N0185_d.JPG,0,test-2,19515,malleti,19515_19N0185_d.JPG,mimic
+19N0184,https://zenodo.org/record/4288311/files/19N0184_d.JPG,0,test-2,19513,malleti,19513_19N0184_d.JPG,mimic
+19N0183,https://zenodo.org/record/4288311/files/19N0183_d.JPG,0,test-2,19511,malleti,19511_19N0183_d.JPG,mimic
+19N0182,https://zenodo.org/record/4288311/files/19N0182_d.JPG,0,test-2,19509,malleti,19509_19N0182_d.JPG,mimic
+19N0181,https://zenodo.org/record/4288311/files/19N0181_d.JPG,0,test-2,19507,malleti,19507_19N0181_d.JPG,mimic
+19N0180,https://zenodo.org/record/4288311/files/19N0180_d.JPG,0,test-2,19505,malleti,19505_19N0180_d.JPG,mimic
+19N0179,https://zenodo.org/record/4288311/files/19N0179_d.JPG,0,test-2,19503,malleti,19503_19N0179_d.JPG,mimic
+19N0178,https://zenodo.org/record/4288311/files/19N0178_d.JPG,0,test-2,19501,malleti,19501_19N0178_d.JPG,mimic
+19N0177,https://zenodo.org/record/4288311/files/19N0177_d.JPG,0,test-2,19499,malleti,19499_19N0177_d.JPG,mimic
+19N0175,https://zenodo.org/record/4288311/files/19N0175_d.JPG,0,test-2,19495,malleti,19495_19N0175_d.JPG,mimic
+19N0174,https://zenodo.org/record/4288311/files/19N0174_d.JPG,0,test-2,19493,malleti,19493_19N0174_d.JPG,mimic
+19N0173,https://zenodo.org/record/4288311/files/19N0173_d.JPG,0,test-2,19491,malleti,19491_19N0173_d.JPG,mimic
+19N0172,https://zenodo.org/record/4288311/files/19N0172_d.JPG,0,test-2,19489,malleti,19489_19N0172_d.JPG,mimic
+19N0171,https://zenodo.org/record/4288311/files/19N0171_d.JPG,0,test-2,19487,malleti,19487_19N0171_d.JPG,mimic
+19N0170,https://zenodo.org/record/4288311/files/19N0170_d.JPG,0,test-2,19485,malleti,19485_19N0170_d.JPG,mimic
+19N0169,https://zenodo.org/record/4288311/files/19N0169_d.JPG,0,test-2,19483,malleti,19483_19N0169_d.JPG,mimic
+19N2260,https://zenodo.org/record/4288311/files/19N2260_d.JPG,0,test-2,21967,malleti,21967_19N2260_d.JPG,mimic
+19N1260,https://zenodo.org/record/4288311/files/19N1260_d.JPG,0,test-2,20255,malleti,20255_19N1260_d.JPG,mimic
+19N2257,https://zenodo.org/record/4288311/files/19N2257_d.JPG,0,test-2,21955,malleti,21955_19N2257_d.JPG,mimic
+19N2259,https://zenodo.org/record/4288311/files/19N2259_d.JPG,0,test-2,21963,malleti,21963_19N2259_d.JPG,mimic
+19N2270,https://zenodo.org/record/4288311/files/19N2270_d.JPG,0,test-2,22007,malleti,22007_19N2270_d.JPG,mimic
+19N2272,https://zenodo.org/record/4288311/files/19N2272_d.JPG,0,test-2,22015,malleti,22015_19N2272_d.JPG,mimic
+19N2273,https://zenodo.org/record/4288311/files/19N2273_d.JPG,0,test-2,22019,malleti,22019_19N2273_d.JPG,mimic
+19N2254,https://zenodo.org/record/4288311/files/19N2254_d.JPG,0,test-2,21943,malleti,21943_19N2254_d.JPG,mimic
+19N2253,https://zenodo.org/record/4288311/files/19N2253_d.JPG,0,test-2,21939,malleti,21939_19N2253_d.JPG,mimic
+19N2235,https://zenodo.org/record/4288311/files/19N2235_d.JPG,0,test-2,21867,malleti,21867_19N2235_d.JPG,mimic
+19N2236,https://zenodo.org/record/4288311/files/19N2236_d.JPG,0,test-2,21871,malleti,21871_19N2236_d.JPG,mimic
+19N2237,https://zenodo.org/record/4288311/files/19N2237_d.JPG,0,test-2,21875,malleti,21875_19N2237_d.JPG,mimic
+19N2242,https://zenodo.org/record/4288311/files/19N2242_d.JPG,0,test-2,21895,malleti,21895_19N2242_d.JPG,mimic
+19N2244,https://zenodo.org/record/4288311/files/19N2244_d.JPG,0,test-2,21903,malleti,21903_19N2244_d.JPG,mimic
+19N2246,https://zenodo.org/record/4288311/files/19N2246_d.JPG,0,test-2,21911,malleti,21911_19N2246_d.JPG,mimic
+19N2249,https://zenodo.org/record/4288311/files/19N2249_d.JPG,0,test-2,21923,malleti,21923_19N2249_d.JPG,mimic
+19N2250,https://zenodo.org/record/4288311/files/19N2250_d.JPG,0,test-2,21927,malleti,21927_19N2250_d.JPG,mimic
+19N2251,https://zenodo.org/record/4288311/files/19N2251_d.JPG,0,test-2,21931,malleti,21931_19N2251_d.JPG,mimic
+19N2252,https://zenodo.org/record/4288311/files/19N2252_d.JPG,0,test-2,21935,malleti,21935_19N2252_d.JPG,mimic
+19N2277,https://zenodo.org/record/4288311/files/19N2277_d.JPG,0,test-2,22035,malleti,22035_19N2277_d.JPG,mimic
+19N2279,https://zenodo.org/record/4288311/files/19N2279_d.JPG,0,test-2,22043,malleti,22043_19N2279_d.JPG,mimic
+19N1997,https://zenodo.org/record/4288311/files/19N1997_d.JPG,0,test-2,21387,malleti,21387_19N1997_d.JPG,mimic
+19N1996,https://zenodo.org/record/4288311/files/19N1996_d.JPG,0,test-2,21383,malleti,21383_19N1996_d.JPG,mimic
+19N1983,https://zenodo.org/record/4288311/files/19N1983_d.JPG,0,test-2,21347,malleti,21347_19N1983_d.JPG,mimic
+19N1981,https://zenodo.org/record/4288311/files/19N1981_d.JPG,0,test-2,21339,malleti,21339_19N1981_d.JPG,mimic
+19N1977,https://zenodo.org/record/4288311/files/19N1977_d.JPG,0,test-2,21335,malleti,21335_19N1977_d.JPG,mimic
+19N1989,https://zenodo.org/record/4288311/files/19N1989_d.JPG,0,test-2,21367,malleti,21367_19N1989_d.JPG,mimic
+19N2011,https://zenodo.org/record/4288311/files/19N2011_d.JPG,0,test-2,21415,malleti,21415_19N2011_d.JPG,mimic
+19N2280,https://zenodo.org/record/4288311/files/19N2280_d.JPG,0,test-2,22047,malleti,22047_19N2280_d.JPG,mimic
+19N2283,https://zenodo.org/record/4288311/files/19N2283_d.JPG,0,test-2,22059,malleti,22059_19N2283_d.JPG,mimic
+19N2284,https://zenodo.org/record/4288311/files/19N2284_d.JPG,0,test-2,22063,malleti,22063_19N2284_d.JPG,mimic
+19N2040,https://zenodo.org/record/4288311/files/19N2040_d.JPG,0,test-2,21487,malleti,21487_19N2040_d.JPG,mimic
+19N2036,https://zenodo.org/record/4288311/files/19N2036_d.JPG,0,test-2,21475,malleti,21475_19N2036_d.JPG,mimic
+19N2034,https://zenodo.org/record/4288311/files/19N2034_d.JPG,0,test-2,21467,malleti,21467_19N2034_d.JPG,mimic
+19N2033,https://zenodo.org/record/4288311/files/19N2033_d.JPG,0,test-2,21463,malleti,21463_19N2033_d.JPG,mimic
+19N2027,https://zenodo.org/record/4288311/files/19N2027_d.JPG,0,test-2,21459,malleti,21459_19N2027_d.JPG,mimic
+19N2026,https://zenodo.org/record/4288311/files/19N2026_d.JPG,0,test-2,21455,malleti,21455_19N2026_d.JPG,mimic
+19N2025,https://zenodo.org/record/4288311/files/19N2025_d.JPG,0,test-2,21451,malleti,21451_19N2025_d.JPG,mimic
+19N2020,https://zenodo.org/record/4288311/files/19N2020_d.JPG,0,test-2,21435,malleti,21435_19N2020_d.JPG,mimic
+19N2230,https://zenodo.org/record/4288311/files/19N2230_d.JPG,0,test-2,21847,malleti,21847_19N2230_d.JPG,mimic
+19N2088,https://zenodo.org/record/4288311/files/19N2088_d.JPG,0,test-2,21595,malleti,21595_19N2088_d.JPG,mimic
+19N2115,https://zenodo.org/record/4288311/files/19N2115_d.JPG,0,test-2,21611,malleti,21611_19N2115_d.JPG,mimic
+19N2116,https://zenodo.org/record/4288311/files/19N2116_d.JPG,0,test-2,21615,malleti,21615_19N2116_d.JPG,mimic
+19N2082,https://zenodo.org/record/4288311/files/19N2082_d.JPG,0,test-2,21579,malleti,21579_19N2082_d.JPG,mimic
+19N2118,https://zenodo.org/record/4288311/files/19N2118_d.JPG,0,test-2,21623,malleti,21623_19N2118_d.JPG,mimic
+19N2122,https://zenodo.org/record/4288311/files/19N2122_d.JPG,0,test-2,21635,malleti,21635_19N2122_d.JPG,mimic
+19N2126,https://zenodo.org/record/4288311/files/19N2126_d.JPG,0,test-2,21643,malleti,21643_19N2126_d.JPG,mimic
+19N2127,https://zenodo.org/record/4288311/files/19N2127_d.JPG,0,test-2,21647,malleti,21647_19N2127_d.JPG,mimic
+19N2119,https://zenodo.org/record/4288311/files/19N2119_d.JPG,0,test-2,21627,malleti,21627_19N2119_d.JPG,mimic
+19N2081,https://zenodo.org/record/4288311/files/19N2081_d.JPG,0,test-2,21575,malleti,21575_19N2081_d.JPG,mimic
+19N2079,https://zenodo.org/record/4288311/files/19N2079_d.JPG,0,test-2,21571,malleti,21571_19N2079_d.JPG,mimic
+19N2078,https://zenodo.org/record/4288311/files/19N2078_d.JPG,0,test-2,21567,malleti,21567_19N2078_d.JPG,mimic
+19N2041,https://zenodo.org/record/4288311/files/19N2041_d.JPG,0,test-2,21491,malleti,21491_19N2041_d.JPG,mimic
+19N2042,https://zenodo.org/record/4288311/files/19N2042_d.JPG,0,test-2,21495,malleti,21495_19N2042_d.JPG,mimic
+19N2043,https://zenodo.org/record/4288311/files/19N2043_d.JPG,0,test-2,21499,malleti,21499_19N2043_d.JPG,mimic
+19N2056,https://zenodo.org/record/4288311/files/19N2056_d.JPG,0,test-2,21511,malleti,21511_19N2056_d.JPG,mimic
+19N2059,https://zenodo.org/record/4288311/files/19N2059_d.JPG,0,test-2,21523,malleti,21523_19N2059_d.JPG,mimic
+19N2060,https://zenodo.org/record/4288311/files/19N2060_d.JPG,0,test-2,21527,malleti,21527_19N2060_d.JPG,mimic
+19N2061,https://zenodo.org/record/4288311/files/19N2061_d.JPG,0,test-2,21531,malleti,21531_19N2061_d.JPG,mimic
+19N2063,https://zenodo.org/record/4288311/files/19N2063_d.JPG,0,test-2,21539,malleti,21539_19N2063_d.JPG,mimic
+19N2068,https://zenodo.org/record/4288311/files/19N2068_d.JPG,0,test-2,21547,malleti,21547_19N2068_d.JPG,mimic
+19N2070,https://zenodo.org/record/4288311/files/19N2070_d.JPG,0,test-2,21555,malleti,21555_19N2070_d.JPG,mimic
+19N2231,https://zenodo.org/record/4288311/files/19N2231_d.JPG,0,test-2,21851,malleti,21851_19N2231_d.JPG,mimic
+19N2141,https://zenodo.org/record/4288311/files/19N2141_d.JPG,0,test-2,21667,malleti,21667_19N2141_d.JPG,mimic
+19N2143,https://zenodo.org/record/4288311/files/19N2143_d.JPG,0,test-2,21675,malleti,21675_19N2143_d.JPG,mimic
+19N2216,https://zenodo.org/record/4288311/files/19N2216_d.JPG,0,test-2,21791,malleti,21791_19N2216_d.JPG,mimic
+19N2219,https://zenodo.org/record/4288311/files/19N2219_d.JPG,0,test-2,21803,malleti,21803_19N2219_d.JPG,mimic
+19N2220,https://zenodo.org/record/4288311/files/19N2220_d.JPG,0,test-2,21807,malleti,21807_19N2220_d.JPG,mimic
+19N2224,https://zenodo.org/record/4288311/files/19N2224_d.JPG,0,test-2,21823,malleti,21823_19N2224_d.JPG,mimic
+19N2225,https://zenodo.org/record/4288311/files/19N2225_d.JPG,0,test-2,21827,malleti,21827_19N2225_d.JPG,mimic
+19N2227,https://zenodo.org/record/4288311/files/19N2227_d.JPG,0,test-2,21835,malleti,21835_19N2227_d.JPG,mimic
+19N2228,https://zenodo.org/record/4288311/files/19N2228_d.JPG,0,test-2,21839,malleti,21839_19N2228_d.JPG,mimic
+19N2229,https://zenodo.org/record/4288311/files/19N2229_d.JPG,0,test-2,21843,malleti,21843_19N2229_d.JPG,mimic
+19N2221,https://zenodo.org/record/4288311/files/19N2221_d.JPG,0,test-2,21811,malleti,21811_19N2221_d.JPG,mimic
+19N2144,https://zenodo.org/record/4288311/files/19N2144_d.JPG,0,test-2,21679,malleti,21679_19N2144_d.JPG,mimic
+19N2158,https://zenodo.org/record/4288311/files/19N2158_d.JPG,0,test-2,21687,malleti,21687_19N2158_d.JPG,mimic
+19N2165,https://zenodo.org/record/4288311/files/19N2165_d.JPG,0,test-2,21695,malleti,21695_19N2165_d.JPG,mimic
+19N2166,https://zenodo.org/record/4288311/files/19N2166_d.JPG,0,test-2,21699,malleti,21699_19N2166_d.JPG,mimic
+19N2188,https://zenodo.org/record/4288311/files/19N2188_d.JPG,0,test-2,21719,malleti,21719_19N2188_d.JPG,mimic
+19N2189,https://zenodo.org/record/4288311/files/19N2189_d.JPG,0,test-2,21723,malleti,21723_19N2189_d.JPG,mimic
+19N2142,https://zenodo.org/record/4288311/files/19N2142_d.JPG,0,test-2,21671,malleti,21671_19N2142_d.JPG,mimic
+19N1974,https://zenodo.org/record/4288311/files/19N1974_d.JPG,0,test-2,21323,malleti,21323_19N1974_d.JPG,mimic
+19N2038,https://zenodo.org/record/4288311/files/19N2038_d.JPG,0,test-2,21479,malleti,21479_19N2038_d.JPG,mimic
+19N1735,https://zenodo.org/record/4288311/files/19N1735_d.JPG,0,test-2,20935,malleti,20935_19N1735_d.JPG,mimic
+19N1714,https://zenodo.org/record/4288311/files/19N1714_d.JPG,0,test-2,20899,malleti,20899_19N1714_d.JPG,mimic
+19N1699,https://zenodo.org/record/4288311/files/19N1699_d.JPG,0,test-2,20891,malleti,20891_19N1699_d.JPG,mimic
+19N1646,https://zenodo.org/record/4288311/files/19N1646_d.JPG,0,test-2,20835,malleti,20835_19N1646_d.JPG,mimic
+19N1743,https://zenodo.org/record/4288311/files/19N1743_d.JPG,0,test-2,20943,malleti,20943_19N1743_d.JPG,mimic
+19N1744,https://zenodo.org/record/4288311/files/19N1744_d.JPG,0,test-2,20947,malleti,20947_19N1744_d.JPG,mimic
+19N1745,https://zenodo.org/record/4288311/files/19N1745_d.JPG,0,test-2,20951,malleti,20951_19N1745_d.JPG,mimic
+19N1821,https://zenodo.org/record/4288311/files/19N1821_d.JPG,0,test-2,21071,malleti,21071_19N1821_d.JPG,mimic
+19N1820,https://zenodo.org/record/4288311/files/19N1820_d.JPG,0,test-2,21067,malleti,21067_19N1820_d.JPG,mimic
+19N1813,https://zenodo.org/record/4288311/files/19N1813_d.JPG,0,test-2,21059,malleti,21059_19N1813_d.JPG,mimic
+19N1810,https://zenodo.org/record/4288311/files/19N1810_d.JPG,0,test-2,21047,malleti,21047_19N1810_d.JPG,mimic
+19N1806,https://zenodo.org/record/4288311/files/19N1806_d.JPG,0,test-2,21039,malleti,21039_19N1806_d.JPG,mimic
+19N1771,https://zenodo.org/record/4288311/files/19N1771_d.JPG,0,test-2,20999,malleti,20999_19N1771_d.JPG,mimic
+19N1769,https://zenodo.org/record/4288311/files/19N1769_d.JPG,0,test-2,20991,malleti,20991_19N1769_d.JPG,mimic
+19N1763,https://zenodo.org/record/4288311/files/19N1763_d.JPG,0,test-2,20979,malleti,20979_19N1763_d.JPG,mimic
+19N1762,https://zenodo.org/record/4288311/files/19N1762_d.JPG,0,test-2,20975,malleti,20975_19N1762_d.JPG,mimic
+19N1761,https://zenodo.org/record/4288311/files/19N1761_d.JPG,0,test-2,20971,malleti,20971_19N1761_d.JPG,mimic
+19N1754,https://zenodo.org/record/4288311/files/19N1754_d.JPG,0,test-2,20967,malleti,20967_19N1754_d.JPG,mimic
+19N1379,https://zenodo.org/record/4288311/files/19N1379_d.JPG,0,test-2,20313,malleti,20313_19N1379_d.JPG,mimic
+19N1377,https://zenodo.org/record/4288311/files/19N1377_d.JPG,0,test-2,20309,malleti,20309_19N1377_d.JPG,mimic
+19N1373,https://zenodo.org/record/4288311/files/19N1373_d.JPG,0,test-2,20305,malleti,20305_19N1373_d.JPG,mimic
+19N1367,https://zenodo.org/record/4288311/files/19N1367_d.JPG,0,test-2,20301,malleti,20301_19N1367_d.JPG,mimic
+19N1363,https://zenodo.org/record/4288311/files/19N1363_d.JPG,0,test-2,20299,malleti,20299_19N1363_d.JPG,mimic
+19N1349,https://zenodo.org/record/4288311/files/19N1349_d.JPG,0,test-2,20289,malleti,20289_19N1349_d.JPG,mimic
+19N1348,https://zenodo.org/record/4288311/files/19N1348_d.JPG,0,test-2,20287,malleti,20287_19N1348_d.JPG,mimic
+19N1334,https://zenodo.org/record/4288311/files/19N1334_d.JPG,0,test-2,20283,malleti,20283_19N1334_d.JPG,mimic
+19N1333,https://zenodo.org/record/4288311/files/19N1333_d.JPG,0,test-2,20281,malleti,20281_19N1333_d.JPG,mimic
+19N1332,https://zenodo.org/record/4288311/files/19N1332_d.JPG,0,test-2,20279,malleti,20279_19N1332_d.JPG,mimic
+19N1318,https://zenodo.org/record/4288311/files/19N1318_d.JPG,0,test-2,20275,malleti,20275_19N1318_d.JPG,mimic
+19N1316,https://zenodo.org/record/4288311/files/19N1316_d.JPG,0,test-2,20271,malleti,20271_19N1316_d.JPG,mimic
+19N1312,https://zenodo.org/record/4288311/files/19N1312_d.JPG,0,test-2,20269,malleti,20269_19N1312_d.JPG,mimic
+19N1299,https://zenodo.org/record/4288311/files/19N1299_d.JPG,0,test-2,20267,malleti,20267_19N1299_d.JPG,mimic
+19N1298,https://zenodo.org/record/4288311/files/19N1298_d.JPG,0,test-2,20265,malleti,20265_19N1298_d.JPG,mimic
+19N1380,https://zenodo.org/record/4288311/files/19N1380_d.JPG,0,test-2,20315,malleti,20315_19N1380_d.JPG,mimic
+19N1381,https://zenodo.org/record/4288311/files/19N1381_d.JPG,0,test-2,20317,malleti,20317_19N1381_d.JPG,mimic
+19N1382,https://zenodo.org/record/4288311/files/19N1382_d.JPG,0,test-2,20319,malleti,20319_19N1382_d.JPG,mimic
+19N1471,https://zenodo.org/record/4288311/files/19N1471_d.JPG,0,test-2,20381,malleti,20381_19N1471_d.JPG,mimic
+19N1467,https://zenodo.org/record/4288311/files/19N1467_d.JPG,0,test-2,20379,malleti,20379_19N1467_d.JPG,mimic
+19N1446,https://zenodo.org/record/4288311/files/19N1446_d.JPG,0,test-2,20371,malleti,20371_19N1446_d.JPG,mimic
+19N1432,https://zenodo.org/record/4288311/files/19N1432_d.JPG,0,test-2,20363,malleti,20363_19N1432_d.JPG,mimic
+19N1426,https://zenodo.org/record/4288311/files/19N1426_d.JPG,0,test-2,20357,malleti,20357_19N1426_d.JPG,mimic
+19N1422,https://zenodo.org/record/4288311/files/19N1422_d.JPG,0,test-2,20353,malleti,20353_19N1422_d.JPG,mimic
+19N1421,https://zenodo.org/record/4288311/files/19N1421_d.JPG,0,test-2,20351,malleti,20351_19N1421_d.JPG,mimic
+19N1419,https://zenodo.org/record/4288311/files/19N1419_d.JPG,0,test-2,20347,malleti,20347_19N1419_d.JPG,mimic
+19N1398,https://zenodo.org/record/4288311/files/19N1398_d.JPG,0,test-2,20339,malleti,20339_19N1398_d.JPG,mimic
+19N1394,https://zenodo.org/record/4288311/files/19N1394_d.JPG,0,test-2,20333,malleti,20333_19N1394_d.JPG,mimic
+19N1393,https://zenodo.org/record/4288311/files/19N1393_d.JPG,0,test-2,20331,malleti,20331_19N1393_d.JPG,mimic
+19N1392,https://zenodo.org/record/4288311/files/19N1392_d.JPG,0,test-2,20329,malleti,20329_19N1392_d.JPG,mimic
+19N1389,https://zenodo.org/record/4288311/files/19N1389_d.JPG,0,test-2,20327,malleti,20327_19N1389_d.JPG,mimic
+19N1388,https://zenodo.org/record/4288311/files/19N1388_d.JPG,0,test-2,20325,malleti,20325_19N1388_d.JPG,mimic
+19N1387,https://zenodo.org/record/4288311/files/19N1387_d.JPG,0,test-2,20323,malleti,20323_19N1387_d.JPG,mimic
+19N1827,https://zenodo.org/record/4288311/files/19N1827_d.JPG,0,test-2,21087,malleti,21087_19N1827_d.JPG,mimic
+19N1912,https://zenodo.org/record/4288311/files/19N1912_d.JPG,0,test-2,21219,malleti,21219_19N1912_d.JPG,mimic
+19N1909,https://zenodo.org/record/4288311/files/19N1909_d.JPG,0,test-2,21215,malleti,21215_19N1909_d.JPG,mimic
+19N1908,https://zenodo.org/record/4288311/files/19N1908_d.JPG,0,test-2,21211,malleti,21211_19N1908_d.JPG,mimic
+19N1907,https://zenodo.org/record/4288311/files/19N1907_d.JPG,0,test-2,21207,malleti,21207_19N1907_d.JPG,mimic
+19N1896,https://zenodo.org/record/4288311/files/19N1896_d.JPG,0,test-2,21191,malleti,21191_19N1896_d.JPG,mimic
+19N1892,https://zenodo.org/record/4288311/files/19N1892_d.JPG,0,test-2,21183,malleti,21183_19N1892_d.JPG,mimic
+19N1890,https://zenodo.org/record/4288311/files/19N1890_d.JPG,0,test-2,21179,malleti,21179_19N1890_d.JPG,mimic
+19N1888,https://zenodo.org/record/4288311/files/19N1888_d.JPG,0,test-2,21171,malleti,21171_19N1888_d.JPG,mimic
+19N1877,https://zenodo.org/record/4288311/files/19N1877_d.JPG,0,test-2,21159,malleti,21159_19N1877_d.JPG,mimic
+19N1957,https://zenodo.org/record/4288311/files/19N1957_d.JPG,0,test-2,21299,malleti,21299_19N1957_d.JPG,mimic
+19N1876,https://zenodo.org/record/4288311/files/19N1876_d.JPG,0,test-2,21155,malleti,21155_19N1876_d.JPG,mimic
+19N1945,https://zenodo.org/record/4288311/files/19N1945_d.JPG,0,test-2,21275,malleti,21275_19N1945_d.JPG,mimic
+19N1932,https://zenodo.org/record/4288311/files/19N1932_d.JPG,0,test-2,21251,malleti,21251_19N1932_d.JPG,mimic
+19N1251,https://zenodo.org/record/4288311/files/19N1251_d.JPG,0,test-2,20253,malleti,20253_19N1251_d.JPG,mimic
+19N1867,https://zenodo.org/record/4288311/files/19N1867_d.JPG,0,test-2,21143,malleti,21143_19N1867_d.JPG,mimic
+19N1875,https://zenodo.org/record/4288311/files/19N1875_d.JPG,0,test-2,21151,malleti,21151_19N1875_d.JPG,mimic
+19N1864,https://zenodo.org/record/4288311/files/19N1864_d.JPG,0,test-2,21131,malleti,21131_19N1864_d.JPG,mimic
+19N1861,https://zenodo.org/record/4288311/files/19N1861_d.JPG,0,test-2,21123,malleti,21123_19N1861_d.JPG,mimic
+19N1857,https://zenodo.org/record/4288311/files/19N1857_d.JPG,0,test-2,21115,malleti,21115_19N1857_d.JPG,mimic
+19N1856,https://zenodo.org/record/4288311/files/19N1856_d.JPG,0,test-2,21111,malleti,21111_19N1856_d.JPG,mimic
+19N1855,https://zenodo.org/record/4288311/files/19N1855_d.JPG,0,test-2,21107,malleti,21107_19N1855_d.JPG,mimic
+19N1850,https://zenodo.org/record/4288311/files/19N1850_d.JPG,0,test-2,21103,malleti,21103_19N1850_d.JPG,mimic
+19N1845,https://zenodo.org/record/4288311/files/19N1845_d.JPG,0,test-2,21099,malleti,21099_19N1845_d.JPG,mimic
+19N1841,https://zenodo.org/record/4288311/files/19N1841_d.JPG,0,test-2,21095,malleti,21095_19N1841_d.JPG,mimic
+19N1860,https://zenodo.org/record/4288311/files/19N1860_d.JPG,0,test-2,21119,malleti,21119_19N1860_d.JPG,mimic
+15N261,https://zenodo.org/record/4289223/files/15N261_d.JPG,0,test,15220,venus,15220_15N261_d.JPG,minor
+15N145,https://zenodo.org/record/4289223/files/15N145_d.JPG,0,test,14957,venus,14957_15N145_d.JPG,minor
+15N146,https://zenodo.org/record/4289223/files/15N146_d.JPG,0,test,14959,venus,14959_15N146_d.JPG,minor
+15N149,https://zenodo.org/record/4289223/files/15N149_d.JPG,0,test,14961,venus,14961_15N149_d.JPG,minor
+15N192,https://zenodo.org/record/4289223/files/15N192_d.JPG,0,test,15202,venus,15202_15N192_d.JPG,minor
+15N193,https://zenodo.org/record/4289223/files/15N193_d.JPG,0,test,15204,venus,15204_15N193_d.JPG,minor
+15N194,https://zenodo.org/record/4289223/files/15N194_d.JPG,0,test,15206,venus,15206_15N194_d.JPG,minor
+15N195,https://zenodo.org/record/4289223/files/15N195_d.JPG,0,test,15208,venus,15208_15N195_d.JPG,minor
+15N238,https://zenodo.org/record/4289223/files/15N238_d.JPG,0,test,15210,venus,15210_15N238_d.JPG,minor
+15N239,https://zenodo.org/record/4289223/files/15N239_d.JPG,0,test,15212,venus,15212_15N239_d.JPG,minor
+15N241,https://zenodo.org/record/4289223/files/15N241_d.JPG,0,test,15216,venus,15216_15N241_d.JPG,minor
+15N136,https://zenodo.org/record/4289223/files/15N136_d.JPG,0,test,15184,chestertonii,15184_15N136_d.JPG,minor
+15N135,https://zenodo.org/record/4289223/files/15N135_d.JPG,0,test,15182,chestertonii,15182_15N135_d.JPG,minor
+15N101,https://zenodo.org/record/4289223/files/15N101_d.JPG,0,test,14953,venus,14953_15N101_d.JPG,minor
+15N111,https://zenodo.org/record/4289223/files/15N111_d.JPG,0,test,15169,venus,15169_15N111_d.JPG,minor
+15N112,https://zenodo.org/record/4289223/files/15N112_d.JPG,0,test,15171,venus,15171_15N112_d.JPG,minor
+15N113,https://zenodo.org/record/4289223/files/15N113_d.JPG,0,test,15173,venus,15173_15N113_d.JPG,minor
+15N115,https://zenodo.org/record/4289223/files/15N115_d.JPG,0,test,14955,venus,14955_15N115_d.JPG,minor
+15N120,https://zenodo.org/record/4289223/files/15N120_d.JPG,0,test,15174,venus,15174_15N120_d.JPG,minor
+15N121,https://zenodo.org/record/4289223/files/15N121_d.JPG,0,test,15176,venus,15176_15N121_d.JPG,minor
+CAM041525,https://zenodo.org/record/4291095/files/CAM041525_d.JPG,0,test-2,39072,malleti,39072_CAM041525_d.JPG,mimic
+CAM041524,https://zenodo.org/record/4291095/files/CAM041524_d.JPG,0,test-2,39068,malleti,39068_CAM041524_d.JPG,mimic
+CAM041517,https://zenodo.org/record/4291095/files/CAM041517_d.JPG,0,test-2,39040,malleti,39040_CAM041517_d.JPG,mimic
+CAM041526,https://zenodo.org/record/4291095/files/CAM041526_d.JPG,0,test-2,39076,malleti,39076_CAM041526_d.JPG,mimic
+CAM041500,https://zenodo.org/record/4291095/files/CAM041500_d.JPG,0,test-2,38972,malleti,38972_CAM041500_d.JPG,mimic
+CAM041499,https://zenodo.org/record/4291095/files/CAM041499_d.JPG,0,test-2,38968,malleti,38968_CAM041499_d.JPG,mimic
+CAM041498,https://zenodo.org/record/4291095/files/CAM041498_d.JPG,0,test-2,38964,malleti,38964_CAM041498_d.JPG,mimic
+CAM041497,https://zenodo.org/record/4291095/files/CAM041497_d.JPG,0,test-2,38960,malleti,38960_CAM041497_d.JPG,mimic
+CAM041496,https://zenodo.org/record/4291095/files/CAM041496_d.JPG,0,test-2,38956,malleti,38956_CAM041496_d.JPG,mimic
+CAM041582,https://zenodo.org/record/4291095/files/CAM041582_d.JPG,0,test-2,39296,malleti,39296_CAM041582_d.JPG,mimic
+CAM041581,https://zenodo.org/record/4291095/files/CAM041581_d.JPG,0,test-2,39292,malleti,39292_CAM041581_d.JPG,mimic
+CAM041580,https://zenodo.org/record/4291095/files/CAM041580_d.JPG,0,test-2,39288,malleti,39288_CAM041580_d.JPG,mimic
+CAM041579,https://zenodo.org/record/4291095/files/CAM041579_d.JPG,0,test-2,39284,malleti,39284_CAM041579_d.JPG,mimic
+CAM041578,https://zenodo.org/record/4291095/files/CAM041578_d.JPG,0,test-2,39280,malleti,39280_CAM041578_d.JPG,mimic
+CAM041577,https://zenodo.org/record/4291095/files/CAM041577_d.JPG,0,test-2,39276,malleti,39276_CAM041577_d.JPG,mimic
+CAM041576,https://zenodo.org/record/4291095/files/CAM041576_d.JPG,0,test-2,39272,malleti,39272_CAM041576_d.JPG,mimic
+CAM041557,https://zenodo.org/record/4291095/files/CAM041557_d.JPG,0,test-2,39196,malleti,39196_CAM041557_d.JPG,mimic
+CAM041547,https://zenodo.org/record/4291095/files/CAM041547_d.JPG,0,test-2,39160,malleti,39160_CAM041547_d.JPG,mimic
+CAM041546,https://zenodo.org/record/4291095/files/CAM041546_d.JPG,0,test-2,39156,malleti,39156_CAM041546_d.JPG,mimic
+CAM041542,https://zenodo.org/record/4291095/files/CAM041542_d.JPG,0,test-2,39140,malleti,39140_CAM041542_d.JPG,mimic
+CAM041372,https://zenodo.org/record/4291095/files/CAM041372_d.JPG,0,test-2,38468,malleti,38468_CAM041372_d.JPG,mimic
+CAM041371,https://zenodo.org/record/4291095/files/CAM041371_d.JPG,0,test-2,38464,malleti,38464_CAM041371_d.JPG,mimic
+CAM041369,https://zenodo.org/record/4291095/files/CAM041369_d.JPG,0,test-2,38456,malleti,38456_CAM041369_d.JPG,mimic
+CAM041368,https://zenodo.org/record/4291095/files/CAM041368_d.JPG,0,test-2,38452,malleti,38452_CAM041368_d.JPG,mimic
+CAM041367,https://zenodo.org/record/4291095/files/CAM041367_d.JPG,0,test-2,38448,malleti,38448_CAM041367_d.JPG,mimic
+CAM041475,https://zenodo.org/record/4291095/files/CAM041475_d.JPG,0,test-2,38868,malleti,38868_CAM041475_d.JPG,mimic
+CAM041458,https://zenodo.org/record/4291095/files/CAM041458_d.JPG,0,test-2,38804,malleti,38804_CAM041458_d.JPG,mimic
+CAM041456,https://zenodo.org/record/4291095/files/CAM041456_d.JPG,0,test-2,38796,malleti,38796_CAM041456_d.JPG,mimic
+CAM041403,https://zenodo.org/record/4291095/files/CAM041403_d.JPG,0,test-2,38584,malleti,38584_CAM041403_d.JPG,mimic
+CAM041400,https://zenodo.org/record/4291095/files/CAM041400_d.JPG,0,test-2,38572,malleti,38572_CAM041400_d.JPG,mimic
+CAM041587,https://zenodo.org/record/4291095/files/CAM041587_d.JPG,0,test-2,39315,malleti,39315_CAM041587_d.JPG,mimic
+CAM041588,https://zenodo.org/record/4291095/files/CAM041588_d.JPG,0,test-2,39319,malleti,39319_CAM041588_d.JPG,mimic
+CAM041803,https://zenodo.org/record/4291095/files/CAM041803_d.JPG,0,test,40179,lativitta,40179_CAM041803_d.JPG,major
+CAM041802,https://zenodo.org/record/4291095/files/CAM041802_d.JPG,0,test,40175,lativitta,40175_CAM041802_d.JPG,major
+CAM041801,https://zenodo.org/record/4291095/files/CAM041801_d.JPG,0,test,40171,lativitta,40171_CAM041801_d.JPG,major
+CAM041800,https://zenodo.org/record/4291095/files/CAM041800_d.JPG,0,test,40167,lativitta,40167_CAM041800_d.JPG,major
+CAM041799,https://zenodo.org/record/4291095/files/CAM041799_d.JPG,0,test,40163,lativitta,40163_CAM041799_d.JPG,major
+CAM041798,https://zenodo.org/record/4291095/files/CAM041798_d.JPG,0,test,40159,lativitta,40159_CAM041798_d.JPG,major
+CAM041797,https://zenodo.org/record/4291095/files/CAM041797_d.JPG,0,test,40155,lativitta,40155_CAM041797_d.JPG,major
+CAM041796,https://zenodo.org/record/4291095/files/CAM041796_d.JPG,0,test,40151,lativitta,40151_CAM041796_d.JPG,major
+CAM041795,https://zenodo.org/record/4291095/files/CAM041795_d.JPG,0,test,40147,lativitta,40147_CAM041795_d.JPG,major
+CAM041794,https://zenodo.org/record/4291095/files/CAM041794_d.JPG,0,test,40143,lativitta,40143_CAM041794_d.JPG,major
+CAM041793,https://zenodo.org/record/4291095/files/CAM041793_d.JPG,0,test,40139,lativitta,40139_CAM041793_d.JPG,major
+CAM041792,https://zenodo.org/record/4291095/files/CAM041792_d.JPG,0,test,40135,lativitta,40135_CAM041792_d.JPG,major
+CAM041791,https://zenodo.org/record/4291095/files/CAM041791_d.JPG,0,test,40131,lativitta,40131_CAM041791_d.JPG,major
+CAM041790,https://zenodo.org/record/4291095/files/CAM041790_d.JPG,0,test,40127,lativitta,40127_CAM041790_d.JPG,major
+CAM041789,https://zenodo.org/record/4291095/files/CAM041789_d.JPG,0,test,40123,lativitta,40123_CAM041789_d.JPG,major
+CAM041788,https://zenodo.org/record/4291095/files/CAM041788_d.JPG,0,test,40119,lativitta,40119_CAM041788_d.JPG,major
+CAM041787,https://zenodo.org/record/4291095/files/CAM041787_d.JPG,0,test,40115,lativitta,40115_CAM041787_d.JPG,major
+CAM041786,https://zenodo.org/record/4291095/files/CAM041786_d.JPG,0,test,40111,lativitta,40111_CAM041786_d.JPG,major
+CAM041785,https://zenodo.org/record/4291095/files/CAM041785_d.JPG,0,test,40107,lativitta,40107_CAM041785_d.JPG,major
+CAM041784,https://zenodo.org/record/4291095/files/CAM041784_d.JPG,0,test,40103,lativitta,40103_CAM041784_d.JPG,major
+CAM041783,https://zenodo.org/record/4291095/files/CAM041783_d.JPG,0,test,40099,lativitta,40099_CAM041783_d.JPG,major
+CAM041782,https://zenodo.org/record/4291095/files/CAM041782_d.JPG,0,test,40095,lativitta,40095_CAM041782_d.JPG,major
+CAM041780,https://zenodo.org/record/4291095/files/CAM041780_d.JPG,0,test,40087,lativitta,40087_CAM041780_d.JPG,major
+CAM041805,https://zenodo.org/record/4291095/files/CAM041805_d.JPG,0,test,40187,lativitta,40187_CAM041805_d.JPG,major
+CAM041753,https://zenodo.org/record/4291095/files/CAM041753_d.JPG,0,test,39979,lativitta,39979_CAM041753_d.JPG,major
+CAM041751,https://zenodo.org/record/4291095/files/CAM041751_d.JPG,0,test,39971,lativitta,39971_CAM041751_d.JPG,major
+CAM041723,https://zenodo.org/record/4291095/files/CAM041723_d.JPG,0,test,39859,lativitta,39859_CAM041723_d.JPG,major
+CAM041722,https://zenodo.org/record/4291095/files/CAM041722_d.JPG,0,test,39855,lativitta,39855_CAM041722_d.JPG,major
+CAM041721,https://zenodo.org/record/4291095/files/CAM041721_d.JPG,0,test,39851,lativitta,39851_CAM041721_d.JPG,major
+CAM041720,https://zenodo.org/record/4291095/files/CAM041720_d.JPG,0,test,39847,lativitta,39847_CAM041720_d.JPG,major
+CAM041719,https://zenodo.org/record/4291095/files/CAM041719_d.JPG,0,test,39843,lativitta,39843_CAM041719_d.JPG,major
+CAM041718,https://zenodo.org/record/4291095/files/CAM041718_d.JPG,0,test,39839,lativitta,39839_CAM041718_d.JPG,major
+CAM041717,https://zenodo.org/record/4291095/files/CAM041717_d.JPG,0,test,39835,lativitta,39835_CAM041717_d.JPG,major
+CAM041716,https://zenodo.org/record/4291095/files/CAM041716_d.JPG,0,test,39831,lativitta,39831_CAM041716_d.JPG,major
+CAM041715,https://zenodo.org/record/4291095/files/CAM041715_d.JPG,0,test,39827,lativitta,39827_CAM041715_d.JPG,major
+CAM041714,https://zenodo.org/record/4291095/files/CAM041714_d.JPG,0,test,39823,lativitta,39823_CAM041714_d.JPG,major
+CAM041713,https://zenodo.org/record/4291095/files/CAM041713_d.JPG,0,test,39819,lativitta,39819_CAM041713_d.JPG,major
+CAM041712,https://zenodo.org/record/4291095/files/CAM041712_d.JPG,0,test,39815,lativitta,39815_CAM041712_d.JPG,major
+CAM041711,https://zenodo.org/record/4291095/files/CAM041711_d.JPG,0,test,39811,lativitta,39811_CAM041711_d.JPG,major
+CAM041710,https://zenodo.org/record/4291095/files/CAM041710_d.JPG,0,test,39807,lativitta,39807_CAM041710_d.JPG,major
+CAM041709,https://zenodo.org/record/4291095/files/CAM041709_d.JPG,0,test,39803,lativitta,39803_CAM041709_d.JPG,major
+CAM041708,https://zenodo.org/record/4291095/files/CAM041708_d.JPG,0,test,39799,lativitta,39799_CAM041708_d.JPG,major
+CAM041707,https://zenodo.org/record/4291095/files/CAM041707_d.JPG,0,test,39795,lativitta,39795_CAM041707_d.JPG,major
+CAM041706,https://zenodo.org/record/4291095/files/CAM041706_d.JPG,0,test,39791,lativitta,39791_CAM041706_d.JPG,major
+CAM041705,https://zenodo.org/record/4291095/files/CAM041705_d.JPG,0,test,39787,lativitta,39787_CAM041705_d.JPG,major
+CAM041704,https://zenodo.org/record/4291095/files/CAM041704_d.JPG,0,test,39783,lativitta,39783_CAM041704_d.JPG,major
+CAM041703,https://zenodo.org/record/4291095/files/CAM041703_d.JPG,0,test,39779,lativitta,39779_CAM041703_d.JPG,major
+CAM041702,https://zenodo.org/record/4291095/files/CAM041702_d.JPG,0,test,39775,lativitta,39775_CAM041702_d.JPG,major
+CAM041701,https://zenodo.org/record/4291095/files/CAM041701_d.JPG,0,test,39771,lativitta,39771_CAM041701_d.JPG,major
+CAM041724,https://zenodo.org/record/4291095/files/CAM041724_d.JPG,0,test,39863,lativitta,39863_CAM041724_d.JPG,major
+CAM041752,https://zenodo.org/record/4291095/files/CAM041752_d.JPG,0,test,39975,lativitta,39975_CAM041752_d.JPG,major
+CAM041725,https://zenodo.org/record/4291095/files/CAM041725_d.JPG,0,test,39867,lativitta,39867_CAM041725_d.JPG,major
+CAM041727,https://zenodo.org/record/4291095/files/CAM041727_d.JPG,0,test,39875,lativitta,39875_CAM041727_d.JPG,major
+CAM041750,https://zenodo.org/record/4291095/files/CAM041750_d.JPG,0,test,39967,lativitta,39967_CAM041750_d.JPG,major
+CAM041749,https://zenodo.org/record/4291095/files/CAM041749_d.JPG,0,test,39963,lativitta,39963_CAM041749_d.JPG,major
+CAM041748,https://zenodo.org/record/4291095/files/CAM041748_d.JPG,0,test,39959,lativitta,39959_CAM041748_d.JPG,major
+CAM041747,https://zenodo.org/record/4291095/files/CAM041747_d.JPG,0,test,39955,lativitta,39955_CAM041747_d.JPG,major
+CAM041746,https://zenodo.org/record/4291095/files/CAM041746_d.JPG,0,test,39951,lativitta,39951_CAM041746_d.JPG,major
+CAM041745,https://zenodo.org/record/4291095/files/CAM041745_d.JPG,0,test,39947,lativitta,39947_CAM041745_d.JPG,major
+CAM041744,https://zenodo.org/record/4291095/files/CAM041744_d.JPG,0,test,39943,lativitta,39943_CAM041744_d.JPG,major
+CAM041743,https://zenodo.org/record/4291095/files/CAM041743_d.JPG,0,test,39939,lativitta,39939_CAM041743_d.JPG,major
+CAM041742,https://zenodo.org/record/4291095/files/CAM041742_d.JPG,0,test,39935,lativitta,39935_CAM041742_d.JPG,major
+CAM041741,https://zenodo.org/record/4291095/files/CAM041741_d.JPG,0,test,39931,lativitta,39931_CAM041741_d.JPG,major
+CAM041740,https://zenodo.org/record/4291095/files/CAM041740_d.JPG,0,test,39927,lativitta,39927_CAM041740_d.JPG,major
+CAM041739,https://zenodo.org/record/4291095/files/CAM041739_d.JPG,0,test,39923,lativitta,39923_CAM041739_d.JPG,major
+CAM041738,https://zenodo.org/record/4291095/files/CAM041738_d.JPG,0,test,39919,lativitta,39919_CAM041738_d.JPG,major
+CAM041737,https://zenodo.org/record/4291095/files/CAM041737_d.JPG,0,test,39915,lativitta,39915_CAM041737_d.JPG,major
+CAM041736,https://zenodo.org/record/4291095/files/CAM041736_d.JPG,0,test,39911,lativitta,39911_CAM041736_d.JPG,major
+CAM041735,https://zenodo.org/record/4291095/files/CAM041735_d.JPG,0,test,39907,lativitta,39907_CAM041735_d.JPG,major
+CAM041734,https://zenodo.org/record/4291095/files/CAM041734_d.JPG,0,test,39903,lativitta,39903_CAM041734_d.JPG,major
+CAM041733,https://zenodo.org/record/4291095/files/CAM041733_d.JPG,0,test,39899,lativitta,39899_CAM041733_d.JPG,major
+CAM041732,https://zenodo.org/record/4291095/files/CAM041732_d.JPG,0,test,39895,lativitta,39895_CAM041732_d.JPG,major
+CAM041731,https://zenodo.org/record/4291095/files/CAM041731_d.JPG,0,test,39891,lativitta,39891_CAM041731_d.JPG,major
+CAM041730,https://zenodo.org/record/4291095/files/CAM041730_d.JPG,0,test,39887,lativitta,39887_CAM041730_d.JPG,major
+CAM041729,https://zenodo.org/record/4291095/files/CAM041729_d.JPG,0,test,39883,lativitta,39883_CAM041729_d.JPG,major
+CAM041728,https://zenodo.org/record/4291095/files/CAM041728_d.JPG,0,test,39879,lativitta,39879_CAM041728_d.JPG,major
+CAM041726,https://zenodo.org/record/4291095/files/CAM041726_d.JPG,0,test,39871,lativitta,39871_CAM041726_d.JPG,major
+CAM041806,https://zenodo.org/record/4291095/files/CAM041806_d.JPG,0,test,40191,lativitta,40191_CAM041806_d.JPG,major
+CAM041779,https://zenodo.org/record/4291095/files/CAM041779_d.JPG,0,test,40083,lativitta,40083_CAM041779_d.JPG,major
+CAM041808,https://zenodo.org/record/4291095/files/CAM041808_d.JPG,0,test,40199,lativitta,40199_CAM041808_d.JPG,major
+CAM041885,https://zenodo.org/record/4291095/files/CAM041885_d.JPG,0,test,40504,lativitta,40504_CAM041885_d.JPG,major
+CAM041884,https://zenodo.org/record/4291095/files/CAM041884_d.JPG,0,test,40500,lativitta,40500_CAM041884_d.JPG,major
+CAM041883,https://zenodo.org/record/4291095/files/CAM041883_d.JPG,0,test,40496,lativitta,40496_CAM041883_d.JPG,major
+CAM041882,https://zenodo.org/record/4291095/files/CAM041882_d.JPG,0,test,40492,lativitta,40492_CAM041882_d.JPG,major
+CAM041881,https://zenodo.org/record/4291095/files/CAM041881_d.JPG,0,test,40488,lativitta,40488_CAM041881_d.JPG,major
+CAM041880,https://zenodo.org/record/4291095/files/CAM041880_d.JPG,0,test,40484,lativitta,40484_CAM041880_d.JPG,major
+CAM041879,https://zenodo.org/record/4291095/files/CAM041879_d.JPG,0,test,40480,lativitta,40480_CAM041879_d.JPG,major
+CAM041878,https://zenodo.org/record/4291095/files/CAM041878_d.JPG,0,test,40476,lativitta,40476_CAM041878_d.JPG,major
+CAM041877,https://zenodo.org/record/4291095/files/CAM041877_d.JPG,0,test,40472,lativitta,40472_CAM041877_d.JPG,major
+CAM041876,https://zenodo.org/record/4291095/files/CAM041876_d.JPG,0,test,40468,lativitta,40468_CAM041876_d.JPG,major
+CAM041886,https://zenodo.org/record/4291095/files/CAM041886_d.JPG,0,test,40508,lativitta,40508_CAM041886_d.JPG,major
+CAM041875,https://zenodo.org/record/4291095/files/CAM041875_d.JPG,0,test,40464,lativitta,40464_CAM041875_d.JPG,major
+CAM041873,https://zenodo.org/record/4291095/files/CAM041873_d.JPG,0,test,40456,lativitta,40456_CAM041873_d.JPG,major
+CAM041872,https://zenodo.org/record/4291095/files/CAM041872_d.JPG,0,test,40452,lativitta,40452_CAM041872_d.JPG,major
+CAM041871,https://zenodo.org/record/4291095/files/CAM041871_d.JPG,0,test,40448,lativitta,40448_CAM041871_d.JPG,major
+CAM041870,https://zenodo.org/record/4291095/files/CAM041870_d.JPG,0,test,40444,lativitta,40444_CAM041870_d.JPG,major
+CAM041869,https://zenodo.org/record/4291095/files/CAM041869_d.JPG,0,test,40440,lativitta,40440_CAM041869_d.JPG,major
+CAM041868,https://zenodo.org/record/4291095/files/CAM041868_d.JPG,0,test,40436,lativitta,40436_CAM041868_d.JPG,major
+CAM041867,https://zenodo.org/record/4291095/files/CAM041867_d.JPG,0,test,40432,lativitta,40432_CAM041867_d.JPG,major
+CAM041866,https://zenodo.org/record/4291095/files/CAM041866_d.JPG,0,test,40428,lativitta,40428_CAM041866_d.JPG,major
+CAM041865,https://zenodo.org/record/4291095/files/CAM041865_d.JPG,0,test,40424,lativitta,40424_CAM041865_d.JPG,major
+CAM041864,https://zenodo.org/record/4291095/files/CAM041864_d.JPG,0,test,40420,lativitta,40420_CAM041864_d.JPG,major
+CAM041874,https://zenodo.org/record/4291095/files/CAM041874_d.JPG,0,test,40460,lativitta,40460_CAM041874_d.JPG,major
+CAM041888,https://zenodo.org/record/4291095/files/CAM041888_d.JPG,0,test,40516,lativitta,40516_CAM041888_d.JPG,major
+CAM041807,https://zenodo.org/record/4291095/files/CAM041807_d.JPG,0,test,40195,lativitta,40195_CAM041807_d.JPG,major
+CAM041890,https://zenodo.org/record/4291095/files/CAM041890_d.JPG,0,test,40524,lativitta,40524_CAM041890_d.JPG,major
+CAM041354,https://zenodo.org/record/4291095/files/CAM041354_d.JPG,0,test,38396,lativitta,38396_CAM041354_d.JPG,major
+CAM041912,https://zenodo.org/record/4291095/files/CAM041912_d.JPG,0,test,40612,lativitta,40612_CAM041912_d.JPG,major
+CAM041911,https://zenodo.org/record/4291095/files/CAM041911_d.JPG,0,test,40608,lativitta,40608_CAM041911_d.JPG,major
+CAM041910,https://zenodo.org/record/4291095/files/CAM041910_d.JPG,0,test,40604,lativitta,40604_CAM041910_d.JPG,major
+CAM041909,https://zenodo.org/record/4291095/files/CAM041909_d.JPG,0,test,40600,lativitta,40600_CAM041909_d.JPG,major
+CAM041908,https://zenodo.org/record/4291095/files/CAM041908_d.JPG,0,test,40596,lativitta,40596_CAM041908_d.JPG,major
+CAM041907,https://zenodo.org/record/4291095/files/CAM041907_d.JPG,0,test,40592,lativitta,40592_CAM041907_d.JPG,major
+CAM041906,https://zenodo.org/record/4291095/files/CAM041906_d.JPG,0,test,40588,lativitta,40588_CAM041906_d.JPG,major
+CAM041905,https://zenodo.org/record/4291095/files/CAM041905_d.JPG,0,test,40584,lativitta,40584_CAM041905_d.JPG,major
+CAM041904,https://zenodo.org/record/4291095/files/CAM041904_d.JPG,0,test,40580,lativitta,40580_CAM041904_d.JPG,major
+CAM041903,https://zenodo.org/record/4291095/files/CAM041903_d.JPG,0,test,40576,lativitta,40576_CAM041903_d.JPG,major
+CAM041902,https://zenodo.org/record/4291095/files/CAM041902_d.JPG,0,test,40572,lativitta,40572_CAM041902_d.JPG,major
+CAM041901,https://zenodo.org/record/4291095/files/CAM041901_d.JPG,0,test,40568,lativitta,40568_CAM041901_d.JPG,major
+CAM041900,https://zenodo.org/record/4291095/files/CAM041900_d.JPG,0,test,40564,lativitta,40564_CAM041900_d.JPG,major
+CAM041899,https://zenodo.org/record/4291095/files/CAM041899_d.JPG,0,test,40560,lativitta,40560_CAM041899_d.JPG,major
+CAM041898,https://zenodo.org/record/4291095/files/CAM041898_d.JPG,0,test,40556,lativitta,40556_CAM041898_d.JPG,major
+CAM041897,https://zenodo.org/record/4291095/files/CAM041897_d.JPG,0,test,40552,lativitta,40552_CAM041897_d.JPG,major
+CAM041896,https://zenodo.org/record/4291095/files/CAM041896_d.JPG,0,test,40548,lativitta,40548_CAM041896_d.JPG,major
+CAM041895,https://zenodo.org/record/4291095/files/CAM041895_d.JPG,0,test,40544,lativitta,40544_CAM041895_d.JPG,major
+CAM041894,https://zenodo.org/record/4291095/files/CAM041894_d.JPG,0,test,40540,lativitta,40540_CAM041894_d.JPG,major
+CAM041893,https://zenodo.org/record/4291095/files/CAM041893_d.JPG,0,test,40536,lativitta,40536_CAM041893_d.JPG,major
+CAM041892,https://zenodo.org/record/4291095/files/CAM041892_d.JPG,0,test,40532,lativitta,40532_CAM041892_d.JPG,major
+CAM041891,https://zenodo.org/record/4291095/files/CAM041891_d.JPG,0,test,40528,lativitta,40528_CAM041891_d.JPG,major
+CAM041863,https://zenodo.org/record/4291095/files/CAM041863_d.JPG,0,test,40416,lativitta,40416_CAM041863_d.JPG,major
+CAM041862,https://zenodo.org/record/4291095/files/CAM041862_d.JPG,0,test,40412,lativitta,40412_CAM041862_d.JPG,major
+CAM041889,https://zenodo.org/record/4291095/files/CAM041889_d.JPG,0,test,40520,lativitta,40520_CAM041889_d.JPG,major
+CAM041860,https://zenodo.org/record/4291095/files/CAM041860_d.JPG,0,test,40404,lativitta,40404_CAM041860_d.JPG,major
+CAM041831,https://zenodo.org/record/4291095/files/CAM041831_d.JPG,0,test,40291,lativitta,40291_CAM041831_d.JPG,major
+CAM041830,https://zenodo.org/record/4291095/files/CAM041830_d.JPG,0,test,40287,lativitta,40287_CAM041830_d.JPG,major
+CAM041829,https://zenodo.org/record/4291095/files/CAM041829_d.JPG,0,test,40283,lativitta,40283_CAM041829_d.JPG,major
+CAM041828,https://zenodo.org/record/4291095/files/CAM041828_d.JPG,0,test,40279,lativitta,40279_CAM041828_d.JPG,major
+CAM041827,https://zenodo.org/record/4291095/files/CAM041827_d.JPG,0,test,40275,lativitta,40275_CAM041827_d.JPG,major
+CAM041826,https://zenodo.org/record/4291095/files/CAM041826_d.JPG,0,test,40271,lativitta,40271_CAM041826_d.JPG,major
+CAM041825,https://zenodo.org/record/4291095/files/CAM041825_d.JPG,0,test,40267,lativitta,40267_CAM041825_d.JPG,major
+CAM041824,https://zenodo.org/record/4291095/files/CAM041824_d.JPG,0,test,40263,lativitta,40263_CAM041824_d.JPG,major
+CAM041823,https://zenodo.org/record/4291095/files/CAM041823_d.JPG,0,test,40259,lativitta,40259_CAM041823_d.JPG,major
+CAM041822,https://zenodo.org/record/4291095/files/CAM041822_d.JPG,0,test,40255,lativitta,40255_CAM041822_d.JPG,major
+CAM041820,https://zenodo.org/record/4291095/files/CAM041820_d.JPG,0,test,40247,lativitta,40247_CAM041820_d.JPG,major
+CAM041819,https://zenodo.org/record/4291095/files/CAM041819_d.JPG,0,test,40243,lativitta,40243_CAM041819_d.JPG,major
+CAM041818,https://zenodo.org/record/4291095/files/CAM041818_d.JPG,0,test,40239,lativitta,40239_CAM041818_d.JPG,major
+CAM041817,https://zenodo.org/record/4291095/files/CAM041817_d.JPG,0,test,40235,lativitta,40235_CAM041817_d.JPG,major
+CAM041816,https://zenodo.org/record/4291095/files/CAM041816_d.JPG,0,test,40231,lativitta,40231_CAM041816_d.JPG,major
+CAM041815,https://zenodo.org/record/4291095/files/CAM041815_d.JPG,0,test,40227,lativitta,40227_CAM041815_d.JPG,major
+CAM041814,https://zenodo.org/record/4291095/files/CAM041814_d.JPG,0,test,40223,lativitta,40223_CAM041814_d.JPG,major
+CAM041813,https://zenodo.org/record/4291095/files/CAM041813_d.JPG,0,test,40219,lativitta,40219_CAM041813_d.JPG,major
+CAM041812,https://zenodo.org/record/4291095/files/CAM041812_d.JPG,0,test,40215,lativitta,40215_CAM041812_d.JPG,major
+CAM041811,https://zenodo.org/record/4291095/files/CAM041811_d.JPG,0,test,40211,lativitta,40211_CAM041811_d.JPG,major
+CAM041810,https://zenodo.org/record/4291095/files/CAM041810_d.JPG,0,test,40207,lativitta,40207_CAM041810_d.JPG,major
+CAM041861,https://zenodo.org/record/4291095/files/CAM041861_d.JPG,0,test,40408,lativitta,40408_CAM041861_d.JPG,major
+CAM041809,https://zenodo.org/record/4291095/files/CAM041809_d.JPG,0,test,40203,lativitta,40203_CAM041809_d.JPG,major
+CAM041832,https://zenodo.org/record/4291095/files/CAM041832_d.JPG,0,test,40295,lativitta,40295_CAM041832_d.JPG,major
+CAM041833,https://zenodo.org/record/4291095/files/CAM041833_d.JPG,0,test,40299,lativitta,40299_CAM041833_d.JPG,major
+CAM041821,https://zenodo.org/record/4291095/files/CAM041821_d.JPG,0,test,40251,lativitta,40251_CAM041821_d.JPG,major
+CAM041851,https://zenodo.org/record/4291095/files/CAM041851_d.JPG,0,test,40371,lativitta,40371_CAM041851_d.JPG,major
+CAM041859,https://zenodo.org/record/4291095/files/CAM041859_d.JPG,0,test,40400,lativitta,40400_CAM041859_d.JPG,major
+CAM041834,https://zenodo.org/record/4291095/files/CAM041834_d.JPG,0,test,40303,lativitta,40303_CAM041834_d.JPG,major
+CAM041857,https://zenodo.org/record/4291095/files/CAM041857_d.JPG,0,test,40392,lativitta,40392_CAM041857_d.JPG,major
+CAM041856,https://zenodo.org/record/4291095/files/CAM041856_d.JPG,0,test,40388,lativitta,40388_CAM041856_d.JPG,major
+CAM041855,https://zenodo.org/record/4291095/files/CAM041855_d.JPG,0,test,40384,lativitta,40384_CAM041855_d.JPG,major
+CAM041853,https://zenodo.org/record/4291095/files/CAM041853_d.JPG,0,test,40379,lativitta,40379_CAM041853_d.JPG,major
+CAM041852,https://zenodo.org/record/4291095/files/CAM041852_d.JPG,0,test,40375,lativitta,40375_CAM041852_d.JPG,major
+CAM041850,https://zenodo.org/record/4291095/files/CAM041850_d.JPG,0,test,40367,lativitta,40367_CAM041850_d.JPG,major
+CAM041849,https://zenodo.org/record/4291095/files/CAM041849_d.JPG,0,test,40363,lativitta,40363_CAM041849_d.JPG,major
+CAM041848,https://zenodo.org/record/4291095/files/CAM041848_d.JPG,0,test,40359,lativitta,40359_CAM041848_d.JPG,major
+CAM041858,https://zenodo.org/record/4291095/files/CAM041858_d.JPG,0,test,40396,lativitta,40396_CAM041858_d.JPG,major
+CAM041846,https://zenodo.org/record/4291095/files/CAM041846_d.JPG,0,test,40351,lativitta,40351_CAM041846_d.JPG,major
+CAM041847,https://zenodo.org/record/4291095/files/CAM041847_d.JPG,0,test,40355,lativitta,40355_CAM041847_d.JPG,major
+CAM041845,https://zenodo.org/record/4291095/files/CAM041845_d.JPG,0,test,40347,lativitta,40347_CAM041845_d.JPG,major
+CAM041844,https://zenodo.org/record/4291095/files/CAM041844_d.JPG,0,test,40343,lativitta,40343_CAM041844_d.JPG,major
+CAM041843,https://zenodo.org/record/4291095/files/CAM041843_d.JPG,0,test,40339,lativitta,40339_CAM041843_d.JPG,major
+CAM041842,https://zenodo.org/record/4291095/files/CAM041842_d.JPG,0,test,40335,lativitta,40335_CAM041842_d.JPG,major
+CAM041841,https://zenodo.org/record/4291095/files/CAM041841_d.JPG,0,test,40331,lativitta,40331_CAM041841_d.JPG,major
+CAM041840,https://zenodo.org/record/4291095/files/CAM041840_d.JPG,0,test,40327,lativitta,40327_CAM041840_d.JPG,major
+CAM041839,https://zenodo.org/record/4291095/files/CAM041839_d.JPG,0,test,40323,lativitta,40323_CAM041839_d.JPG,major
+CAM041838,https://zenodo.org/record/4291095/files/CAM041838_d.JPG,0,test,40319,lativitta,40319_CAM041838_d.JPG,major
+CAM041837,https://zenodo.org/record/4291095/files/CAM041837_d.JPG,0,test,40315,lativitta,40315_CAM041837_d.JPG,major
+CAM041836,https://zenodo.org/record/4291095/files/CAM041836_d.JPG,0,test,40311,lativitta,40311_CAM041836_d.JPG,major
+CAM041835,https://zenodo.org/record/4291095/files/CAM041835_d.JPG,0,test,40307,lativitta,40307_CAM041835_d.JPG,major
+CAM045262,https://zenodo.org/record/5526257/files/CAM045262_d.JPG,0,test,43611,cyrbia,43611_CAM045262_d.JPG,minor
+CAM045263,https://zenodo.org/record/5526257/files/CAM045263_d.JPG,0,test,43615,cyrbia,43615_CAM045263_d.JPG,minor
+CAM045248,https://zenodo.org/record/5526257/files/CAM045248_d.JPG,0,test,43555,cyrbia,43555_CAM045248_d.JPG,minor
+CAM045264,https://zenodo.org/record/5526257/files/CAM045264_d.JPG,0,test,43619,cyrbia,43619_CAM045264_d.JPG,minor
+CAM045230,https://zenodo.org/record/5526257/files/CAM045230_d.JPG,0,test,43483,cyrbia,43483_CAM045230_d.JPG,minor
+CAM045228,https://zenodo.org/record/5526257/files/CAM045228_d.JPG,0,test,43475,cyrbia,43475_CAM045228_d.JPG,minor
+CAM045136,https://zenodo.org/record/5526257/files/CAM045136_d.JPG,0,test,43111,cyrbia,43111_CAM045136_d.JPG,minor
+CAM045199,https://zenodo.org/record/5526257/files/CAM045199_d.JPG,0,test,43361,cyrbia,43361_CAM045199_d.JPG,minor
+CAM045200,https://zenodo.org/record/5526257/files/CAM045200_d.JPG,0,test,43365,cyrbia,43365_CAM045200_d.JPG,minor
+CAM045201,https://zenodo.org/record/5526257/files/CAM045201_d.JPG,0,test,43367,cyrbia,43367_CAM045201_d.JPG,minor
+CAM045202,https://zenodo.org/record/5526257/files/CAM045202_d.JPG,0,test,43371,cyrbia,43371_CAM045202_d.JPG,minor
+CAM045203,https://zenodo.org/record/5526257/files/CAM045203_d.JPG,0,test,43375,cyrbia,43375_CAM045203_d.JPG,minor
+CAM045204,https://zenodo.org/record/5526257/files/CAM045204_d.JPG,0,test,43379,cyrbia,43379_CAM045204_d.JPG,minor
+CAM045205,https://zenodo.org/record/5526257/files/CAM045205_d.JPG,0,test,43383,cyrbia,43383_CAM045205_d.JPG,minor
+CAM045206,https://zenodo.org/record/5526257/files/CAM045206_d.JPG,0,test,43387,cyrbia,43387_CAM045206_d.JPG,minor
+CAM045207,https://zenodo.org/record/5526257/files/CAM045207_d.JPG,0,test,43391,cyrbia,43391_CAM045207_d.JPG,minor
+CAM045208,https://zenodo.org/record/5526257/files/CAM045208_d.JPG,0,test,43395,cyrbia,43395_CAM045208_d.JPG,minor
+CAM045209,https://zenodo.org/record/5526257/files/CAM045209_d.JPG,0,test,43399,cyrbia,43399_CAM045209_d.JPG,minor
+CAM045210,https://zenodo.org/record/5526257/files/CAM045210_d.JPG,0,test,43403,cyrbia,43403_CAM045210_d.JPG,minor
+CAM045211,https://zenodo.org/record/5526257/files/CAM045211_d.JPG,0,test,43407,cyrbia,43407_CAM045211_d.JPG,minor
+CAM045229,https://zenodo.org/record/5526257/files/CAM045229_d.JPG,0,test,43479,cyrbia,43479_CAM045229_d.JPG,minor
+CAM045212,https://zenodo.org/record/5526257/files/CAM045212_d.JPG,0,test,43411,cyrbia,43411_CAM045212_d.JPG,minor
+CAM045214,https://zenodo.org/record/5526257/files/CAM045214_d.JPG,0,test,43419,cyrbia,43419_CAM045214_d.JPG,minor
+CAM045215,https://zenodo.org/record/5526257/files/CAM045215_d.JPG,0,test,43423,cyrbia,43423_CAM045215_d.JPG,minor
+CAM045216,https://zenodo.org/record/5526257/files/CAM045216_d.JPG,0,test,43427,cyrbia,43427_CAM045216_d.JPG,minor
+CAM045217,https://zenodo.org/record/5526257/files/CAM045217_d.JPG,0,test,43431,cyrbia,43431_CAM045217_d.JPG,minor
+CAM045218,https://zenodo.org/record/5526257/files/CAM045218_d.JPG,0,test,43435,cyrbia,43435_CAM045218_d.JPG,minor
+CAM045219,https://zenodo.org/record/5526257/files/CAM045219_d.JPG,0,test,43439,cyrbia,43439_CAM045219_d.JPG,minor
+CAM045220,https://zenodo.org/record/5526257/files/CAM045220_d.JPG,0,test,43443,cyrbia,43443_CAM045220_d.JPG,minor
+CAM045221,https://zenodo.org/record/5526257/files/CAM045221_d.JPG,0,test,43447,cyrbia,43447_CAM045221_d.JPG,minor
+CAM045222,https://zenodo.org/record/5526257/files/CAM045222_d.JPG,0,test,43451,cyrbia,43451_CAM045222_d.JPG,minor
+CAM045223,https://zenodo.org/record/5526257/files/CAM045223_d.JPG,0,test,43455,cyrbia,43455_CAM045223_d.JPG,minor
+CAM045224,https://zenodo.org/record/5526257/files/CAM045224_d.JPG,0,test,43459,cyrbia,43459_CAM045224_d.JPG,minor
+CAM045225,https://zenodo.org/record/5526257/files/CAM045225_d.JPG,0,test,43463,cyrbia,43463_CAM045225_d.JPG,minor
+CAM045226,https://zenodo.org/record/5526257/files/CAM045226_d.JPG,0,test,43467,cyrbia,43467_CAM045226_d.JPG,minor
+CAM045227,https://zenodo.org/record/5526257/files/CAM045227_d.JPG,0,test,43471,cyrbia,43471_CAM045227_d.JPG,minor
+CAM045213,https://zenodo.org/record/5526257/files/CAM045213_d.JPG,0,test,43415,cyrbia,43415_CAM045213_d.JPG,minor
+CAM045265,https://zenodo.org/record/5526257/files/CAM045265_d.JPG,0,test,43623,cyrbia,43623_CAM045265_d.JPG,minor
+CAM045251,https://zenodo.org/record/5526257/files/CAM045251_d.JPG,0,test,43567,cyrbia,43567_CAM045251_d.JPG,minor
+CAM045198,https://zenodo.org/record/5526257/files/CAM045198_d.JPG,0,test,43357,cyrbia,43357_CAM045198_d.JPG,minor
+CAM045168,https://zenodo.org/record/5526257/files/CAM045168_d.JPG,0,test,43237,cyrbia,43237_CAM045168_d.JPG,minor
+CAM045167,https://zenodo.org/record/5526257/files/CAM045167_d.JPG,0,test,43233,cyrbia,43233_CAM045167_d.JPG,minor
+CAM045166,https://zenodo.org/record/5526257/files/CAM045166_d.JPG,0,test,43229,cyrbia,43229_CAM045166_d.JPG,minor
+CAM045165,https://zenodo.org/record/5526257/files/CAM045165_d.JPG,0,test,43225,cyrbia,43225_CAM045165_d.JPG,minor
+CAM045164,https://zenodo.org/record/5526257/files/CAM045164_d.JPG,0,test,43221,cyrbia,43221_CAM045164_d.JPG,minor
+CAM045163,https://zenodo.org/record/5526257/files/CAM045163_d.JPG,0,test,43217,cyrbia,43217_CAM045163_d.JPG,minor
+CAM045162,https://zenodo.org/record/5526257/files/CAM045162_d.JPG,0,test,43213,cyrbia,43213_CAM045162_d.JPG,minor
+CAM045161,https://zenodo.org/record/5526257/files/CAM045161_d.JPG,0,test,43209,cyrbia,43209_CAM045161_d.JPG,minor
+CAM045160,https://zenodo.org/record/5526257/files/CAM045160_d.JPG,0,test,43205,cyrbia,43205_CAM045160_d.JPG,minor
+CAM045159,https://zenodo.org/record/5526257/files/CAM045159_d.JPG,0,test,43201,cyrbia,43201_CAM045159_d.JPG,minor
+CAM045158,https://zenodo.org/record/5526257/files/CAM045158_d.JPG,0,test,43197,cyrbia,43197_CAM045158_d.JPG,minor
+CAM045157,https://zenodo.org/record/5526257/files/CAM045157_d.JPG,0,test,43193,cyrbia,43193_CAM045157_d.JPG,minor
+CAM045266,https://zenodo.org/record/5526257/files/CAM045266_d.JPG,0,test,43627,cyrbia,43627_CAM045266_d.JPG,minor
+CAM045155,https://zenodo.org/record/5526257/files/CAM045155_d.JPG,0,test,43187,cyrbia,43187_CAM045155_d.JPG,minor
+CAM045154,https://zenodo.org/record/5526257/files/CAM045154_d.JPG,0,test,43183,cyrbia,43183_CAM045154_d.JPG,minor
+CAM045153,https://zenodo.org/record/5526257/files/CAM045153_d.JPG,0,test,43179,cyrbia,43179_CAM045153_d.JPG,minor
+CAM045152,https://zenodo.org/record/5526257/files/CAM045152_d.JPG,0,test,43175,cyrbia,43175_CAM045152_d.JPG,minor
+CAM045138,https://zenodo.org/record/5526257/files/CAM045138_d.JPG,0,test,43119,cyrbia,43119_CAM045138_d.JPG,minor
+CAM045139,https://zenodo.org/record/5526257/files/CAM045139_d.JPG,0,test,43123,cyrbia,43123_CAM045139_d.JPG,minor
+CAM045140,https://zenodo.org/record/5526257/files/CAM045140_d.JPG,0,test,43127,cyrbia,43127_CAM045140_d.JPG,minor
+CAM045141,https://zenodo.org/record/5526257/files/CAM045141_d.JPG,0,test,43131,cyrbia,43131_CAM045141_d.JPG,minor
+CAM045142,https://zenodo.org/record/5526257/files/CAM045142_d.JPG,0,test,43135,cyrbia,43135_CAM045142_d.JPG,minor
+CAM045143,https://zenodo.org/record/5526257/files/CAM045143_d.JPG,0,test,43139,cyrbia,43139_CAM045143_d.JPG,minor
+CAM045169,https://zenodo.org/record/5526257/files/CAM045169_d.JPG,0,test,43241,cyrbia,43241_CAM045169_d.JPG,minor
+CAM045144,https://zenodo.org/record/5526257/files/CAM045144_d.JPG,0,test,43143,cyrbia,43143_CAM045144_d.JPG,minor
+CAM045146,https://zenodo.org/record/5526257/files/CAM045146_d.JPG,0,test,43151,cyrbia,43151_CAM045146_d.JPG,minor
+CAM045147,https://zenodo.org/record/5526257/files/CAM045147_d.JPG,0,test,43155,cyrbia,43155_CAM045147_d.JPG,minor
+CAM045148,https://zenodo.org/record/5526257/files/CAM045148_d.JPG,0,test,43159,cyrbia,43159_CAM045148_d.JPG,minor
+CAM045149,https://zenodo.org/record/5526257/files/CAM045149_d.JPG,0,test,43163,cyrbia,43163_CAM045149_d.JPG,minor
+CAM045150,https://zenodo.org/record/5526257/files/CAM045150_d.JPG,0,test,43167,cyrbia,43167_CAM045150_d.JPG,minor
+CAM045151,https://zenodo.org/record/5526257/files/CAM045151_d.JPG,0,test,43171,cyrbia,43171_CAM045151_d.JPG,minor
+CAM045145,https://zenodo.org/record/5526257/files/CAM045145_d.JPG,0,test,43147,cyrbia,43147_CAM045145_d.JPG,minor
+CAM045170,https://zenodo.org/record/5526257/files/CAM045170_d.JPG,0,test,43245,cyrbia,43245_CAM045170_d.JPG,minor
+CAM045156,https://zenodo.org/record/5526257/files/CAM045156_d.JPG,0,test,43191,cyrbia,43191_CAM045156_d.JPG,minor
+CAM045172,https://zenodo.org/record/5526257/files/CAM045172_d.JPG,0,test,43253,cyrbia,43253_CAM045172_d.JPG,minor
+CAM045267,https://zenodo.org/record/5526257/files/CAM045267_d.JPG,0,test,43631,cyrbia,43631_CAM045267_d.JPG,minor
+CAM045171,https://zenodo.org/record/5526257/files/CAM045171_d.JPG,0,test,43249,cyrbia,43249_CAM045171_d.JPG,minor
+CAM045269,https://zenodo.org/record/5526257/files/CAM045269_d.JPG,0,test,43639,cyrbia,43639_CAM045269_d.JPG,minor
+CAM045270,https://zenodo.org/record/5526257/files/CAM045270_d.JPG,0,test,43643,cyrbia,43643_CAM045270_d.JPG,minor
+CAM045271,https://zenodo.org/record/5526257/files/CAM045271_d.JPG,0,test,43647,cyrbia,43647_CAM045271_d.JPG,minor
+CAM045197,https://zenodo.org/record/5526257/files/CAM045197_d.JPG,0,test,43353,cyrbia,43353_CAM045197_d.JPG,minor
+CAM045196,https://zenodo.org/record/5526257/files/CAM045196_d.JPG,0,test,43349,cyrbia,43349_CAM045196_d.JPG,minor
+CAM045195,https://zenodo.org/record/5526257/files/CAM045195_d.JPG,0,test,43345,cyrbia,43345_CAM045195_d.JPG,minor
+CAM045194,https://zenodo.org/record/5526257/files/CAM045194_d.JPG,0,test,43341,cyrbia,43341_CAM045194_d.JPG,minor
+CAM045193,https://zenodo.org/record/5526257/files/CAM045193_d.JPG,0,test,43337,cyrbia,43337_CAM045193_d.JPG,minor
+CAM045192,https://zenodo.org/record/5526257/files/CAM045192_d.JPG,0,test,43333,cyrbia,43333_CAM045192_d.JPG,minor
+CAM045191,https://zenodo.org/record/5526257/files/CAM045191_d.JPG,0,test,43329,cyrbia,43329_CAM045191_d.JPG,minor
+CAM045190,https://zenodo.org/record/5526257/files/CAM045190_d.JPG,0,test,43325,cyrbia,43325_CAM045190_d.JPG,minor
+CAM045189,https://zenodo.org/record/5526257/files/CAM045189_d.JPG,0,test,43321,cyrbia,43321_CAM045189_d.JPG,minor
+CAM045188,https://zenodo.org/record/5526257/files/CAM045188_d.JPG,0,test,43317,cyrbia,43317_CAM045188_d.JPG,minor
+CAM045268,https://zenodo.org/record/5526257/files/CAM045268_d.JPG,0,test,43635,cyrbia,43635_CAM045268_d.JPG,minor
+CAM045186,https://zenodo.org/record/5526257/files/CAM045186_d.JPG,0,test,43309,cyrbia,43309_CAM045186_d.JPG,minor
+CAM045187,https://zenodo.org/record/5526257/files/CAM045187_d.JPG,0,test,43313,cyrbia,43313_CAM045187_d.JPG,minor
+CAM045174,https://zenodo.org/record/5526257/files/CAM045174_d.JPG,0,test,43261,cyrbia,43261_CAM045174_d.JPG,minor
+CAM045175,https://zenodo.org/record/5526257/files/CAM045175_d.JPG,0,test,43265,cyrbia,43265_CAM045175_d.JPG,minor
+CAM045176,https://zenodo.org/record/5526257/files/CAM045176_d.JPG,0,test,43269,cyrbia,43269_CAM045176_d.JPG,minor
+CAM045177,https://zenodo.org/record/5526257/files/CAM045177_d.JPG,0,test,43273,cyrbia,43273_CAM045177_d.JPG,minor
+CAM045178,https://zenodo.org/record/5526257/files/CAM045178_d.JPG,0,test,43277,cyrbia,43277_CAM045178_d.JPG,minor
+CAM045179,https://zenodo.org/record/5526257/files/CAM045179_d.JPG,0,test,43281,cyrbia,43281_CAM045179_d.JPG,minor
+CAM045173,https://zenodo.org/record/5526257/files/CAM045173_d.JPG,0,test,43257,cyrbia,43257_CAM045173_d.JPG,minor
+CAM045181,https://zenodo.org/record/5526257/files/CAM045181_d.JPG,0,test,43289,cyrbia,43289_CAM045181_d.JPG,minor
+CAM045182,https://zenodo.org/record/5526257/files/CAM045182_d.JPG,0,test,43293,cyrbia,43293_CAM045182_d.JPG,minor
+CAM045183,https://zenodo.org/record/5526257/files/CAM045183_d.JPG,0,test,43297,cyrbia,43297_CAM045183_d.JPG,minor
+CAM045184,https://zenodo.org/record/5526257/files/CAM045184_d.JPG,0,test,43301,cyrbia,43301_CAM045184_d.JPG,minor
+CAM045185,https://zenodo.org/record/5526257/files/CAM045185_d.JPG,0,test,43305,cyrbia,43305_CAM045185_d.JPG,minor
+CAM045180,https://zenodo.org/record/5526257/files/CAM045180_d.JPG,0,test,43285,cyrbia,43285_CAM045180_d.JPG,minor
+CAM036275,https://zenodo.org/record/5561246/files/CAM036275_d.JPG,0,test,41755,phyllis,41755_CAM036275_d.JPG,minor
+CAM036274,https://zenodo.org/record/5561246/files/CAM036274_d.JPG,0,test,41751,phyllis,41751_CAM036274_d.JPG,minor
+CAM036260,https://zenodo.org/record/5561246/files/CAM036260_d.JPG,0,test,41719,phyllis,41719_CAM036260_d.JPG,minor
+CAM036257,https://zenodo.org/record/5561246/files/CAM036257_d.JPG,0,test,41707,phyllis,41707_CAM036257_d.JPG,minor
+CAM036256,https://zenodo.org/record/5561246/files/CAM036256_d.JPG,0,test,41703,phyllis,41703_CAM036256_d.JPG,minor
+CAM036255,https://zenodo.org/record/5561246/files/CAM036255_d.JPG,0,test,41699,phyllis,41699_CAM036255_d.JPG,minor
+CAM036254,https://zenodo.org/record/5561246/files/CAM036254_d.JPG,0,test,41695,phyllis,41695_CAM036254_d.JPG,minor
+CAM036253,https://zenodo.org/record/5561246/files/CAM036253_d.JPG,0,test,41691,phyllis,41691_CAM036253_d.JPG,minor
+CAM036232,https://zenodo.org/record/5561246/files/CAM036232_d.JPG,0,test,41639,phyllis,41639_CAM036232_d.JPG,minor
+CAM036231,https://zenodo.org/record/5561246/files/CAM036231_d.JPG,0,test,41635,phyllis,41635_CAM036231_d.JPG,minor
+CAM036230,https://zenodo.org/record/5561246/files/CAM036230_d.JPG,0,test,41631,phyllis,41631_CAM036230_d.JPG,minor
+CAM036229,https://zenodo.org/record/5561246/files/CAM036229_d.JPG,0,test,41627,phyllis,41627_CAM036229_d.JPG,minor
+CAM036226,https://zenodo.org/record/5561246/files/CAM036226_d.JPG,0,test,41615,phyllis,41615_CAM036226_d.JPG,minor
+CAM036225,https://zenodo.org/record/5561246/files/CAM036225_d.JPG,0,test,41611,phyllis,41611_CAM036225_d.JPG,minor
+CAM036587,https://zenodo.org/record/5561246/files/CAM036587_d.JPG,0,test,42515,phyllis,42515_CAM036587_d.JPG,minor
+CAM017800,https://zenodo.org/record/1748277/files/CAM017800_v_whitestandard.JPG,0,test-2,16459,plesseni,16459_CAM017800_v_whitestandard.JPG,mimic
+CAM017908,https://zenodo.org/record/1748277/files/CAM017908_v_whitestandard.JPG,0,test-2,16887,malleti,16887_CAM017908_v_whitestandard.JPG,mimic
+CAM017449,https://zenodo.org/record/1748277/files/CAM017449_d_whitestandard.JPG,0,test-2,15259,malleti,15259_CAM017449_d_whitestandard.JPG,mimic
+CAM017453,https://zenodo.org/record/1748277/files/CAM017453_d_whitestandard.JPG,0,test-2,15275,plesseni,15275_CAM017453_d_whitestandard.JPG,mimic
+CAM017455,https://zenodo.org/record/1748277/files/CAM017455_d_whitestandard.JPG,0,test-2,15283,malleti,15283_CAM017455_d_whitestandard.JPG,mimic
+CAM017458,https://zenodo.org/record/1748277/files/CAM017458_d_whitestandard.JPG,0,test-2,15295,plesseni,15295_CAM017458_d_whitestandard.JPG,mimic
+CAM017704,https://zenodo.org/record/1748277/files/CAM017704_d_whitestandard.JPG,0,test-2,16079,plesseni,16079_CAM017704_d_whitestandard.JPG,mimic
+CAM018268,https://zenodo.org/record/2548678/files/CAM018268_v_whitestandard.JPG,0,test-2,17501,plesseni,17501_CAM018268_v_whitestandard.JPG,mimic
+CAM018282,https://zenodo.org/record/2548678/files/CAM018282_v_whitestandard.JPG,0,test-2,17557,malleti,17557_CAM018282_v_whitestandard.JPG,mimic
+CAM018353,https://zenodo.org/record/2548678/files/CAM018353_v_whitestandard.JPG,0,test-2,17829,malleti,17829_CAM018353_v_whitestandard.JPG,mimic
+CAM018339,https://zenodo.org/record/2548678/files/CAM018339_v_whitestandard.JPG,0,test-2,17773,plesseni,17773_CAM018339_v_whitestandard.JPG,mimic
+CAM018357,https://zenodo.org/record/2548678/files/CAM018357_v_whitestandard.JPG,1,test-2,17845,plesseni x malleti,17845_CAM018357_v_whitestandard.JPG,mimic
+CAM018438,https://zenodo.org/record/2548678/files/CAM018438_v_whitestandard.JPG,0,test-2,18165,malleti,18165_CAM018438_v_whitestandard.JPG,mimic
+CAM018447,https://zenodo.org/record/2548678/files/CAM018447_v_whitestandard.JPG,0,test-2,18201,plesseni,18201_CAM018447_v_whitestandard.JPG,mimic
+CAM018528,https://zenodo.org/record/2548678/files/CAM018528_v_whitestandard.JPG,0,test-2,18525,malleti,18525_CAM018528_v_whitestandard.JPG,mimic
+CAM010077,https://zenodo.org/record/2549524/files/CAM010077_d.JPG,0,test-2,26327,malleti,26327_CAM010077_d.JPG,mimic
+CAM010014,https://zenodo.org/record/2549524/files/CAM010014_d.JPG,0,test-2,26227,malleti,26227_CAM010014_d.JPG,mimic
+CAM010006,https://zenodo.org/record/2549524/files/CAM010006_d.JPG,0,test-2,26215,malleti,26215_CAM010006_d.JPG,mimic
+CAM010089,https://zenodo.org/record/2549524/files/CAM010089_d.JPG,0,test-2,26347,malleti,26347_CAM010089_d.JPG,mimic
+CAM011423,https://zenodo.org/record/2550097/files/CAM011423_d.JPG,0,test-2,28192,plesseni,28192_CAM011423_d.JPG,mimic
+CAM011411,https://zenodo.org/record/2550097/files/CAM011411_d.JPG,0,test-2,28144,plesseni,28144_CAM011411_d.JPG,mimic
+CAM011428,https://zenodo.org/record/2550097/files/CAM011428_d.JPG,0,test-2,28212,malleti,28212_CAM011428_d.JPG,mimic
+CAM011410,https://zenodo.org/record/2550097/files/CAM011410_d.JPG,0,test-2,28140,plesseni,28140_CAM011410_d.JPG,mimic
+CAM011438,https://zenodo.org/record/2550097/files/CAM011438_d.JPG,0,test-2,28244,plesseni,28244_CAM011438_d.JPG,mimic
+CAM011406,https://zenodo.org/record/2550097/files/CAM011406_d.JPG,0,test-2,28124,plesseni,28124_CAM011406_d.JPG,mimic
+CAM011296,https://zenodo.org/record/2550097/files/CAM011296_d.JPG,0,test-2,27822,malleti,27822_CAM011296_d.JPG,mimic
+CAM011443,https://zenodo.org/record/2550097/files/CAM011443_d.JPG,0,test-2,28264,plesseni,28264_CAM011443_d.JPG,mimic
+CAM011449,https://zenodo.org/record/2550097/files/CAM011449_d.JPG,0,test-2,28288,plesseni,28288_CAM011449_d.JPG,mimic
+CAM011444,https://zenodo.org/record/2550097/files/CAM011444_d.JPG,0,test-2,28268,malleti,28268_CAM011444_d.JPG,mimic
+CAM011447,https://zenodo.org/record/2550097/files/CAM011447_d.JPG,0,test-2,28280,malleti,28280_CAM011447_d.JPG,mimic
+CAM011456,https://zenodo.org/record/2550097/files/CAM011456_d.JPG,0,test-2,28316,plesseni,28316_CAM011456_d.JPG,mimic
+CAM010035,https://zenodo.org/record/2552371/files/10035d.jpg,0,test-2,23118,malleti,23118_10035d.jpg,mimic
+CAM011437,https://zenodo.org/record/2552371/files/11437d.jpg,0,test-2,24550,plesseni,24550_11437d.jpg,mimic
+CAM011440,https://zenodo.org/record/2552371/files/11440d.jpg,0,test-2,24552,plesseni,24552_11440d.jpg,mimic
+CAM011446,https://zenodo.org/record/2552371/files/11446d.jpg,0,test-2,24556,plesseni,24556_11446d.jpg,mimic
+CS003830,https://zenodo.org/record/2553501/files/CS3830 dorsal.jpeg,0,test-2,25987,malleti,25987_CS3830 dorsal.jpeg,mimic
+CS003815,https://zenodo.org/record/2553501/files/CS3815 dorsal.jpeg,0,test-2,25983,malleti,25983_CS3815 dorsal.jpeg,mimic
+CS003728,https://zenodo.org/record/2553501/files/CS3728 dorsal.jpeg,0,test-2,25967,malleti,25967_CS3728 dorsal.jpeg,mimic
+CS003730,https://zenodo.org/record/2553501/files/CS3730 dorsal.jpeg,0,test-2,25969,malleti,25969_CS3730 dorsal.jpeg,mimic
+CS003820,https://zenodo.org/record/2553501/files/CS3820 dorsal.jpeg,0,test-2,25985,malleti,25985_CS3820 dorsal.jpeg,mimic
+CS003709,https://zenodo.org/record/2553501/files/CS3709 dorsal.jpeg,0,test-2,25965,malleti,25965_CS3709 dorsal.jpeg,mimic
+CS003706,https://zenodo.org/record/2553501/files/CS3706 dorsal.jpeg,0,test-2,25963,malleti,25963_CS3706 dorsal.jpeg,mimic
+CS001011,https://zenodo.org/record/2553501/files/CS1011 dorsal.jpeg,0,test-2,25595,malleti,25595_CS1011 dorsal.jpeg,mimic
+CS001002,https://zenodo.org/record/2553501/files/CS1002 dorsal.jpeg,0,test-2,25591,malleti,25591_CS1002 dorsal.jpeg,mimic
+CS001286,https://zenodo.org/record/2553501/files/CS1286 dorsal.jpeg,0,test-2,25625,malleti,25625_CS1286 dorsal.jpeg,mimic
+CS000615,https://zenodo.org/record/2553501/files/CS615 dorsal.jpeg,0,test-2,26011,malleti,26011_CS615 dorsal.jpeg,mimic
+CS000594,https://zenodo.org/record/2553501/files/CS594 dorsal.jpeg,0,test-2,26007,malleti,26007_CS594 dorsal.jpeg,mimic
+CS000583,https://zenodo.org/record/2553501/files/CS583 dorsal.jpeg,0,test-2,26003,malleti,26003_CS583 dorsal.jpeg,mimic
+CS000470,https://zenodo.org/record/2553501/files/CS470 dorsal.jpeg,0,test-2,25997,malleti,25997_CS470 dorsal.jpeg,mimic
+CS000604,https://zenodo.org/record/2553501/files/CS604 dorsal.jpeg,0,test-2,26009,malleti,26009_CS604 dorsal.jpeg,mimic
+CS001321,https://zenodo.org/record/2553501/files/CS1321 dorsal.jpeg,0,test-2,25627,malleti,25627_CS1321 dorsal.jpeg,mimic
+CS000586,https://zenodo.org/record/2553501/files/CS586 dorsal.jpeg,0,test-2,26005,malleti,26005_CS586 dorsal.jpeg,mimic
+CS003544,https://zenodo.org/record/2553501/files/CS3544 dorsal.jpeg,0,test-2,25941,malleti,25941_CS3544 dorsal.jpeg,mimic
+CS003543,https://zenodo.org/record/2553501/files/CS3543 dorsal.jpeg,0,test-2,25939,malleti,25939_CS3543 dorsal.jpeg,mimic
+CS003542,https://zenodo.org/record/2553501/files/CS3542 dorsal.jpeg,0,test-2,25937,malleti,25937_CS3542 dorsal.jpeg,mimic
+CS003541,https://zenodo.org/record/2553501/files/CS3541 dorsal.jpeg,0,test-2,25935,malleti,25935_CS3541 dorsal.jpeg,mimic
+CS003447,https://zenodo.org/record/2553501/files/CS3447 dorsal.jpeg,0,test-2,25933,malleti,25933_CS3447 dorsal.jpeg,mimic
+CS003366,https://zenodo.org/record/2553501/files/CS3366 dorsal.jpeg,0,test-2,25901,malleti,25901_CS3366 dorsal.jpeg,mimic
+CS003109,https://zenodo.org/record/2553501/files/CS3109 dorsal.jpeg,0,test-2,25847,malleti,25847_CS3109 dorsal.jpeg,mimic
+CS002311,https://zenodo.org/record/2553501/files/CS2311 dorsal.jpeg,0,test-2,25701,malleti,25701_CS2311 dorsal.jpeg,mimic
+CS001815,https://zenodo.org/record/2553501/files/CS1815 dorsal.jpeg,0,test-2,25643,malleti,25643_CS1815 dorsal.jpeg,mimic
+CAM017162,https://zenodo.org/record/2553977/files/17162_H_melpomene_malleti_D.JPG.jpg,0,test-2,26053,malleti,26053_17162_H_melpomene_malleti_D.JPG.jpg,mimic
+CAM016293,https://zenodo.org/record/2553977/files/16293_H_melpomene_plesseni_D.JPG.jpg,0,test-2,26047,plesseni,26047_16293_H_melpomene_plesseni_D.JPG.jpg,mimic
+F875,https://zenodo.org/record/2555086/files/F875_d.JPG,0,test,38136,demophoon,38136_F875_d.JPG,minor
+F876,https://zenodo.org/record/2555086/files/F876_d.JPG,0,test,38140,demophoon,38140_F876_d.JPG,minor
+F880,https://zenodo.org/record/2555086/files/F880_d.JPG,0,test,38144,demophoon,38144_F880_d.JPG,minor
+F884,https://zenodo.org/record/2555086/files/F884_d.JPG,0,test,38148,demophoon,38148_F884_d.JPG,minor
+F868,https://zenodo.org/record/2555086/files/F868_d.JPG,0,test,38120,demophoon,38120_F868_d.JPG,minor
+F889,https://zenodo.org/record/2555086/files/F889_d.JPG,0,test,38152,demophoon,38152_F889_d.JPG,minor
+F895,https://zenodo.org/record/2555086/files/F895_d.JPG,0,test,38160,demophoon,38160_F895_d.JPG,minor
+F901,https://zenodo.org/record/2555086/files/F901_d.JPG,0,test,38168,demophoon,38168_F901_d.JPG,minor
+F902,https://zenodo.org/record/2555086/files/F902_d.JPG,0,test,38172,demophoon,38172_F902_d.JPG,minor
+F905,https://zenodo.org/record/2555086/files/F905_d.JPG,0,test,38176,demophoon,38176_F905_d.JPG,minor
+F906,https://zenodo.org/record/2555086/files/F906_d.JPG,0,test,38180,demophoon,38180_F906_d.JPG,minor
+F907,https://zenodo.org/record/2555086/files/F907_d.JPG,0,test,38184,demophoon,38184_F907_d.JPG,minor
+F794,https://zenodo.org/record/2555086/files/F794_d.JPG,0,test,38040,demophoon,38040_F794_d.JPG,minor
+F891,https://zenodo.org/record/2555086/files/F891_d.JPG,0,test,38156,demophoon,38156_F891_d.JPG,minor
+F867,https://zenodo.org/record/2555086/files/F867_d.JPG,0,test,38116,demophoon,38116_F867_d.JPG,minor
+F900,https://zenodo.org/record/2555086/files/F900_d.JPG,0,test,38164,demophoon,38164_F900_d.JPG,minor
+F865,https://zenodo.org/record/2555086/files/F865_d.JPG,0,test,38108,demophoon,38108_F865_d.JPG,minor
+CAM000057,https://zenodo.org/record/2677821/files/CAM000057_d.JPG,1,test,5949,chestertonii x venus,5949_CAM000057_d.JPG,minor
+CAM000171,https://zenodo.org/record/2677821/files/CAM000171_d.JPG,0,test,6174,chestertonii,6174_CAM000171_d.JPG,minor
+CAM000170,https://zenodo.org/record/2677821/files/CAM000170_d.JPG,0,test,6172,chestertonii,6172_CAM000170_d.JPG,minor
+CAM000169,https://zenodo.org/record/2677821/files/CAM000169_d.JPG,0,test,6170,chestertonii,6170_CAM000169_d.JPG,minor
+CAM000149,https://zenodo.org/record/2677821/files/CAM000149_d.JPG,0,test,6130,chestertonii,6130_CAM000149_d.JPG,minor
+CAM000148,https://zenodo.org/record/2677821/files/CAM000148_d.JPG,0,test,6128,chestertonii,6128_CAM000148_d.JPG,minor
+CAM000230,https://zenodo.org/record/2677821/files/CAM000230_d.JPG,0,test,6286,chestertonii,6286_CAM000230_d.JPG,minor
+CAM000231,https://zenodo.org/record/2677821/files/CAM000231_d.JPG,0,test,6288,chestertonii,6288_CAM000231_d.JPG,minor
+CAM000232,https://zenodo.org/record/2677821/files/CAM000232_d.JPG,0,test,6290,chestertonii,6290_CAM000232_d.JPG,minor
+CAM000233,https://zenodo.org/record/2677821/files/CAM000233_d.JPG,0,test,6292,chestertonii,6292_CAM000233_d.JPG,minor
+CAM000243,https://zenodo.org/record/2677821/files/CAM000243_d.JPG,0,test,6312,chestertonii,6312_CAM000243_d.JPG,minor
+CAM002903,https://zenodo.org/record/2684906/files/CAM002903_d.JPG,1,test,8491,hydara x petiverana,8491_CAM002903_d.JPG,minor
+CAM008158,https://zenodo.org/record/2684906/files/CAM008158_d.JPG,0,test-2,8762,malleti,8762_CAM008158_d.JPG,mimic
+CAM008226,https://zenodo.org/record/2684906/files/CAM008226_d.JPG,0,test-2,8895,malleti,8895_CAM008226_d.JPG,mimic
+CAM008163,https://zenodo.org/record/2684906/files/CAM008163_d.JPG,0,test-2,8772,malleti,8772_CAM008163_d.JPG,mimic
+CAM008160,https://zenodo.org/record/2684906/files/CAM008160_d.JPG,0,test-2,8766,malleti,8766_CAM008160_d.JPG,mimic
+CAM008159,https://zenodo.org/record/2684906/files/CAM008159_d.JPG,0,test-2,8764,malleti,8764_CAM008159_d.JPG,mimic
+CAM008161,https://zenodo.org/record/2684906/files/CAM008161_d.JPG,0,test-2,8768,malleti,8768_CAM008161_d.JPG,mimic
+CAM008546,https://zenodo.org/record/2684906/files/CAM008546_d.JPG,0,test-2,9444,plesseni,9444_CAM008546_d.JPG,mimic
+CAM008545,https://zenodo.org/record/2684906/files/CAM008545_d.JPG,0,test-2,9442,plesseni,9442_CAM008545_d.JPG,mimic
+CAM008544,https://zenodo.org/record/2684906/files/CAM008544_d.JPG,0,test-2,9440,plesseni,9440_CAM008544_d.JPG,mimic
+CAM008543,https://zenodo.org/record/2684906/files/CAM008543_d.JPG,0,test-2,9438,plesseni,9438_CAM008543_d.JPG,mimic
+CAM008539,https://zenodo.org/record/2684906/files/CAM008539_d.JPG,0,test-2,9432,plesseni,9432_CAM008539_d.JPG,mimic
+CAM008542,https://zenodo.org/record/2684906/files/CAM008542_d.JPG,0,test-2,9436,plesseni,9436_CAM008542_d.JPG,mimic
+CAM008244,https://zenodo.org/record/2684906/files/CAM008244_d.JPG,0,test-2,8923,malleti,8923_CAM008244_d.JPG,mimic
+CAM009424,https://zenodo.org/record/2686762/files/CAM009424_d.JPG,0,test-2,10646,plesseni,10646_CAM009424_d.JPG,mimic
+CAM009416,https://zenodo.org/record/2686762/files/CAM009416_d.JPG,0,test-2,10630,plesseni,10630_CAM009416_d.JPG,mimic
+CAM009417,https://zenodo.org/record/2686762/files/CAM009417_d.JPG,0,test-2,10632,plesseni,10632_CAM009417_d.JPG,mimic
+CAM009423,https://zenodo.org/record/2686762/files/CAM009423_d.JPG,0,test-2,10644,plesseni,10644_CAM009423_d.JPG,mimic
+CAM009429,https://zenodo.org/record/2686762/files/CAM009429_d.JPG,0,test-2,10656,plesseni,10656_CAM009429_d.JPG,mimic
+CAM009436,https://zenodo.org/record/2686762/files/CAM009436_d.JPG,0,test-2,10670,plesseni,10670_CAM009436_d.JPG,mimic
+CAM009437,https://zenodo.org/record/2686762/files/CAM009437_d.JPG,0,test-2,10672,plesseni,10672_CAM009437_d.JPG,mimic
+CAM009438,https://zenodo.org/record/2686762/files/CAM009438_d.JPG,0,test-2,10674,plesseni,10674_CAM009438_d.JPG,mimic
+CAM009439,https://zenodo.org/record/2686762/files/CAM009439_d.JPG,0,test-2,10676,plesseni,10676_CAM009439_d.JPG,mimic
+CAM009442,https://zenodo.org/record/2686762/files/CAM009442_d.JPG,0,test-2,10682,plesseni,10682_CAM009442_d.JPG,mimic
+CAM009500,https://zenodo.org/record/2686762/files/CAM009500_d.JPG,1,test,10742,hydara x petiverana,10742_CAM009500_d.JPG,minor
+CAM009407,https://zenodo.org/record/2686762/files/CAM009407_d.JPG,0,test-2,10612,malleti,10612_CAM009407_d.JPG,mimic
+CAM009544,https://zenodo.org/record/2686762/files/CAM009544_d.JPG,1,test,10830,hydara x petiverana,10830_CAM009544_d.JPG,minor
+CAM009504,https://zenodo.org/record/2686762/files/CAM009504_d.JPG,1,test,10750,hydara x petiverana,10750_CAM009504_d.JPG,minor
+CAM009546,https://zenodo.org/record/2686762/files/CAM009546_d.JPG,1,test,10834,hydara x petiverana,10834_CAM009546_d.JPG,minor
+CAM009549,https://zenodo.org/record/2686762/files/CAM009549_d.JPG,1,test,10840,hydara x petiverana,10840_CAM009549_d.JPG,minor
+CAM009551,https://zenodo.org/record/2686762/files/CAM009551_d.JPG,1,test,10844,hydara x petiverana,10844_CAM009551_d.JPG,minor
+CAM009552,https://zenodo.org/record/2686762/files/CAM009552_d.JPG,1,test,10846,hydara x petiverana,10846_CAM009552_d.JPG,minor
+CAM009524,https://zenodo.org/record/2686762/files/CAM009524_d.JPG,0,test,10790,petiverana,10790_CAM009524_d.JPG,minor
+CAM009525,https://zenodo.org/record/2686762/files/CAM009525_d.JPG,0,test,10792,petiverana,10792_CAM009525_d.JPG,minor
+CAM009206,https://zenodo.org/record/2686762/files/CAM009206_d.JPG,0,test-2,10381,plesseni,10381_CAM009206_d.JPG,mimic
+CAM009008,https://zenodo.org/record/2686762/files/CAM009008_d.JPG,0,test,10121,hydara,10121_CAM009008_d.JPG,minor
+CAM009007,https://zenodo.org/record/2686762/files/CAM009007_d.JPG,0,test,10119,hydara,10119_CAM009007_d.JPG,minor
+CAM009006,https://zenodo.org/record/2686762/files/CAM009006_d.JPG,0,test,10117,hydara,10117_CAM009006_d.JPG,minor
+CAM009004,https://zenodo.org/record/2686762/files/CAM009004_d.JPG,0,test,10113,hydara,10113_CAM009004_d.JPG,minor
+CAM009003,https://zenodo.org/record/2686762/files/CAM009003_d.JPG,0,test,10111,hydara,10111_CAM009003_d.JPG,minor
+CAM009002,https://zenodo.org/record/2686762/files/CAM009002_d.JPG,0,test,10109,hydara,10109_CAM009002_d.JPG,minor
+CAM009001,https://zenodo.org/record/2686762/files/CAM009001_d.JPG,0,test,10107,hydara,10107_CAM009001_d.JPG,minor
+CAM008999,https://zenodo.org/record/2686762/files/CAM008999_d.JPG,0,test,10103,hydara,10103_CAM008999_d.JPG,minor
+CAM008998,https://zenodo.org/record/2686762/files/CAM008998_d.JPG,0,test,10101,hydara,10101_CAM008998_d.JPG,minor
+CAM008997,https://zenodo.org/record/2686762/files/CAM008997_d.JPG,0,test,10099,hydara,10099_CAM008997_d.JPG,minor
+CAM008986,https://zenodo.org/record/2686762/files/CAM008986_d.JPG,0,test,10077,hydara,10077_CAM008986_d.JPG,minor
+CAM008985,https://zenodo.org/record/2686762/files/CAM008985_d.JPG,0,test,10075,hydara,10075_CAM008985_d.JPG,minor
+CAM009000,https://zenodo.org/record/2686762/files/CAM009000_d.JPG,0,test,10105,hydara,10105_CAM009000_d.JPG,minor
+CAM008867,https://zenodo.org/record/2686762/files/CAM008867_d.JPG,0,test,9955,hydara,9955_CAM008867_d.JPG,minor
+CAM008866,https://zenodo.org/record/2686762/files/CAM008866_d.JPG,0,test,9953,hydara,9953_CAM008866_d.JPG,minor
+CAM009332,https://zenodo.org/record/2686762/files/CAM009332_d.JPG,0,test,10516,hydara,10516_CAM009332_d.JPG,minor
+CAM008865,https://zenodo.org/record/2686762/files/CAM008865_d.JPG,0,test,9951,hydara,9951_CAM008865_d.JPG,minor
+CAM008864,https://zenodo.org/record/2686762/files/CAM008864_d.JPG,0,test,9949,hydara,9949_CAM008864_d.JPG,minor
+CAM008801,https://zenodo.org/record/2686762/files/CAM008801_d.JPG,0,test,9855,hydara,9855_CAM008801_d.JPG,minor
+CAM008961,https://zenodo.org/record/2686762/files/CAM008961_d.JPG,0,test,10027,hydara,10027_CAM008961_d.JPG,minor
+CAM009300,https://zenodo.org/record/2686762/files/CAM009300_d.JPG,0,test,10452,hydara,10452_CAM009300_d.JPG,minor
+CAM009237,https://zenodo.org/record/2686762/files/CAM009237_d.JPG,0,test-2,10442,plesseni,10442_CAM009237_d.JPG,mimic
+CAM009236,https://zenodo.org/record/2686762/files/CAM009236_d.JPG,0,test-2,10440,plesseni,10440_CAM009236_d.JPG,mimic
+CAM009235,https://zenodo.org/record/2686762/files/CAM009235_d.JPG,0,test-2,10438,plesseni,10438_CAM009235_d.JPG,mimic
+CAM009233,https://zenodo.org/record/2686762/files/CAM009233_d.JPG,0,test-2,10434,plesseni,10434_CAM009233_d.JPG,mimic
+CAM009232,https://zenodo.org/record/2686762/files/CAM009232_d.JPG,0,test-2,10432,plesseni,10432_CAM009232_d.JPG,mimic
+CAM009231,https://zenodo.org/record/2686762/files/CAM009231_d.JPG,0,test-2,10430,plesseni,10430_CAM009231_d.JPG,mimic
+CAM009230,https://zenodo.org/record/2686762/files/CAM009230_d.JPG,0,test-2,10428,plesseni,10428_CAM009230_d.JPG,mimic
+CAM009229,https://zenodo.org/record/2686762/files/CAM009229_d.JPG,0,test-2,10426,plesseni,10426_CAM009229_d.JPG,mimic
+CAM009234,https://zenodo.org/record/2686762/files/CAM009234_d.JPG,0,test-2,10436,plesseni,10436_CAM009234_d.JPG,mimic
+CAM009207,https://zenodo.org/record/2686762/files/CAM009207_d.JPG,0,test-2,10383,plesseni,10383_CAM009207_d.JPG,mimic
+CAM009205,https://zenodo.org/record/2686762/files/CAM009205_d.JPG,0,test-2,10379,plesseni,10379_CAM009205_d.JPG,mimic
+CAM009228,https://zenodo.org/record/2686762/files/CAM009228_d.JPG,0,test-2,10424,plesseni,10424_CAM009228_d.JPG,mimic
+CAM009203,https://zenodo.org/record/2686762/files/CAM009203_d.JPG,0,test-2,10375,plesseni,10375_CAM009203_d.JPG,mimic
+CAM009159,https://zenodo.org/record/2686762/files/CAM009159_d.JPG,0,test-2,10287,plesseni,10287_CAM009159_d.JPG,mimic
+CAM009204,https://zenodo.org/record/2686762/files/CAM009204_d.JPG,0,test-2,10377,plesseni,10377_CAM009204_d.JPG,mimic
+CAM009157,https://zenodo.org/record/2686762/files/CAM009157_d.JPG,0,test-2,10283,plesseni,10283_CAM009157_d.JPG,mimic
+CAM009156,https://zenodo.org/record/2686762/files/CAM009156_d.JPG,0,test-2,10281,plesseni,10281_CAM009156_d.JPG,mimic
+CAM009126,https://zenodo.org/record/2686762/files/CAM009126_d.JPG,0,test,10221,etylus,10221_CAM009126_d.JPG,minor
+CAM009160,https://zenodo.org/record/2686762/files/CAM009160_d.JPG,0,test-2,10289,plesseni,10289_CAM009160_d.JPG,mimic
+CAM009161,https://zenodo.org/record/2686762/files/CAM009161_d.JPG,0,test-2,10291,plesseni,10291_CAM009161_d.JPG,mimic
+CAM009158,https://zenodo.org/record/2686762/files/CAM009158_d.JPG,0,test-2,10285,plesseni,10285_CAM009158_d.JPG,mimic
+CAM009194,https://zenodo.org/record/2686762/files/CAM009194_d.JPG,0,test-2,10357,plesseni,10357_CAM009194_d.JPG,mimic
+CAM009197,https://zenodo.org/record/2686762/files/CAM009197_d.JPG,0,test-2,10363,plesseni,10363_CAM009197_d.JPG,mimic
+CAM009198,https://zenodo.org/record/2686762/files/CAM009198_d.JPG,0,test-2,10365,plesseni,10365_CAM009198_d.JPG,mimic
+CAM009193,https://zenodo.org/record/2686762/files/CAM009193_d.JPG,0,test-2,10355,plesseni,10355_CAM009193_d.JPG,mimic
+CAM009199,https://zenodo.org/record/2686762/files/CAM009199_d.JPG,0,test-2,10367,plesseni,10367_CAM009199_d.JPG,mimic
+CAM009192,https://zenodo.org/record/2686762/files/CAM009192_d.JPG,0,test-2,10353,plesseni,10353_CAM009192_d.JPG,mimic
+CAM009191,https://zenodo.org/record/2686762/files/CAM009191_d.JPG,0,test-2,10351,plesseni,10351_CAM009191_d.JPG,mimic
+CAM009195,https://zenodo.org/record/2686762/files/CAM009195_d.JPG,0,test-2,10359,plesseni,10359_CAM009195_d.JPG,mimic
+CAM009200,https://zenodo.org/record/2686762/files/CAM009200_d.JPG,0,test-2,10369,plesseni,10369_CAM009200_d.JPG,mimic
+CAM009201,https://zenodo.org/record/2686762/files/CAM009201_d.JPG,0,test-2,10371,plesseni,10371_CAM009201_d.JPG,mimic
+CAM009202,https://zenodo.org/record/2686762/files/CAM009202_d.JPG,0,test-2,10373,plesseni,10373_CAM009202_d.JPG,mimic
+CAM009189,https://zenodo.org/record/2686762/files/CAM009189_d.JPG,0,test-2,10347,plesseni,10347_CAM009189_d.JPG,mimic
+CAM009188,https://zenodo.org/record/2686762/files/CAM009188_d.JPG,0,test-2,10345,plesseni,10345_CAM009188_d.JPG,mimic
+CAM009190,https://zenodo.org/record/2686762/files/CAM009190_d.JPG,0,test-2,10349,plesseni,10349_CAM009190_d.JPG,mimic
+CAM009196,https://zenodo.org/record/2686762/files/CAM009196_d.JPG,0,test-2,10361,plesseni,10361_CAM009196_d.JPG,mimic
+CAM018530,https://zenodo.org/record/2702457/files/CAM018530_d.JPG,1,test-2,11391,malleti x plesseni,11391_CAM018530_d.JPG,mimic
+CAM018532,https://zenodo.org/record/2702457/files/CAM018532_d.JPG,1,test-2,11393,plesseni x malleti,11393_CAM018532_d.JPG,mimic
+CAM017998,https://zenodo.org/record/2702457/files/CAM017998_d.JPG,1,test-2,10916,plesseni x malleti,10916_CAM017998_d.JPG,mimic
+CAM018529,https://zenodo.org/record/2702457/files/CAM018529_d.JPG,1,test-2,11389,malleti x plesseni,11389_CAM018529_d.JPG,mimic
+CAM018517,https://zenodo.org/record/2702457/files/CAM018517_d.JPG,1,test-2,11369,plesseni x malleti,11369_CAM018517_d.JPG,mimic
+CAM018518,https://zenodo.org/record/2702457/files/CAM018518_d.JPG,1,test-2,11371,malleti x plesseni,11371_CAM018518_d.JPG,mimic
+CAM018519,https://zenodo.org/record/2702457/files/CAM018519_d.JPG,1,test-2,11373,plesseni x malleti,11373_CAM018519_d.JPG,mimic
+CAM018520,https://zenodo.org/record/2702457/files/CAM018520_d.JPG,1,test-2,11375,malleti x plesseni,11375_CAM018520_d.JPG,mimic
+CAM021060,https://zenodo.org/record/2702457/files/CAM021060_d.JPG,0,test,11549,erato,11549_CAM021060_d.JPG,minor
+CAM021062,https://zenodo.org/record/2702457/files/CAM021062_d.JPG,0,test,11553,erato,11553_CAM021062_d.JPG,minor
+CAM021077,https://zenodo.org/record/2702457/files/CAM021077_d.JPG,0,test,11581,erato,11581_CAM021077_d.JPG,minor
+CAM021073,https://zenodo.org/record/2702457/files/CAM021073_d.JPG,0,test,11575,erato,11575_CAM021073_d.JPG,minor
+CAM021068,https://zenodo.org/record/2702457/files/CAM021068_d.JPG,0,test,11565,erato,11565_CAM021068_d.JPG,minor
+CAM021054,https://zenodo.org/record/2702457/files/CAM021054_d.JPG,1,test,11540,hydara x erato,11540_CAM021054_d.JPG,minor
+CAM021021,https://zenodo.org/record/2702457/files/CAM021021_d.JPG,0,test,11480,amalfreda,11480_CAM021021_d.JPG,minor
+CAM021022,https://zenodo.org/record/2702457/files/CAM021022_d.JPG,0,test,11482,amalfreda,11482_CAM021022_d.JPG,minor
+CAM021023,https://zenodo.org/record/2702457/files/CAM021023_d.JPG,0,test,11484,amalfreda,11484_CAM021023_d.JPG,minor
+CAM021025,https://zenodo.org/record/2702457/files/CAM021025_d.JPG,0,test,11488,amalfreda,11488_CAM021025_d.JPG,minor
+CAM021028,https://zenodo.org/record/2702457/files/CAM021028_d.JPG,1,test,11490,hydara x amalfreda,11490_CAM021028_d.JPG,minor
+CAM021029,https://zenodo.org/record/2702457/files/CAM021029_d.JPG,1,test,11492,hydara x amalfreda,11492_CAM021029_d.JPG,minor
+CAM021030,https://zenodo.org/record/2702457/files/CAM021030_d.JPG,1,test,11494,hydara x amalfreda,11494_CAM021030_d.JPG,minor
+CAM021031,https://zenodo.org/record/2702457/files/CAM021031_d.JPG,1,test,11496,hydara x amalfreda,11496_CAM021031_d.JPG,minor
+CAM018315,https://zenodo.org/record/2702457/files/CAM018315_d.JPG,1,test-2,11060,plesseni x malleti,11060_CAM018315_d.JPG,mimic
+CAM018309,https://zenodo.org/record/2702457/files/CAM018309_d.JPG,1,test-2,11052,plesseni x malleti,11052_CAM018309_d.JPG,mimic
+CAM018405,https://zenodo.org/record/2702457/files/CAM018405_d.JPG,1,test-2,11174,plesseni x malleti,11174_CAM018405_d.JPG,mimic
+CAM018360,https://zenodo.org/record/2702457/files/CAM018360_d.JPG,1,test-2,11127,plesseni x malleti,11127_CAM018360_d.JPG,mimic
+CAM018361,https://zenodo.org/record/2702457/files/CAM018361_d.JPG,1,test-2,11128,plesseni x malleti,11128_CAM018361_d.JPG,mimic
+CAM018365,https://zenodo.org/record/2702457/files/CAM018365_d.JPG,1,test-2,11130,malleti x plesseni,11130_CAM018365_d.JPG,mimic
+CAM018391,https://zenodo.org/record/2702457/files/CAM018391_d.JPG,1,test-2,11156,malleti x plesseni,11156_CAM018391_d.JPG,mimic
+CAM018401,https://zenodo.org/record/2702457/files/CAM018401_d.JPG,1,test-2,11166,plesseni x malleti,11166_CAM018401_d.JPG,mimic
+CAM018402,https://zenodo.org/record/2702457/files/CAM018402_d.JPG,1,test-2,11168,plesseni x malleti,11168_CAM018402_d.JPG,mimic
+CAM018403,https://zenodo.org/record/2702457/files/CAM018403_d.JPG,1,test-2,11170,plesseni x malleti,11170_CAM018403_d.JPG,mimic
+CAM018404,https://zenodo.org/record/2702457/files/CAM018404_d.JPG,1,test-2,11172,plesseni x malleti,11172_CAM018404_d.JPG,mimic
+CAM018338,https://zenodo.org/record/2702457/files/CAM018338_d.JPG,1,test-2,11096,malleti x plesseni,11096_CAM018338_d.JPG,mimic
+CAM018466,https://zenodo.org/record/2702457/files/CAM018466_d.JPG,1,test-2,11274,plesseni x malleti,11274_CAM018466_d.JPG,mimic
+CAM018259,https://zenodo.org/record/2702457/files/CAM018259_d.JPG,1,test-2,10990,plesseni x malleti,10990_CAM018259_d.JPG,mimic
+CAM018258,https://zenodo.org/record/2702457/files/CAM018258_d.JPG,1,test-2,10988,plesseni x malleti,10988_CAM018258_d.JPG,mimic
+CAM018482,https://zenodo.org/record/2702457/files/CAM018482_d.JPG,1,test-2,11305,plesseni x malleti,11305_CAM018482_d.JPG,mimic
+CAM018257,https://zenodo.org/record/2702457/files/CAM018257_d.JPG,1,test-2,10986,plesseni x malleti,10986_CAM018257_d.JPG,mimic
+CAM018256,https://zenodo.org/record/2702457/files/CAM018256_d.JPG,1,test-2,10984,plesseni x malleti,10984_CAM018256_d.JPG,mimic
+CAM018250,https://zenodo.org/record/2702457/files/CAM018250_d.JPG,1,test-2,10974,plesseni x malleti,10974_CAM018250_d.JPG,mimic
+CAM018296,https://zenodo.org/record/2702457/files/CAM018296_d.JPG,1,test-2,11034,malleti x plesseni,11034_CAM018296_d.JPG,mimic
+CAM018295,https://zenodo.org/record/2702457/files/CAM018295_d.JPG,1,test-2,11032,plesseni x malleti,11032_CAM018295_d.JPG,mimic
+CAM018294,https://zenodo.org/record/2702457/files/CAM018294_d.JPG,1,test-2,11030,plesseni x malleti,11030_CAM018294_d.JPG,mimic
+CAM018285,https://zenodo.org/record/2702457/files/CAM018285_d.JPG,1,test-2,11022,plesseni x malleti,11022_CAM018285_d.JPG,mimic
+CAM018281,https://zenodo.org/record/2702457/files/CAM018281_d.JPG,1,test-2,11018,plesseni x malleti,11018_CAM018281_d.JPG,mimic
+CAM040293,https://zenodo.org/record/2707828/files/CAM040293_d.JPG,0,test-2,12202,malleti,12202_CAM040293_d.JPG,mimic
+CAM040440,https://zenodo.org/record/2707828/files/CAM040440_d.JPG,0,test-2,12492,malleti,12492_CAM040440_d.JPG,mimic
+CAM040129,https://zenodo.org/record/2707828/files/CAM040129_d.JPG,0,test-2,11898,malleti,11898_CAM040129_d.JPG,mimic
+CAM040150,https://zenodo.org/record/2707828/files/CAM040150_d.JPG,0,test-2,11936,malleti,11936_CAM040150_d.JPG,mimic
+CAM040149,https://zenodo.org/record/2707828/files/CAM040149_d.JPG,0,test-2,11934,malleti,11934_CAM040149_d.JPG,mimic
+CAM040038,https://zenodo.org/record/2707828/files/CAM040038_d.JPG,0,test,11756,dignus,11756_CAM040038_d.JPG,minor
+CAM040023,https://zenodo.org/record/2707828/files/CAM040023_d.JPG,0,test-2,11730,malleti,11730_CAM040023_d.JPG,mimic
+CAM040022,https://zenodo.org/record/2707828/files/CAM040022_d.JPG,0,test-2,11728,malleti,11728_CAM040022_d.JPG,mimic
+CAM040021,https://zenodo.org/record/2707828/files/CAM040021_d.JPG,0,test-2,11726,malleti,11726_CAM040021_d.JPG,mimic
+CAM040020,https://zenodo.org/record/2707828/files/CAM040020_d.JPG,0,test-2,11724,malleti,11724_CAM040020_d.JPG,mimic
+CAM040019,https://zenodo.org/record/2707828/files/CAM040019_d.JPG,0,test-2,11722,malleti,11722_CAM040019_d.JPG,mimic
+CAM040018,https://zenodo.org/record/2707828/files/CAM040018_d.JPG,0,test,11720,dignus,11720_CAM040018_d.JPG,minor
+CAM040017,https://zenodo.org/record/2707828/files/CAM040017_d.JPG,0,test,11718,dignus,11718_CAM040017_d.JPG,minor
+CAM040294,https://zenodo.org/record/2707828/files/CAM040294_d.JPG,0,test-2,12204,malleti,12204_CAM040294_d.JPG,mimic
+CAM040292,https://zenodo.org/record/2707828/files/CAM040292_d.JPG,0,test-2,12200,malleti,12200_CAM040292_d.JPG,mimic
+CAM040291,https://zenodo.org/record/2707828/files/CAM040291_d.JPG,0,test-2,12198,malleti,12198_CAM040291_d.JPG,mimic
+CAM040290,https://zenodo.org/record/2707828/files/CAM040290_d.JPG,0,test-2,12196,malleti,12196_CAM040290_d.JPG,mimic
+CAM040289,https://zenodo.org/record/2707828/files/CAM040289_d.JPG,0,test-2,12194,malleti,12194_CAM040289_d.JPG,mimic
+CAM040288,https://zenodo.org/record/2707828/files/CAM040288_d.JPG,0,test-2,12192,malleti,12192_CAM040288_d.JPG,mimic
+CAM040287,https://zenodo.org/record/2707828/files/CAM040287_d.JPG,0,test-2,12190,malleti,12190_CAM040287_d.JPG,mimic
+CAM040286,https://zenodo.org/record/2707828/files/CAM040286_d.JPG,0,test-2,12188,malleti,12188_CAM040286_d.JPG,mimic
+CAM040285,https://zenodo.org/record/2707828/files/CAM040285_d.JPG,0,test-2,12186,malleti,12186_CAM040285_d.JPG,mimic
+CAM040284,https://zenodo.org/record/2707828/files/CAM040284_d.JPG,0,test-2,12184,malleti,12184_CAM040284_d.JPG,mimic
+CAM040283,https://zenodo.org/record/2707828/files/CAM040283_d.JPG,0,test-2,12182,malleti,12182_CAM040283_d.JPG,mimic
+CAM040282,https://zenodo.org/record/2707828/files/CAM040282_d.JPG,0,test-2,12180,malleti,12180_CAM040282_d.JPG,mimic
+CAM040281,https://zenodo.org/record/2707828/files/CAM040281_d.JPG,0,test-2,12178,malleti,12178_CAM040281_d.JPG,mimic
+CAM040269,https://zenodo.org/record/2707828/files/CAM040269_d.JPG,0,test-2,12154,malleti,12154_CAM040269_d.JPG,mimic
+CAM040268,https://zenodo.org/record/2707828/files/CAM040268_d.JPG,0,test-2,12152,malleti,12152_CAM040268_d.JPG,mimic
+CAM040267,https://zenodo.org/record/2707828/files/CAM040267_d.JPG,0,test-2,12150,malleti,12150_CAM040267_d.JPG,mimic
+CAM040266,https://zenodo.org/record/2707828/files/CAM040266_d.JPG,0,test-2,12148,malleti,12148_CAM040266_d.JPG,mimic
+CAM040265,https://zenodo.org/record/2707828/files/CAM040265_d.JPG,0,test-2,12146,malleti,12146_CAM040265_d.JPG,mimic
+CAM040264,https://zenodo.org/record/2707828/files/CAM040264_d.JPG,0,test-2,12144,malleti,12144_CAM040264_d.JPG,mimic
+CAM040263,https://zenodo.org/record/2707828/files/CAM040263_d.JPG,0,test-2,12142,malleti,12142_CAM040263_d.JPG,mimic
+CAM040262,https://zenodo.org/record/2707828/files/CAM040262_d.JPG,0,test-2,12140,malleti,12140_CAM040262_d.JPG,mimic
+CAM040261,https://zenodo.org/record/2707828/files/CAM040261_d.JPG,0,test-2,12138,malleti,12138_CAM040261_d.JPG,mimic
+CAM040260,https://zenodo.org/record/2707828/files/CAM040260_d.JPG,0,test-2,12136,malleti,12136_CAM040260_d.JPG,mimic
+CAM040295,https://zenodo.org/record/2707828/files/CAM040295_d.JPG,0,test-2,12206,malleti,12206_CAM040295_d.JPG,mimic
+CAM040259,https://zenodo.org/record/2707828/files/CAM040259_d.JPG,0,test-2,12134,malleti,12134_CAM040259_d.JPG,mimic
+CAM040296,https://zenodo.org/record/2707828/files/CAM040296_d.JPG,0,test-2,12208,malleti,12208_CAM040296_d.JPG,mimic
+CAM040298,https://zenodo.org/record/2707828/files/CAM040298_d.JPG,0,test-2,12212,malleti,12212_CAM040298_d.JPG,mimic
+CAM040297,https://zenodo.org/record/2707828/files/CAM040297_d.JPG,0,test-2,12210,malleti,12210_CAM040297_d.JPG,mimic
+CAM040258,https://zenodo.org/record/2707828/files/CAM040258_d.JPG,0,test-2,12132,malleti,12132_CAM040258_d.JPG,mimic
+CAM040256,https://zenodo.org/record/2707828/files/CAM040256_d.JPG,0,test-2,12128,malleti,12128_CAM040256_d.JPG,mimic
+CAM040198,https://zenodo.org/record/2707828/files/CAM040198_d.JPG,0,test-2,12022,malleti,12022_CAM040198_d.JPG,mimic
+CAM040197,https://zenodo.org/record/2707828/files/CAM040197_d.JPG,0,test-2,12020,malleti,12020_CAM040197_d.JPG,mimic
+CAM040192,https://zenodo.org/record/2707828/files/CAM040192_d.JPG,0,test-2,12012,malleti,12012_CAM040192_d.JPG,mimic
+CAM040190,https://zenodo.org/record/2707828/files/CAM040190_d.JPG,0,test-2,12008,malleti,12008_CAM040190_d.JPG,mimic
+CAM040183,https://zenodo.org/record/2707828/files/CAM040183_d.JPG,0,test-2,11994,malleti,11994_CAM040183_d.JPG,mimic
+CAM040181,https://zenodo.org/record/2707828/files/CAM040181_d.JPG,0,test-2,11992,malleti,11992_CAM040181_d.JPG,mimic
+CAM040180,https://zenodo.org/record/2707828/files/CAM040180_d.JPG,0,test-2,11990,malleti,11990_CAM040180_d.JPG,mimic
+CAM040172,https://zenodo.org/record/2707828/files/CAM040172_d.JPG,0,test-2,11974,malleti,11974_CAM040172_d.JPG,mimic
+CAM040171,https://zenodo.org/record/2707828/files/CAM040171_d.JPG,0,test-2,11972,malleti,11972_CAM040171_d.JPG,mimic
+CAM040257,https://zenodo.org/record/2707828/files/CAM040257_d.JPG,0,test-2,12130,malleti,12130_CAM040257_d.JPG,mimic
+CAM040201,https://zenodo.org/record/2707828/files/CAM040201_d.JPG,0,test-2,12028,malleti,12028_CAM040201_d.JPG,mimic
+CAM040210,https://zenodo.org/record/2707828/files/CAM040210_d.JPG,0,test-2,12044,malleti,12044_CAM040210_d.JPG,mimic
+CAM040240,https://zenodo.org/record/2707828/files/CAM040240_d.JPG,0,test-2,12096,malleti,12096_CAM040240_d.JPG,mimic
+CAM040255,https://zenodo.org/record/2707828/files/CAM040255_d.JPG,0,test-2,12126,malleti,12126_CAM040255_d.JPG,mimic
+CAM040253,https://zenodo.org/record/2707828/files/CAM040253_d.JPG,0,test-2,12122,malleti,12122_CAM040253_d.JPG,mimic
+CAM040245,https://zenodo.org/record/2707828/files/CAM040245_d.JPG,0,test-2,12106,malleti,12106_CAM040245_d.JPG,mimic
+CAM040238,https://zenodo.org/record/2707828/files/CAM040238_d.JPG,0,test-2,12092,malleti,12092_CAM040238_d.JPG,mimic
+CAM040237,https://zenodo.org/record/2707828/files/CAM040237_d.JPG,0,test-2,12090,malleti,12090_CAM040237_d.JPG,mimic
+CAM040235,https://zenodo.org/record/2707828/files/CAM040235_d.JPG,0,test-2,12086,malleti,12086_CAM040235_d.JPG,mimic
+CAM040254,https://zenodo.org/record/2707828/files/CAM040254_d.JPG,0,test-2,12124,malleti,12124_CAM040254_d.JPG,mimic
+CAM040222,https://zenodo.org/record/2707828/files/CAM040222_d.JPG,0,test-2,12064,malleti,12064_CAM040222_d.JPG,mimic
+CAM041061,https://zenodo.org/record/2714333/files/CAM041061_d.JPG,0,test-2,13761,malleti,13761_CAM041061_d.JPG,mimic
+CAM041093,https://zenodo.org/record/2714333/files/CAM041093_d.JPG,0,test-2,13824,malleti,13824_CAM041093_d.JPG,mimic
+CAM041091,https://zenodo.org/record/2714333/files/CAM041091_d.JPG,0,test-2,13820,malleti,13820_CAM041091_d.JPG,mimic
+CAM041100,https://zenodo.org/record/2714333/files/CAM041100_d.JPG,0,test-2,13838,malleti,13838_CAM041100_d.JPG,mimic
+CAM041067,https://zenodo.org/record/2714333/files/CAM041067_d.JPG,0,test-2,13773,malleti,13773_CAM041067_d.JPG,mimic
+CAM041065,https://zenodo.org/record/2714333/files/CAM041065_d.JPG,0,test-2,13769,malleti,13769_CAM041065_d.JPG,mimic
+CAM041064,https://zenodo.org/record/2714333/files/CAM041064_d.JPG,0,test-2,13767,malleti,13767_CAM041064_d.JPG,mimic
+CAM041063,https://zenodo.org/record/2714333/files/CAM041063_d.JPG,0,test-2,13765,malleti,13765_CAM041063_d.JPG,mimic
+CAM041101,https://zenodo.org/record/2714333/files/CAM041101_d.JPG,0,test-2,13840,malleti,13840_CAM041101_d.JPG,mimic
+CAM041138,https://zenodo.org/record/2714333/files/CAM041138_d.JPG,0,test-2,13914,malleti,13914_CAM041138_d.JPG,mimic
+CAM041121,https://zenodo.org/record/2714333/files/CAM041121_d.JPG,0,test-2,13880,malleti,13880_CAM041121_d.JPG,mimic
+CAM041062,https://zenodo.org/record/2714333/files/CAM041062_d.JPG,0,test-2,13763,malleti,13763_CAM041062_d.JPG,mimic
+CAM041060,https://zenodo.org/record/2714333/files/CAM041060_d.JPG,0,test-2,13759,malleti,13759_CAM041060_d.JPG,mimic
+CAM041053,https://zenodo.org/record/2714333/files/CAM041053_d.JPG,0,test-2,13745,malleti,13745_CAM041053_d.JPG,mimic
+CAM041013,https://zenodo.org/record/2714333/files/CAM041013_d.JPG,0,test-2,13665,malleti,13665_CAM041013_d.JPG,mimic
+CAM040999,https://zenodo.org/record/2714333/files/CAM040999_d.JPG,0,test-2,13637,malleti,13637_CAM040999_d.JPG,mimic
+CAM040992,https://zenodo.org/record/2714333/files/CAM040992_d.JPG,0,test-2,13623,malleti,13623_CAM040992_d.JPG,mimic
+CAM041000,https://zenodo.org/record/2714333/files/CAM041000_d.JPG,0,test-2,13639,malleti,13639_CAM041000_d.JPG,mimic
+CAM041052,https://zenodo.org/record/2714333/files/CAM041052_d.JPG,0,test-2,13743,malleti,13743_CAM041052_d.JPG,mimic
+CAM041051,https://zenodo.org/record/2714333/files/CAM041051_d.JPG,0,test-2,13741,malleti,13741_CAM041051_d.JPG,mimic
+CAM041048,https://zenodo.org/record/2714333/files/CAM041048_d.JPG,0,test-2,13735,malleti,13735_CAM041048_d.JPG,mimic
+CAM041046,https://zenodo.org/record/2714333/files/CAM041046_d.JPG,0,test-2,13731,malleti,13731_CAM041046_d.JPG,mimic
+CAM041038,https://zenodo.org/record/2714333/files/CAM041038_d.JPG,0,test-2,13715,malleti,13715_CAM041038_d.JPG,mimic
+CAM041036,https://zenodo.org/record/2714333/files/CAM041036_d.JPG,0,test-2,13711,malleti,13711_CAM041036_d.JPG,mimic
+CAM041035,https://zenodo.org/record/2714333/files/CAM041035_d.JPG,0,test-2,13709,malleti,13709_CAM041035_d.JPG,mimic
+CAM041027,https://zenodo.org/record/2714333/files/CAM041027_d.JPG,0,test-2,13693,malleti,13693_CAM041027_d.JPG,mimic
+CAM041021,https://zenodo.org/record/2714333/files/CAM041021_d.JPG,0,test-2,13681,malleti,13681_CAM041021_d.JPG,mimic
+CAM041191,https://zenodo.org/record/2714333/files/CAM041191_d.JPG,0,test-2,14019,malleti,14019_CAM041191_d.JPG,mimic
+CAM041187,https://zenodo.org/record/2714333/files/CAM041187_d.JPG,0,test-2,14011,malleti,14011_CAM041187_d.JPG,mimic
+CAM041186,https://zenodo.org/record/2714333/files/CAM041186_d.JPG,0,test-2,14009,malleti,14009_CAM041186_d.JPG,mimic
+CAM041185,https://zenodo.org/record/2714333/files/CAM041185_d.JPG,0,test-2,14007,malleti,14007_CAM041185_d.JPG,mimic
+CAM041184,https://zenodo.org/record/2714333/files/CAM041184_d.JPG,0,test-2,14005,malleti,14005_CAM041184_d.JPG,mimic
+CAM041183,https://zenodo.org/record/2714333/files/CAM041183_d.JPG,0,test-2,14003,malleti,14003_CAM041183_d.JPG,mimic
+CAM041182,https://zenodo.org/record/2714333/files/CAM041182_d.JPG,0,test-2,14001,malleti,14001_CAM041182_d.JPG,mimic
+CAM041181,https://zenodo.org/record/2714333/files/CAM041181_d.JPG,0,test-2,13999,malleti,13999_CAM041181_d.JPG,mimic
+CAM041180,https://zenodo.org/record/2714333/files/CAM041180_d.JPG,0,test-2,13997,malleti,13997_CAM041180_d.JPG,mimic
+CAM041179,https://zenodo.org/record/2714333/files/CAM041179_d.JPG,0,test-2,13995,malleti,13995_CAM041179_d.JPG,mimic
+CAM041159,https://zenodo.org/record/2714333/files/CAM041159_d.JPG,0,test-2,13955,malleti,13955_CAM041159_d.JPG,mimic
+CAM041200,https://zenodo.org/record/2714333/files/CAM041200_d.JPG,0,test-2,14037,malleti,14037_CAM041200_d.JPG,mimic
+CAM041168,https://zenodo.org/record/2714333/files/CAM041168_d.JPG,0,test-2,13973,malleti,13973_CAM041168_d.JPG,mimic
+CAM041174,https://zenodo.org/record/2714333/files/CAM041174_d.JPG,0,test-2,13985,malleti,13985_CAM041174_d.JPG,mimic
+CAM041176,https://zenodo.org/record/2714333/files/CAM041176_d.JPG,0,test-2,13989,malleti,13989_CAM041176_d.JPG,mimic
+CAM041177,https://zenodo.org/record/2714333/files/CAM041177_d.JPG,0,test-2,13991,malleti,13991_CAM041177_d.JPG,mimic
+CAM041178,https://zenodo.org/record/2714333/files/CAM041178_d.JPG,0,test-2,13993,malleti,13993_CAM041178_d.JPG,mimic
+CAM041201,https://zenodo.org/record/2714333/files/CAM041201_d.JPG,0,test-2,14039,malleti,14039_CAM041201_d.JPG,mimic
+CAM041202,https://zenodo.org/record/2714333/files/CAM041202_d.JPG,0,test-2,14041,malleti,14041_CAM041202_d.JPG,mimic
+CAM041203,https://zenodo.org/record/2714333/files/CAM041203_d.JPG,0,test-2,14043,malleti,14043_CAM041203_d.JPG,mimic
+CAM041221,https://zenodo.org/record/2714333/files/CAM041221_d.JPG,0,test-2,14079,malleti,14079_CAM041221_d.JPG,mimic
+CAM041222,https://zenodo.org/record/2714333/files/CAM041222_d.JPG,0,test-2,14081,malleti,14081_CAM041222_d.JPG,mimic
+CAM041223,https://zenodo.org/record/2714333/files/CAM041223_d.JPG,0,test-2,14083,malleti,14083_CAM041223_d.JPG,mimic
+CAM041224,https://zenodo.org/record/2714333/files/CAM041224_d.JPG,0,test-2,14085,malleti,14085_CAM041224_d.JPG,mimic
+CAM041220,https://zenodo.org/record/2714333/files/CAM041220_d.JPG,0,test-2,14077,malleti,14077_CAM041220_d.JPG,mimic
+CAM041218,https://zenodo.org/record/2714333/files/CAM041218_d.JPG,0,test-2,14073,malleti,14073_CAM041218_d.JPG,mimic
+CAM041204,https://zenodo.org/record/2714333/files/CAM041204_d.JPG,0,test-2,14045,malleti,14045_CAM041204_d.JPG,mimic
+CAM041205,https://zenodo.org/record/2714333/files/CAM041205_d.JPG,0,test-2,14047,malleti,14047_CAM041205_d.JPG,mimic
+CAM041206,https://zenodo.org/record/2714333/files/CAM041206_d.JPG,0,test-2,14049,malleti,14049_CAM041206_d.JPG,mimic
+CAM041207,https://zenodo.org/record/2714333/files/CAM041207_d.JPG,0,test-2,14051,malleti,14051_CAM041207_d.JPG,mimic
+CAM041208,https://zenodo.org/record/2714333/files/CAM041208_d.JPG,0,test-2,14053,malleti,14053_CAM041208_d.JPG,mimic
+CAM041209,https://zenodo.org/record/2714333/files/CAM041209_d.JPG,0,test-2,14055,malleti,14055_CAM041209_d.JPG,mimic
+CAM041219,https://zenodo.org/record/2714333/files/CAM041219_d.JPG,0,test-2,14075,malleti,14075_CAM041219_d.JPG,mimic
+CAM041210,https://zenodo.org/record/2714333/files/CAM041210_d.JPG,0,test-2,14057,malleti,14057_CAM041210_d.JPG,mimic
+CAM041212,https://zenodo.org/record/2714333/files/CAM041212_d.JPG,0,test-2,14061,malleti,14061_CAM041212_d.JPG,mimic
+CAM041213,https://zenodo.org/record/2714333/files/CAM041213_d.JPG,0,test-2,14063,malleti,14063_CAM041213_d.JPG,mimic
+CAM041214,https://zenodo.org/record/2714333/files/CAM041214_d.JPG,0,test-2,14065,malleti,14065_CAM041214_d.JPG,mimic
+CAM041215,https://zenodo.org/record/2714333/files/CAM041215_d.JPG,0,test-2,14067,malleti,14067_CAM041215_d.JPG,mimic
+CAM041216,https://zenodo.org/record/2714333/files/CAM041216_d.JPG,0,test-2,14069,malleti,14069_CAM041216_d.JPG,mimic
+CAM041217,https://zenodo.org/record/2714333/files/CAM041217_d.JPG,0,test-2,14071,malleti,14071_CAM041217_d.JPG,mimic
+CAM041211,https://zenodo.org/record/2714333/files/CAM041211_d.JPG,0,test-2,14059,malleti,14059_CAM041211_d.JPG,mimic
+CAM040731,https://zenodo.org/record/2714333/files/CAM040731_d.JPG,0,test-2,13093,malleti,13093_CAM040731_d.JPG,mimic
+CAM040732,https://zenodo.org/record/2714333/files/CAM040732_d.JPG,0,test-2,13097,malleti,13097_CAM040732_d.JPG,mimic
+CAM040708,https://zenodo.org/record/2714333/files/CAM040708_d.JPG,0,test-2,13001,malleti,13001_CAM040708_d.JPG,mimic
+CAM041147,https://zenodo.org/record/2714333/files/CAM041147_d.JPG,0,test-2,13931,malleti,13931_CAM041147_d.JPG,mimic
+CAM041149,https://zenodo.org/record/2714333/files/CAM041149_d.JPG,0,test-2,13935,malleti,13935_CAM041149_d.JPG,mimic
+CAM041274,https://zenodo.org/record/2714333/files/CAM041274_d.JPG,0,test-2,14184,malleti,14184_CAM041274_d.JPG,mimic
+CAM041276,https://zenodo.org/record/2714333/files/CAM041276_d.JPG,0,test-2,14188,malleti,14188_CAM041276_d.JPG,mimic
+CAM041275,https://zenodo.org/record/2714333/files/CAM041275_d.JPG,0,test-2,14186,malleti,14186_CAM041275_d.JPG,mimic
+CS002633,https://zenodo.org/record/2735056/files/CS002633_d.JPG,0,test,40923,venus,40923_CS002633_d.JPG,minor
+CS002631,https://zenodo.org/record/2735056/files/CS002631_d.JPG,0,test,40919,venus,40919_CS002631_d.JPG,minor
+CS002627,https://zenodo.org/record/2735056/files/CS002627_d.JPG,0,test,40915,venus,40915_CS002627_d.JPG,minor
+CS003358,https://zenodo.org/record/2735056/files/CS003358_d.JPG,0,test,40991,venus,40991_CS003358_d.JPG,minor
+CS003660,https://zenodo.org/record/2735056/files/CS003660_d.JPG,0,test,41075,venus,41075_CS003660_d.JPG,minor
+CS003652,https://zenodo.org/record/2735056/files/CS003652_d.JPG,0,test,41043,venus,41043_CS003652_d.JPG,minor
+CS002280,https://zenodo.org/record/2735056/files/CS002280_d.JPG,0,test,40875,venus,40875_CS002280_d.JPG,minor
+CS002272,https://zenodo.org/record/2735056/files/CS002272_d.JPG,0,test,40843,venus,40843_CS002272_d.JPG,minor
+CS002281,https://zenodo.org/record/2735056/files/CS002281_d.JPG,0,test,40879,venus,40879_CS002281_d.JPG,minor
+CS002273,https://zenodo.org/record/2735056/files/CS002273_d.JPG,0,test,40847,venus,40847_CS002273_d.JPG,minor
+CS002274,https://zenodo.org/record/2735056/files/CS002274_d.JPG,0,test,40851,venus,40851_CS002274_d.JPG,minor
+CS002276,https://zenodo.org/record/2735056/files/CS002276_d.JPG,0,test,40859,venus,40859_CS002276_d.JPG,minor
+CS002279,https://zenodo.org/record/2735056/files/CS002279_d.JPG,0,test,40871,venus,40871_CS002279_d.JPG,minor
+CS002275,https://zenodo.org/record/2735056/files/CS002275_d.JPG,0,test,40855,venus,40855_CS002275_d.JPG,minor
+CS002277,https://zenodo.org/record/2735056/files/CS002277_d.JPG,0,test,40863,venus,40863_CS002277_d.JPG,minor
+CAM120557,https://zenodo.org/record/2813153/files/CAM120557_d.JPG,0,test-2,14891,malleti,14891_CAM120557_d.JPG,mimic
+CAM120448,https://zenodo.org/record/2813153/files/CAM120448_d.JPG,0,test-2,14885,malleti,14885_CAM120448_d.JPG,mimic
+CS004030,https://zenodo.org/record/2813153/files/CS004030_d.JPG,0,test-2,14346,malleti,14346_CS004030_d.JPG,mimic
+CS004032,https://zenodo.org/record/2813153/files/CS004032_d.JPG,0,test-2,14350,malleti,14350_CS004032_d.JPG,mimic
+CS004034,https://zenodo.org/record/2813153/files/CS004034_d.JPG,0,test-2,14354,malleti,14354_CS004034_d.JPG,mimic
+CS004038,https://zenodo.org/record/2813153/files/CS004038_d.JPG,0,test-2,14362,malleti,14362_CS004038_d.JPG,mimic
+CS004039,https://zenodo.org/record/2813153/files/CS004039_d.JPG,0,test-2,14364,malleti,14364_CS004039_d.JPG,mimic
+CS004058,https://zenodo.org/record/2813153/files/CS004058_d.JPG,0,test,14382,reductimacula,14382_CS004058_d.JPG,minor
+CAM016792,https://zenodo.org/record/3082688/files/CAM016792_d.JPG,1,test-2,4006,plesseni x malleti,4006_CAM016792_d.JPG,mimic
+CAM016803,https://zenodo.org/record/3082688/files/CAM016803_d.JPG,0,test-2,4028,plesseni,4028_CAM016803_d.JPG,mimic
+CAM016765,https://zenodo.org/record/3082688/files/CAM016765_d.JPG,1,test-2,3966,plesseni x malleti,3966_CAM016765_d.JPG,mimic
+CAM016766,https://zenodo.org/record/3082688/files/CAM016766_d.JPG,0,test-2,3968,malleti,3968_CAM016766_d.JPG,mimic
+CAM016772,https://zenodo.org/record/3082688/files/CAM016772_d.JPG,0,test-2,3978,malleti,3978_CAM016772_d.JPG,mimic
+CAM016778,https://zenodo.org/record/3082688/files/CAM016778_d.JPG,1,test-2,3982,plesseni x malleti,3982_CAM016778_d.JPG,mimic
+CAM016785,https://zenodo.org/record/3082688/files/CAM016785_d.JPG,1,test-2,3992,plesseni x malleti,3992_CAM016785_d.JPG,mimic
+CAM016769,https://zenodo.org/record/3082688/files/CAM016769_d.JPG,1,test-2,3974,plesseni x malleti,3974_CAM016769_d.JPG,mimic
+CAM016808,https://zenodo.org/record/3082688/files/CAM016808_d.JPG,1,test-2,4038,plesseni x malleti,4038_CAM016808_d.JPG,mimic
+CAM016810,https://zenodo.org/record/3082688/files/CAM016810_d.JPG,0,test-2,4042,plesseni,4042_CAM016810_d.JPG,mimic
+CAM016834,https://zenodo.org/record/3082688/files/CAM016834_d.JPG,1,test-2,4089,plesseni x malleti,4089_CAM016834_d.JPG,mimic
+CAM016836,https://zenodo.org/record/3082688/files/CAM016836_d.JPG,1,test-2,4091,plesseni x malleti,4091_CAM016836_d.JPG,mimic
+CAM016843,https://zenodo.org/record/3082688/files/CAM016843_d.JPG,1,test-2,4105,plesseni x malleti,4105_CAM016843_d.JPG,mimic
+CAM016844,https://zenodo.org/record/3082688/files/CAM016844_d.JPG,1,test-2,4107,plesseni x malleti,4107_CAM016844_d.JPG,mimic
+CAM016846,https://zenodo.org/record/3082688/files/CAM016846_d.JPG,1,test-2,4111,plesseni x malleti,4111_CAM016846_d.JPG,mimic
+CAM016847,https://zenodo.org/record/3082688/files/CAM016847_d.JPG,1,test-2,4113,plesseni x malleti,4113_CAM016847_d.JPG,mimic
+CAM016849,https://zenodo.org/record/3082688/files/CAM016849_d.JPG,1,test-2,4117,plesseni x malleti,4117_CAM016849_d.JPG,mimic
+CAM016829,https://zenodo.org/record/3082688/files/CAM016829_d.JPG,1,test-2,4080,plesseni x malleti,4080_CAM016829_d.JPG,mimic
+CAM016809,https://zenodo.org/record/3082688/files/CAM016809_d.JPG,1,test-2,4040,plesseni x malleti,4040_CAM016809_d.JPG,mimic
+CAM016819,https://zenodo.org/record/3082688/files/CAM016819_d.JPG,1,test-2,4060,plesseni x malleti,4060_CAM016819_d.JPG,mimic
+CAM016821,https://zenodo.org/record/3082688/files/CAM016821_d.JPG,1,test-2,4064,plesseni x malleti,4064_CAM016821_d.JPG,mimic
+CAM016822,https://zenodo.org/record/3082688/files/CAM016822_d.JPG,1,test-2,4066,plesseni x malleti,4066_CAM016822_d.JPG,mimic
+CAM016826,https://zenodo.org/record/3082688/files/CAM016826_d.JPG,1,test-2,4074,plesseni x malleti,4074_CAM016826_d.JPG,mimic
+CAM016828,https://zenodo.org/record/3082688/files/CAM016828_d.JPG,1,test-2,4078,plesseni x malleti,4078_CAM016828_d.JPG,mimic
+CAM016820,https://zenodo.org/record/3082688/files/CAM016820_d.JPG,1,test-2,4062,plesseni x malleti,4062_CAM016820_d.JPG,mimic
+CAM016851,https://zenodo.org/record/3082688/files/CAM016851_d.JPG,1,test-2,4121,plesseni x malleti,4121_CAM016851_d.JPG,mimic
+CAM016066,https://zenodo.org/record/3082688/files/CAM016066_d.JPG,1,test-2,3040,plesseni x malleti,3040_CAM016066_d.JPG,mimic
+CAM016065,https://zenodo.org/record/3082688/files/CAM016065_d.JPG,1,test-2,3038,plesseni x malleti,3038_CAM016065_d.JPG,mimic
+CAM016055,https://zenodo.org/record/3082688/files/CAM016055_d.JPG,1,test-2,3019,plesseni x malleti,3019_CAM016055_d.JPG,mimic
+CAM016655,https://zenodo.org/record/3082688/files/CAM016655_d.JPG,1,test-2,3845,plesseni x malleti,3845_CAM016655_d.JPG,mimic
+CAM016656,https://zenodo.org/record/3082688/files/CAM016656_d.JPG,1,test-2,3847,plesseni x malleti,3847_CAM016656_d.JPG,mimic
+CAM016657,https://zenodo.org/record/3082688/files/CAM016657_d.JPG,1,test-2,3849,plesseni x malleti,3849_CAM016657_d.JPG,mimic
+CAM016658,https://zenodo.org/record/3082688/files/CAM016658_d.JPG,1,test-2,3851,plesseni x malleti,3851_CAM016658_d.JPG,mimic
+CAM016659,https://zenodo.org/record/3082688/files/CAM016659_d.JPG,1,test-2,3853,plesseni x malleti,3853_CAM016659_d.JPG,mimic
+CAM016660,https://zenodo.org/record/3082688/files/CAM016660_d.JPG,1,test-2,3855,plesseni x malleti,3855_CAM016660_d.JPG,mimic
+CAM016661,https://zenodo.org/record/3082688/files/CAM016661_d.JPG,1,test-2,3857,plesseni x malleti,3857_CAM016661_d.JPG,mimic
+CAM016662,https://zenodo.org/record/3082688/files/CAM016662_d.JPG,1,test-2,3859,plesseni x malleti,3859_CAM016662_d.JPG,mimic
+CAM016663,https://zenodo.org/record/3082688/files/CAM016663_d.JPG,1,test-2,3861,plesseni x malleti,3861_CAM016663_d.JPG,mimic
+CAM016672,https://zenodo.org/record/3082688/files/CAM016672_d.JPG,1,test-2,3878,plesseni x malleti,3878_CAM016672_d.JPG,mimic
+CAM016042,https://zenodo.org/record/3082688/files/CAM016042_d.JPG,1,test-2,2993,plesseni x malleti,2993_CAM016042_d.JPG,mimic
+CAM016751,https://zenodo.org/record/3082688/files/CAM016751_d.JPG,1,test-2,3938,plesseni x malleti,3938_CAM016751_d.JPG,mimic
+CAM016753,https://zenodo.org/record/3082688/files/CAM016753_d.JPG,1,test-2,3942,plesseni x malleti,3942_CAM016753_d.JPG,mimic
+CAM016754,https://zenodo.org/record/3082688/files/CAM016754_d.JPG,1,test-2,3944,plesseni x malleti,3944_CAM016754_d.JPG,mimic
+CAM016043,https://zenodo.org/record/3082688/files/CAM016043_d.JPG,1,test-2,2995,plesseni x malleti,2995_CAM016043_d.JPG,mimic
+CAM016044,https://zenodo.org/record/3082688/files/CAM016044_d.JPG,1,test-2,2997,plesseni x malleti,2997_CAM016044_d.JPG,mimic
+CAM016050,https://zenodo.org/record/3082688/files/CAM016050_d.JPG,1,test-2,3009,plesseni x malleti,3009_CAM016050_d.JPG,mimic
+CAM017018,https://zenodo.org/record/3082688/files/CAM017018_d.JPG,1,test-2,4391,plesseni x malleti,4391_CAM017018_d.JPG,mimic
+CAM017019,https://zenodo.org/record/3082688/files/CAM017019_d.JPG,0,test-2,4393,malleti,4393_CAM017019_d.JPG,mimic
+CAM016990,https://zenodo.org/record/3082688/files/CAM016990_d.JPG,0,test-2,4342,malleti,4342_CAM016990_d.JPG,mimic
+CAM016998,https://zenodo.org/record/3082688/files/CAM016998_d.JPG,1,test,4355,notabilis x lativitta,4355_CAM016998_d.JPG,major
+CAM017000,https://zenodo.org/record/3082688/files/CAM017000_d.JPG,1,test,4359,notabilis x lativitta,4359_CAM017000_d.JPG,major
+CAM017001,https://zenodo.org/record/3082688/files/CAM017001_d.JPG,1,test,4361,notabilis x lativitta,4361_CAM017001_d.JPG,major
+CAM017002,https://zenodo.org/record/3082688/files/CAM017002_d.JPG,1,test,4363,notabilis x lativitta,4363_CAM017002_d.JPG,major
+CAM017003,https://zenodo.org/record/3082688/files/CAM017003_d.JPG,1,test,4365,notabilis x lativitta,4365_CAM017003_d.JPG,major
+CAM017004,https://zenodo.org/record/3082688/files/CAM017004_d.JPG,1,test,4367,notabilis x lativitta,4367_CAM017004_d.JPG,major
+CAM016997,https://zenodo.org/record/3082688/files/CAM016997_d.JPG,1,test,4354,notabilis x lativitta,4354_CAM016997_d.JPG,major
+CAM016978,https://zenodo.org/record/3082688/files/CAM016978_d.JPG,1,test,4326,notabilis x lativitta,4326_CAM016978_d.JPG,major
+CAM017022,https://zenodo.org/record/3082688/files/CAM017022_d.JPG,1,test,4399,notabilis x lativitta,4399_CAM017022_d.JPG,major
+CAM017963,https://zenodo.org/record/3082688/files/CAM017963_d.JPG,1,test,5806,lativitta x notabilis,5806_CAM017963_d.JPG,major
+CAM017039,https://zenodo.org/record/3082688/files/CAM017039_d.JPG,1,test,4431,notabilis x lativitta,4431_CAM017039_d.JPG,major
+CAM017040,https://zenodo.org/record/3082688/files/CAM017040_d.JPG,1,test-2,4433,plesseni x malleti,4433_CAM017040_d.JPG,mimic
+CAM017041,https://zenodo.org/record/3082688/files/CAM017041_d.JPG,0,test-2,4435,malleti,4435_CAM017041_d.JPG,mimic
+CAM017042,https://zenodo.org/record/3082688/files/CAM017042_d.JPG,1,test,4437,notabilis x lativitta,4437_CAM017042_d.JPG,major
+CAM016282,https://zenodo.org/record/3082688/files/CAM016282_d.JPG,0,test-2,3396,plesseni,3396_CAM016282_d.JPG,mimic
+CAM017044,https://zenodo.org/record/3082688/files/CAM017044_d.JPG,1,test,4441,notabilis x lativitta,4441_CAM017044_d.JPG,major
+CAM017045,https://zenodo.org/record/3082688/files/CAM017045_d.JPG,1,test,4443,notabilis x lativitta,4443_CAM017045_d.JPG,major
+CAM017046,https://zenodo.org/record/3082688/files/CAM017046_d.JPG,1,test,4445,notabilis x lativitta,4445_CAM017046_d.JPG,major
+CAM017038,https://zenodo.org/record/3082688/files/CAM017038_d.JPG,1,test,4429,notabilis x lativitta,4429_CAM017038_d.JPG,major
+CAM017037,https://zenodo.org/record/3082688/files/CAM017037_d.JPG,1,test,4427,notabilis x lativitta,4427_CAM017037_d.JPG,major
+CAM017036,https://zenodo.org/record/3082688/files/CAM017036_d.JPG,1,test,4425,notabilis x lativitta,4425_CAM017036_d.JPG,major
+CAM017034,https://zenodo.org/record/3082688/files/CAM017034_d.JPG,1,test,4423,notabilis x lativitta,4423_CAM017034_d.JPG,major
+CAM017023,https://zenodo.org/record/3082688/files/CAM017023_d.JPG,1,test,4401,notabilis x lativitta,4401_CAM017023_d.JPG,major
+CAM017976,https://zenodo.org/record/3082688/files/CAM017976_d.JPG,1,test-2,5819,plesseni x malleti,5819_CAM017976_d.JPG,mimic
+CAM017025,https://zenodo.org/record/3082688/files/CAM017025_d.JPG,1,test,4405,notabilis x lativitta,4405_CAM017025_d.JPG,major
+CAM017028,https://zenodo.org/record/3082688/files/CAM017028_d.JPG,1,test,4411,notabilis x lativitta,4411_CAM017028_d.JPG,major
+CAM017030,https://zenodo.org/record/3082688/files/CAM017030_d.JPG,0,test-2,4415,malleti,4415_CAM017030_d.JPG,mimic
+CAM017031,https://zenodo.org/record/3082688/files/CAM017031_d.JPG,1,test,4417,notabilis x lativitta,4417_CAM017031_d.JPG,major
+CAM017032,https://zenodo.org/record/3082688/files/CAM017032_d.JPG,1,test,4419,notabilis x lativitta,4419_CAM017032_d.JPG,major
+CAM017033,https://zenodo.org/record/3082688/files/CAM017033_d.JPG,1,test,4421,notabilis x lativitta,4421_CAM017033_d.JPG,major
+CAM017029,https://zenodo.org/record/3082688/files/CAM017029_d.JPG,1,test,4413,notabilis x lativitta,4413_CAM017029_d.JPG,major
+CAM016976,https://zenodo.org/record/3082688/files/CAM016976_d.JPG,1,test,4322,notabilis x lativitta,4322_CAM016976_d.JPG,major
+CAM016970,https://zenodo.org/record/3082688/files/CAM016970_d.JPG,1,test,4310,notabilis x lativitta,4310_CAM016970_d.JPG,major
+CAM016858,https://zenodo.org/record/3082688/files/CAM016858_d.JPG,1,test-2,4135,plesseni x malleti,4135_CAM016858_d.JPG,mimic
+CAM016859,https://zenodo.org/record/3082688/files/CAM016859_d.JPG,1,test-2,4137,plesseni x malleti,4137_CAM016859_d.JPG,mimic
+CAM016860,https://zenodo.org/record/3082688/files/CAM016860_d.JPG,1,test-2,4139,plesseni x malleti,4139_CAM016860_d.JPG,mimic
+CAM016861,https://zenodo.org/record/3082688/files/CAM016861_d.JPG,1,test-2,4141,plesseni x malleti,4141_CAM016861_d.JPG,mimic
+CAM016862,https://zenodo.org/record/3082688/files/CAM016862_d.JPG,1,test,4143,notabilis x lativitta,4143_CAM016862_d.JPG,major
+CAM016863,https://zenodo.org/record/3082688/files/CAM016863_d.JPG,1,test-2,4145,plesseni x malleti,4145_CAM016863_d.JPG,mimic
+CAM016864,https://zenodo.org/record/3082688/files/CAM016864_d.JPG,1,test,4147,notabilis x lativitta,4147_CAM016864_d.JPG,major
+CAM016865,https://zenodo.org/record/3082688/files/CAM016865_d.JPG,1,test-2,4149,plesseni x malleti,4149_CAM016865_d.JPG,mimic
+CAM016866,https://zenodo.org/record/3082688/files/CAM016866_d.JPG,1,test,4151,notabilis x lativitta,4151_CAM016866_d.JPG,major
+CAM016869,https://zenodo.org/record/3082688/files/CAM016869_d.JPG,1,test-2,4155,plesseni x malleti,4155_CAM016869_d.JPG,mimic
+CAM016867,https://zenodo.org/record/3082688/files/CAM016867_d.JPG,1,test-2,4153,plesseni x malleti,4153_CAM016867_d.JPG,mimic
+CAM016927,https://zenodo.org/record/3082688/files/CAM016927_d.JPG,1,test,4255,notabilis x lativitta,4255_CAM016927_d.JPG,major
+CAM016930,https://zenodo.org/record/3082688/files/CAM016930_d.JPG,1,test,4261,notabilis x lativitta,4261_CAM016930_d.JPG,major
+CAM016947,https://zenodo.org/record/3082688/files/CAM016947_d.JPG,1,test,4277,notabilis x lativitta,4277_CAM016947_d.JPG,major
+CAM016954,https://zenodo.org/record/3082688/files/CAM016954_d.JPG,0,test-2,4285,malleti,4285_CAM016954_d.JPG,mimic
+CAM016924,https://zenodo.org/record/3082688/files/CAM016924_d.JPG,1,test,4249,notabilis x lativitta,4249_CAM016924_d.JPG,major
+CAM016955,https://zenodo.org/record/3082688/files/CAM016955_d.JPG,0,test-2,4287,malleti,4287_CAM016955_d.JPG,mimic
+CAM016961,https://zenodo.org/record/3082688/files/CAM016961_d.JPG,1,test,4297,notabilis x lativitta,4297_CAM016961_d.JPG,major
+CAM016964,https://zenodo.org/record/3082688/files/CAM016964_d.JPG,1,test,4303,notabilis x lativitta,4303_CAM016964_d.JPG,major
+CAM016965,https://zenodo.org/record/3082688/files/CAM016965_d.JPG,1,test,4305,notabilis x lativitta,4305_CAM016965_d.JPG,major
+CAM016968,https://zenodo.org/record/3082688/files/CAM016968_d.JPG,1,test,4307,notabilis x lativitta,4307_CAM016968_d.JPG,major
+CAM016969,https://zenodo.org/record/3082688/files/CAM016969_d.JPG,1,test,4308,notabilis x lativitta,4308_CAM016969_d.JPG,major
+CAM016956,https://zenodo.org/record/3082688/files/CAM016956_d.JPG,0,test-2,4289,malleti,4289_CAM016956_d.JPG,mimic
+CAM016654,https://zenodo.org/record/3082688/files/CAM016654_d.JPG,1,test-2,3843,plesseni x malleti,3843_CAM016654_d.JPG,mimic
+CAM016923,https://zenodo.org/record/3082688/files/CAM016923_d.JPG,1,test-2,4247,plesseni x malleti,4247_CAM016923_d.JPG,mimic
+CAM016041,https://zenodo.org/record/3082688/files/CAM016041_d.JPG,1,test-2,2991,plesseni x malleti,2991_CAM016041_d.JPG,mimic
+CAM016040,https://zenodo.org/record/3082688/files/CAM016040_d.JPG,1,test,2989,notabilis x lativitta,2989_CAM016040_d.JPG,major
+CAM016039,https://zenodo.org/record/3082688/files/CAM016039_d.JPG,1,test,2987,notabilis x lativitta,2987_CAM016039_d.JPG,major
+CAM016038,https://zenodo.org/record/3082688/files/CAM016038_d.JPG,1,test,2985,notabilis x lativitta,2985_CAM016038_d.JPG,major
+CAM016036,https://zenodo.org/record/3082688/files/CAM016036_d.JPG,1,test-2,2981,plesseni x malleti,2981_CAM016036_d.JPG,mimic
+CAM016035,https://zenodo.org/record/3082688/files/CAM016035_d.JPG,1,test,2979,notabilis x lativitta,2979_CAM016035_d.JPG,major
+CAM016922,https://zenodo.org/record/3082688/files/CAM016922_d.JPG,1,test-2,4245,plesseni x malleti,4245_CAM016922_d.JPG,mimic
+CAM016034,https://zenodo.org/record/3082688/files/CAM016034_d.JPG,1,test,2977,notabilis x lativitta,2977_CAM016034_d.JPG,major
+CAM016033,https://zenodo.org/record/3082688/files/CAM016033_d.JPG,1,test,2975,notabilis x lativitta,2975_CAM016033_d.JPG,major
+CAM016920,https://zenodo.org/record/3082688/files/CAM016920_d.JPG,1,test-2,4241,plesseni x malleti,4241_CAM016920_d.JPG,mimic
+CAM016653,https://zenodo.org/record/3082688/files/CAM016653_d.JPG,1,test,3841,notabilis x lativitta,3841_CAM016653_d.JPG,major
+CAM016652,https://zenodo.org/record/3082688/files/CAM016652_d.JPG,1,test,3839,notabilis x lativitta,3839_CAM016652_d.JPG,major
+CAM016651,https://zenodo.org/record/3082688/files/CAM016651_d.JPG,1,test,3837,notabilis x lativitta,3837_CAM016651_d.JPG,major
+CAM016117,https://zenodo.org/record/3082688/files/CAM016117_d.JPG,1,test-2,3142,plesseni x malleti,3142_CAM016117_d.JPG,mimic
+CAM016116,https://zenodo.org/record/3082688/files/CAM016116_d.JPG,0,test-2,3140,plesseni,3140_CAM016116_d.JPG,mimic
+CAM016115,https://zenodo.org/record/3082688/files/CAM016115_d.JPG,1,test,3138,notabilis x lativitta,3138_CAM016115_d.JPG,major
+CAM016114,https://zenodo.org/record/3082688/files/CAM016114_d.JPG,1,test,3136,notabilis x lativitta,3136_CAM016114_d.JPG,major
+CAM016113,https://zenodo.org/record/3082688/files/CAM016113_d.JPG,0,test-2,3134,plesseni,3134_CAM016113_d.JPG,mimic
+CAM016112,https://zenodo.org/record/3082688/files/CAM016112_d.JPG,1,test,3132,notabilis x lativitta,3132_CAM016112_d.JPG,major
+CAM016111,https://zenodo.org/record/3082688/files/CAM016111_d.JPG,1,test-2,3130,plesseni x malleti,3130_CAM016111_d.JPG,mimic
+CAM016110,https://zenodo.org/record/3082688/files/CAM016110_d.JPG,1,test,3128,notabilis x lativitta,3128_CAM016110_d.JPG,major
+CAM016106,https://zenodo.org/record/3082688/files/CAM016106_d.JPG,1,test-2,3120,plesseni x malleti,3120_CAM016106_d.JPG,mimic
+CAM016105,https://zenodo.org/record/3082688/files/CAM016105_d.JPG,1,test,3118,notabilis x lativitta,3118_CAM016105_d.JPG,major
+CAM016296,https://zenodo.org/record/3082688/files/CAM016296_d.JPG,0,test-2,3408,plesseni,3408_CAM016296_d.JPG,mimic
+CAM016102,https://zenodo.org/record/3082688/files/CAM016102_d.JPG,1,test,3112,notabilis x lativitta,3112_CAM016102_d.JPG,major
+CAM016118,https://zenodo.org/record/3082688/files/CAM016118_d.JPG,1,test-2,3144,plesseni x malleti,3144_CAM016118_d.JPG,mimic
+CAM016119,https://zenodo.org/record/3082688/files/CAM016119_d.JPG,1,test-2,3146,plesseni x malleti,3146_CAM016119_d.JPG,mimic
+CAM016120,https://zenodo.org/record/3082688/files/CAM016120_d.JPG,1,test-2,3148,plesseni x malleti,3148_CAM016120_d.JPG,mimic
+CAM016121,https://zenodo.org/record/3082688/files/CAM016121_d.JPG,1,test,3150,notabilis x lativitta,3150_CAM016121_d.JPG,major
+CAM016139,https://zenodo.org/record/3082688/files/CAM016139_d.JPG,1,test,3186,notabilis x lativitta,3186_CAM016139_d.JPG,major
+CAM016138,https://zenodo.org/record/3082688/files/CAM016138_d.JPG,1,test,3184,notabilis x lativitta,3184_CAM016138_d.JPG,major
+CAM016137,https://zenodo.org/record/3082688/files/CAM016137_d.JPG,1,test-2,3182,plesseni x malleti,3182_CAM016137_d.JPG,mimic
+CAM016136,https://zenodo.org/record/3082688/files/CAM016136_d.JPG,1,test-2,3180,plesseni x malleti,3180_CAM016136_d.JPG,mimic
+CAM016135,https://zenodo.org/record/3082688/files/CAM016135_d.JPG,1,test-2,3178,plesseni x malleti,3178_CAM016135_d.JPG,mimic
+CAM016134,https://zenodo.org/record/3082688/files/CAM016134_d.JPG,0,test-2,3176,plesseni,3176_CAM016134_d.JPG,mimic
+CAM016133,https://zenodo.org/record/3082688/files/CAM016133_d.JPG,1,test-2,3174,plesseni x malleti,3174_CAM016133_d.JPG,mimic
+CAM016132,https://zenodo.org/record/3082688/files/CAM016132_d.JPG,1,test-2,3172,plesseni x malleti,3172_CAM016132_d.JPG,mimic
+CAM016131,https://zenodo.org/record/3082688/files/CAM016131_d.JPG,1,test-2,3170,plesseni x malleti,3170_CAM016131_d.JPG,mimic
+CAM016129,https://zenodo.org/record/3082688/files/CAM016129_d.JPG,1,test,3166,notabilis x lativitta,3166_CAM016129_d.JPG,major
+CAM016128,https://zenodo.org/record/3082688/files/CAM016128_d.JPG,1,test,3164,notabilis x lativitta,3164_CAM016128_d.JPG,major
+CAM016127,https://zenodo.org/record/3082688/files/CAM016127_d.JPG,1,test-2,3162,plesseni x malleti,3162_CAM016127_d.JPG,mimic
+CAM016126,https://zenodo.org/record/3082688/files/CAM016126_d.JPG,1,test-2,3160,plesseni x malleti,3160_CAM016126_d.JPG,mimic
+CAM016125,https://zenodo.org/record/3082688/files/CAM016125_d.JPG,1,test-2,3158,plesseni x malleti,3158_CAM016125_d.JPG,mimic
+CAM016124,https://zenodo.org/record/3082688/files/CAM016124_d.JPG,1,test,3156,notabilis x lativitta,3156_CAM016124_d.JPG,major
+CAM016122,https://zenodo.org/record/3082688/files/CAM016122_d.JPG,1,test-2,3152,plesseni x malleti,3152_CAM016122_d.JPG,mimic
+CAM016130,https://zenodo.org/record/3082688/files/CAM016130_d.JPG,1,test-2,3168,plesseni x malleti,3168_CAM016130_d.JPG,mimic
+CAM016140,https://zenodo.org/record/3082688/files/CAM016140_d.JPG,1,test,3188,notabilis x lativitta,3188_CAM016140_d.JPG,major
+CAM016100,https://zenodo.org/record/3082688/files/CAM016100_d.JPG,1,test-2,3108,plesseni x malleti,3108_CAM016100_d.JPG,mimic
+CAM016306,https://zenodo.org/record/3082688/files/CAM016306_d.JPG,1,test-2,3412,plesseni x malleti,3412_CAM016306_d.JPG,mimic
+CAM016088,https://zenodo.org/record/3082688/files/CAM016088_d.JPG,1,test,3084,notabilis x lativitta,3084_CAM016088_d.JPG,major
+CAM016354,https://zenodo.org/record/3082688/files/CAM016354_d.JPG,0,test-2,3438,plesseni,3438_CAM016354_d.JPG,mimic
+CAM016355,https://zenodo.org/record/3082688/files/CAM016355_d.JPG,0,test-2,3440,plesseni,3440_CAM016355_d.JPG,mimic
+CAM016087,https://zenodo.org/record/3082688/files/CAM016087_d.JPG,1,test-2,3082,plesseni x malleti,3082_CAM016087_d.JPG,mimic
+CAM016086,https://zenodo.org/record/3082688/files/CAM016086_d.JPG,1,test-2,3080,plesseni x malleti,3080_CAM016086_d.JPG,mimic
+CAM016084,https://zenodo.org/record/3082688/files/CAM016084_d.JPG,1,test-2,3076,plesseni x malleti,3076_CAM016084_d.JPG,mimic
+CAM016089,https://zenodo.org/record/3082688/files/CAM016089_d.JPG,1,test-2,3086,plesseni x malleti,3086_CAM016089_d.JPG,mimic
+CAM016350,https://zenodo.org/record/3082688/files/CAM016350_d.JPG,1,test-2,3436,plesseni x malleti,3436_CAM016350_d.JPG,mimic
+CAM016349,https://zenodo.org/record/3082688/files/CAM016349_d.JPG,0,test-2,3434,plesseni,3434_CAM016349_d.JPG,mimic
+CAM016347,https://zenodo.org/record/3082688/files/CAM016347_d.JPG,0,test-2,3432,plesseni,3432_CAM016347_d.JPG,mimic
+CAM016098,https://zenodo.org/record/3082688/files/CAM016098_d.JPG,1,test-2,3104,plesseni x malleti,3104_CAM016098_d.JPG,mimic
+CAM016097,https://zenodo.org/record/3082688/files/CAM016097_d.JPG,1,test-2,3102,plesseni x malleti,3102_CAM016097_d.JPG,mimic
+CAM016309,https://zenodo.org/record/3082688/files/CAM016309_d.JPG,1,test-2,3414,plesseni x malleti,3414_CAM016309_d.JPG,mimic
+CAM016096,https://zenodo.org/record/3082688/files/CAM016096_d.JPG,1,test,3100,notabilis x lativitta,3100_CAM016096_d.JPG,major
+CAM016312,https://zenodo.org/record/3082688/files/CAM016312_d.JPG,1,test-2,3416,plesseni x malleti,3416_CAM016312_d.JPG,mimic
+CAM016313,https://zenodo.org/record/3082688/files/CAM016313_d.JPG,1,test-2,3418,plesseni x malleti,3418_CAM016313_d.JPG,mimic
+CAM016094,https://zenodo.org/record/3082688/files/CAM016094_d.JPG,1,test,3096,notabilis x lativitta,3096_CAM016094_d.JPG,major
+CAM016099,https://zenodo.org/record/3082688/files/CAM016099_d.JPG,1,test,3106,notabilis x lativitta,3106_CAM016099_d.JPG,major
+CAM016091,https://zenodo.org/record/3082688/files/CAM016091_d.JPG,1,test,3090,notabilis x lativitta,3090_CAM016091_d.JPG,major
+CAM016338,https://zenodo.org/record/3082688/files/CAM016338_d.JPG,1,test-2,3424,plesseni x malleti,3424_CAM016338_d.JPG,mimic
+CAM016339,https://zenodo.org/record/3082688/files/CAM016339_d.JPG,1,test-2,3426,plesseni x malleti,3426_CAM016339_d.JPG,mimic
+CAM016340,https://zenodo.org/record/3082688/files/CAM016340_d.JPG,1,test-2,3428,plesseni x malleti,3428_CAM016340_d.JPG,mimic
+CAM016234,https://zenodo.org/record/3082688/files/CAM016234_d.JPG,0,test-2,3344,malleti,3344_CAM016234_d.JPG,mimic
+CAM016224,https://zenodo.org/record/3082688/files/CAM016224_d.JPG,0,test-2,3334,malleti,3334_CAM016224_d.JPG,mimic
+CAM016205,https://zenodo.org/record/3082688/files/CAM016205_d.JPG,0,test-2,3316,malleti,3316_CAM016205_d.JPG,mimic
+CAM016197,https://zenodo.org/record/3082688/files/CAM016197_d.JPG,0,test-2,3302,malleti,3302_CAM016197_d.JPG,mimic
+CAM016194,https://zenodo.org/record/3082688/files/CAM016194_d.JPG,1,test,3296,notabilis x lativitta,3296_CAM016194_d.JPG,major
+CAM016193,https://zenodo.org/record/3082688/files/CAM016193_d.JPG,1,test,3294,notabilis x lativitta,3294_CAM016193_d.JPG,major
+CAM016192,https://zenodo.org/record/3082688/files/CAM016192_d.JPG,1,test,3292,notabilis x lativitta,3292_CAM016192_d.JPG,major
+CAM016190,https://zenodo.org/record/3082688/files/CAM016190_d.JPG,0,test-2,3288,malleti,3288_CAM016190_d.JPG,mimic
+CAM016274,https://zenodo.org/record/3082688/files/CAM016274_d.JPG,0,test-2,3392,malleti,3392_CAM016274_d.JPG,mimic
+CAM016273,https://zenodo.org/record/3082688/files/CAM016273_d.JPG,0,test-2,3390,malleti,3390_CAM016273_d.JPG,mimic
+CAM016267,https://zenodo.org/record/3082688/files/CAM016267_d.JPG,0,test-2,3380,malleti,3380_CAM016267_d.JPG,mimic
+CAM016266,https://zenodo.org/record/3082688/files/CAM016266_d.JPG,0,test-2,3378,malleti,3378_CAM016266_d.JPG,mimic
+CAM016268,https://zenodo.org/record/3082688/files/CAM016268_d.JPG,0,test-2,3382,malleti,3382_CAM016268_d.JPG,mimic
+CAM016188,https://zenodo.org/record/3082688/files/CAM016188_d.JPG,1,test,3284,notabilis x lativitta,3284_CAM016188_d.JPG,major
+CAM016187,https://zenodo.org/record/3082688/files/CAM016187_d.JPG,1,test,3282,notabilis x lativitta,3282_CAM016187_d.JPG,major
+CAM016186,https://zenodo.org/record/3082688/files/CAM016186_d.JPG,1,test,3280,notabilis x lativitta,3280_CAM016186_d.JPG,major
+CAM016157,https://zenodo.org/record/3082688/files/CAM016157_d.JPG,1,test,3222,notabilis x lativitta,3222_CAM016157_d.JPG,major
+CAM016156,https://zenodo.org/record/3082688/files/CAM016156_d.JPG,1,test,3220,notabilis x lativitta,3220_CAM016156_d.JPG,major
+CAM016155,https://zenodo.org/record/3082688/files/CAM016155_d.JPG,1,test,3218,notabilis x lativitta,3218_CAM016155_d.JPG,major
+CAM016154,https://zenodo.org/record/3082688/files/CAM016154_d.JPG,1,test,3216,notabilis x lativitta,3216_CAM016154_d.JPG,major
+CAM016162,https://zenodo.org/record/3082688/files/CAM016162_d.JPG,1,test,3232,notabilis x lativitta,3232_CAM016162_d.JPG,major
+CAM016153,https://zenodo.org/record/3082688/files/CAM016153_d.JPG,1,test,3214,notabilis x lativitta,3214_CAM016153_d.JPG,major
+CAM016151,https://zenodo.org/record/3082688/files/CAM016151_d.JPG,1,test,3210,notabilis x lativitta,3210_CAM016151_d.JPG,major
+CAM016150,https://zenodo.org/record/3082688/files/CAM016150_d.JPG,1,test,3208,notabilis x lativitta,3208_CAM016150_d.JPG,major
+CAM016149,https://zenodo.org/record/3082688/files/CAM016149_d.JPG,1,test,3206,notabilis x lativitta,3206_CAM016149_d.JPG,major
+CAM016148,https://zenodo.org/record/3082688/files/CAM016148_d.JPG,1,test,3204,notabilis x lativitta,3204_CAM016148_d.JPG,major
+CAM016147,https://zenodo.org/record/3082688/files/CAM016147_d.JPG,1,test,3202,notabilis x lativitta,3202_CAM016147_d.JPG,major
+CAM016146,https://zenodo.org/record/3082688/files/CAM016146_d.JPG,1,test,3200,notabilis x lativitta,3200_CAM016146_d.JPG,major
+CAM016145,https://zenodo.org/record/3082688/files/CAM016145_d.JPG,1,test,3198,notabilis x lativitta,3198_CAM016145_d.JPG,major
+CAM016144,https://zenodo.org/record/3082688/files/CAM016144_d.JPG,0,test-2,3196,malleti,3196_CAM016144_d.JPG,mimic
+CAM016152,https://zenodo.org/record/3082688/files/CAM016152_d.JPG,1,test,3212,notabilis x lativitta,3212_CAM016152_d.JPG,major
+CAM016163,https://zenodo.org/record/3082688/files/CAM016163_d.JPG,1,test,3234,notabilis x lativitta,3234_CAM016163_d.JPG,major
+CAM016185,https://zenodo.org/record/3082688/files/CAM016185_d.JPG,1,test,3278,notabilis x lativitta,3278_CAM016185_d.JPG,major
+CAM016184,https://zenodo.org/record/3082688/files/CAM016184_d.JPG,1,test,3276,notabilis x lativitta,3276_CAM016184_d.JPG,major
+CAM016183,https://zenodo.org/record/3082688/files/CAM016183_d.JPG,1,test,3274,notabilis x lativitta,3274_CAM016183_d.JPG,major
+CAM016182,https://zenodo.org/record/3082688/files/CAM016182_d.JPG,1,test,3272,notabilis x lativitta,3272_CAM016182_d.JPG,major
+CAM016181,https://zenodo.org/record/3082688/files/CAM016181_d.JPG,1,test,3270,notabilis x lativitta,3270_CAM016181_d.JPG,major
+CAM016180,https://zenodo.org/record/3082688/files/CAM016180_d.JPG,1,test,3268,notabilis x lativitta,3268_CAM016180_d.JPG,major
+CAM016179,https://zenodo.org/record/3082688/files/CAM016179_d.JPG,1,test,3266,notabilis x lativitta,3266_CAM016179_d.JPG,major
+CAM016178,https://zenodo.org/record/3082688/files/CAM016178_d.JPG,1,test,3264,notabilis x lativitta,3264_CAM016178_d.JPG,major
+CAM016164,https://zenodo.org/record/3082688/files/CAM016164_d.JPG,1,test,3236,notabilis x lativitta,3236_CAM016164_d.JPG,major
+CAM016177,https://zenodo.org/record/3082688/files/CAM016177_d.JPG,1,test,3262,notabilis x lativitta,3262_CAM016177_d.JPG,major
+CAM016174,https://zenodo.org/record/3082688/files/CAM016174_d.JPG,1,test,3256,notabilis x lativitta,3256_CAM016174_d.JPG,major
+CAM016172,https://zenodo.org/record/3082688/files/CAM016172_d.JPG,1,test,3252,notabilis x lativitta,3252_CAM016172_d.JPG,major
+CAM016171,https://zenodo.org/record/3082688/files/CAM016171_d.JPG,1,test,3250,notabilis x lativitta,3250_CAM016171_d.JPG,major
+CAM016170,https://zenodo.org/record/3082688/files/CAM016170_d.JPG,1,test,3248,notabilis x lativitta,3248_CAM016170_d.JPG,major
+CAM016169,https://zenodo.org/record/3082688/files/CAM016169_d.JPG,1,test,3246,notabilis x lativitta,3246_CAM016169_d.JPG,major
+CAM016168,https://zenodo.org/record/3082688/files/CAM016168_d.JPG,1,test,3244,notabilis x lativitta,3244_CAM016168_d.JPG,major
+CAM016167,https://zenodo.org/record/3082688/files/CAM016167_d.JPG,1,test,3242,notabilis x lativitta,3242_CAM016167_d.JPG,major
+CAM016176,https://zenodo.org/record/3082688/files/CAM016176_d.JPG,1,test,3260,notabilis x lativitta,3260_CAM016176_d.JPG,major
+CAM017049,https://zenodo.org/record/3082688/files/CAM017049_d.JPG,0,test-2,4447,malleti,4447_CAM017049_d.JPG,mimic
+CAM016552,https://zenodo.org/record/3082688/files/CAM016552_d.JPG,0,test-2,3713,malleti,3713_CAM016552_d.JPG,mimic
+CAM016557,https://zenodo.org/record/3082688/files/CAM016557_d.JPG,1,test,3719,notabilis x lativitta,3719_CAM016557_d.JPG,major
+CAM016559,https://zenodo.org/record/3082688/files/CAM016559_d.JPG,1,test,3723,notabilis x lativitta,3723_CAM016559_d.JPG,major
+CAM016560,https://zenodo.org/record/3082688/files/CAM016560_d.JPG,1,test,3725,notabilis x lativitta,3725_CAM016560_d.JPG,major
+CAM016562,https://zenodo.org/record/3082688/files/CAM016562_d.JPG,1,test,3729,notabilis x lativitta,3729_CAM016562_d.JPG,major
+CAM016566,https://zenodo.org/record/3082688/files/CAM016566_d.JPG,1,test,3737,notabilis x lativitta,3737_CAM016566_d.JPG,major
+CAM016567,https://zenodo.org/record/3082688/files/CAM016567_d.JPG,0,test-2,3739,malleti,3739_CAM016567_d.JPG,mimic
+CAM016551,https://zenodo.org/record/3082688/files/CAM016551_d.JPG,0,test-2,3711,malleti,3711_CAM016551_d.JPG,mimic
+CAM016550,https://zenodo.org/record/3082688/files/CAM016550_d.JPG,0,test-2,3709,malleti,3709_CAM016550_d.JPG,mimic
+CAM016549,https://zenodo.org/record/3082688/files/CAM016549_d.JPG,0,test-2,3707,malleti,3707_CAM016549_d.JPG,mimic
+CAM016548,https://zenodo.org/record/3082688/files/CAM016548_d.JPG,0,test-2,3705,malleti,3705_CAM016548_d.JPG,mimic
+CAM016518,https://zenodo.org/record/3082688/files/CAM016518_d.JPG,1,test,3669,notabilis x lativitta,3669_CAM016518_d.JPG,major
+CAM016520,https://zenodo.org/record/3082688/files/CAM016520_d.JPG,1,test,3671,notabilis x lativitta,3671_CAM016520_d.JPG,major
+CAM016521,https://zenodo.org/record/3082688/files/CAM016521_d.JPG,1,test,3673,notabilis x lativitta,3673_CAM016521_d.JPG,major
+CAM016522,https://zenodo.org/record/3082688/files/CAM016522_d.JPG,1,test,3675,notabilis x lativitta,3675_CAM016522_d.JPG,major
+CAM016523,https://zenodo.org/record/3082688/files/CAM016523_d.JPG,1,test,3677,notabilis x lativitta,3677_CAM016523_d.JPG,major
+CAM016524,https://zenodo.org/record/3082688/files/CAM016524_d.JPG,1,test,3679,notabilis x lativitta,3679_CAM016524_d.JPG,major
+CAM016525,https://zenodo.org/record/3082688/files/CAM016525_d.JPG,1,test,3681,notabilis x lativitta,3681_CAM016525_d.JPG,major
+CAM016526,https://zenodo.org/record/3082688/files/CAM016526_d.JPG,1,test,3683,notabilis x lativitta,3683_CAM016526_d.JPG,major
+CAM016527,https://zenodo.org/record/3082688/files/CAM016527_d.JPG,1,test,3685,notabilis x lativitta,3685_CAM016527_d.JPG,major
+CAM016540,https://zenodo.org/record/3082688/files/CAM016540_d.JPG,0,test-2,3691,malleti,3691_CAM016540_d.JPG,mimic
+CAM016541,https://zenodo.org/record/3082688/files/CAM016541_d.JPG,0,test-2,3693,malleti,3693_CAM016541_d.JPG,mimic
+CAM016542,https://zenodo.org/record/3082688/files/CAM016542_d.JPG,0,test-2,3695,malleti,3695_CAM016542_d.JPG,mimic
+CAM016544,https://zenodo.org/record/3082688/files/CAM016544_d.JPG,0,test-2,3697,malleti,3697_CAM016544_d.JPG,mimic
+CAM016545,https://zenodo.org/record/3082688/files/CAM016545_d.JPG,0,test-2,3699,malleti,3699_CAM016545_d.JPG,mimic
+CAM016546,https://zenodo.org/record/3082688/files/CAM016546_d.JPG,0,test-2,3701,malleti,3701_CAM016546_d.JPG,mimic
+CAM016547,https://zenodo.org/record/3082688/files/CAM016547_d.JPG,0,test-2,3703,malleti,3703_CAM016547_d.JPG,mimic
+CAM016538,https://zenodo.org/record/3082688/files/CAM016538_d.JPG,0,test-2,3687,malleti,3687_CAM016538_d.JPG,mimic
+CAM016517,https://zenodo.org/record/3082688/files/CAM016517_d.JPG,1,test,3667,notabilis x lativitta,3667_CAM016517_d.JPG,major
+CAM016577,https://zenodo.org/record/3082688/files/CAM016577_d.JPG,1,test,3745,notabilis x lativitta,3745_CAM016577_d.JPG,major
+CAM016635,https://zenodo.org/record/3082688/files/CAM016635_d.JPG,1,test,3811,notabilis x lativitta,3811_CAM016635_d.JPG,major
+CAM016636,https://zenodo.org/record/3082688/files/CAM016636_d.JPG,1,test,3813,notabilis x lativitta,3813_CAM016636_d.JPG,major
+CAM016639,https://zenodo.org/record/3082688/files/CAM016639_d.JPG,1,test,3817,notabilis x lativitta,3817_CAM016639_d.JPG,major
+CAM016641,https://zenodo.org/record/3082688/files/CAM016641_d.JPG,1,test,3819,notabilis x lativitta,3819_CAM016641_d.JPG,major
+CAM016643,https://zenodo.org/record/3082688/files/CAM016643_d.JPG,1,test,3821,notabilis x lativitta,3821_CAM016643_d.JPG,major
+CAM016644,https://zenodo.org/record/3082688/files/CAM016644_d.JPG,1,test,3823,notabilis x lativitta,3823_CAM016644_d.JPG,major
+CAM016645,https://zenodo.org/record/3082688/files/CAM016645_d.JPG,1,test,3825,notabilis x lativitta,3825_CAM016645_d.JPG,major
+CAM016646,https://zenodo.org/record/3082688/files/CAM016646_d.JPG,1,test,3827,notabilis x lativitta,3827_CAM016646_d.JPG,major
+CAM016647,https://zenodo.org/record/3082688/files/CAM016647_d.JPG,1,test,3829,notabilis x lativitta,3829_CAM016647_d.JPG,major
+CAM016648,https://zenodo.org/record/3082688/files/CAM016648_d.JPG,1,test,3831,notabilis x lativitta,3831_CAM016648_d.JPG,major
+CAM016649,https://zenodo.org/record/3082688/files/CAM016649_d.JPG,1,test,3833,notabilis x lativitta,3833_CAM016649_d.JPG,major
+CAM016650,https://zenodo.org/record/3082688/files/CAM016650_d.JPG,1,test,3835,notabilis x lativitta,3835_CAM016650_d.JPG,major
+CAM016611,https://zenodo.org/record/3082688/files/CAM016611_d.JPG,0,test-2,3807,malleti,3807_CAM016611_d.JPG,mimic
+CAM016610,https://zenodo.org/record/3082688/files/CAM016610_d.JPG,0,test-2,3805,malleti,3805_CAM016610_d.JPG,mimic
+CAM016609,https://zenodo.org/record/3082688/files/CAM016609_d.JPG,0,test-2,3803,malleti,3803_CAM016609_d.JPG,mimic
+CAM016580,https://zenodo.org/record/3082688/files/CAM016580_d.JPG,1,test,3751,notabilis x lativitta,3751_CAM016580_d.JPG,major
+CAM016582,https://zenodo.org/record/3082688/files/CAM016582_d.JPG,1,test,3755,notabilis x lativitta,3755_CAM016582_d.JPG,major
+CAM016584,https://zenodo.org/record/3082688/files/CAM016584_d.JPG,1,test,3759,notabilis x lativitta,3759_CAM016584_d.JPG,major
+CAM016585,https://zenodo.org/record/3082688/files/CAM016585_d.JPG,1,test,3761,notabilis x lativitta,3761_CAM016585_d.JPG,major
+CAM016578,https://zenodo.org/record/3082688/files/CAM016578_d.JPG,1,test,3747,notabilis x lativitta,3747_CAM016578_d.JPG,major
+CAM016588,https://zenodo.org/record/3082688/files/CAM016588_d.JPG,1,test,3767,notabilis x lativitta,3767_CAM016588_d.JPG,major
+CAM016590,https://zenodo.org/record/3082688/files/CAM016590_d.JPG,1,test,3771,notabilis x lativitta,3771_CAM016590_d.JPG,major
+CAM016594,https://zenodo.org/record/3082688/files/CAM016594_d.JPG,0,test-2,3777,malleti,3777_CAM016594_d.JPG,mimic
+CAM016595,https://zenodo.org/record/3082688/files/CAM016595_d.JPG,0,test-2,3779,malleti,3779_CAM016595_d.JPG,mimic
+CAM016598,https://zenodo.org/record/3082688/files/CAM016598_d.JPG,0,test-2,3783,malleti,3783_CAM016598_d.JPG,mimic
+CAM016599,https://zenodo.org/record/3082688/files/CAM016599_d.JPG,0,test-2,3785,malleti,3785_CAM016599_d.JPG,mimic
+CAM016606,https://zenodo.org/record/3082688/files/CAM016606_d.JPG,0,test-2,3799,malleti,3799_CAM016606_d.JPG,mimic
+CAM016516,https://zenodo.org/record/3082688/files/CAM016516_d.JPG,1,test,3665,notabilis x lativitta,3665_CAM016516_d.JPG,major
+CAM016515,https://zenodo.org/record/3082688/files/CAM016515_d.JPG,1,test,3663,notabilis x lativitta,3663_CAM016515_d.JPG,major
+CAM016514,https://zenodo.org/record/3082688/files/CAM016514_d.JPG,1,test,3661,notabilis x lativitta,3661_CAM016514_d.JPG,major
+CAM016410,https://zenodo.org/record/3082688/files/CAM016410_d.JPG,1,test,3531,notabilis x lativitta,3531_CAM016410_d.JPG,major
+CAM016415,https://zenodo.org/record/3082688/files/CAM016415_d.JPG,1,test,3541,notabilis x lativitta,3541_CAM016415_d.JPG,major
+CAM016463,https://zenodo.org/record/3082688/files/CAM016463_d.JPG,1,test,3623,notabilis x lativitta,3623_CAM016463_d.JPG,major
+CAM016464,https://zenodo.org/record/3082688/files/CAM016464_d.JPG,1,test,3625,notabilis x lativitta,3625_CAM016464_d.JPG,major
+CAM016465,https://zenodo.org/record/3082688/files/CAM016465_d.JPG,0,test-2,3627,malleti,3627_CAM016465_d.JPG,mimic
+CAM016466,https://zenodo.org/record/3082688/files/CAM016466_d.JPG,1,test,3629,notabilis x lativitta,3629_CAM016466_d.JPG,major
+CAM016462,https://zenodo.org/record/3082688/files/CAM016462_d.JPG,1,test,3621,notabilis x lativitta,3621_CAM016462_d.JPG,major
+CAM016506,https://zenodo.org/record/3082688/files/CAM016506_d.JPG,0,test-2,3645,malleti,3645_CAM016506_d.JPG,mimic
+CAM016507,https://zenodo.org/record/3082688/files/CAM016507_d.JPG,1,test,3647,notabilis x lativitta,3647_CAM016507_d.JPG,major
+CAM016512,https://zenodo.org/record/3082688/files/CAM016512_d.JPG,1,test,3657,notabilis x lativitta,3657_CAM016512_d.JPG,major
+CAM016513,https://zenodo.org/record/3082688/files/CAM016513_d.JPG,1,test,3659,notabilis x lativitta,3659_CAM016513_d.JPG,major
+CAM016461,https://zenodo.org/record/3082688/files/CAM016461_d.JPG,1,test,3619,notabilis x lativitta,3619_CAM016461_d.JPG,major
+CAM016459,https://zenodo.org/record/3082688/files/CAM016459_d.JPG,1,test,3617,notabilis x lativitta,3617_CAM016459_d.JPG,major
+CAM016423,https://zenodo.org/record/3082688/files/CAM016423_d.JPG,1,test,3557,notabilis x lativitta,3557_CAM016423_d.JPG,major
+CAM016426,https://zenodo.org/record/3082688/files/CAM016426_d.JPG,0,test-2,3563,malleti,3563_CAM016426_d.JPG,mimic
+CAM016447,https://zenodo.org/record/3082688/files/CAM016447_d.JPG,1,test,3599,notabilis x lativitta,3599_CAM016447_d.JPG,major
+CAM016448,https://zenodo.org/record/3082688/files/CAM016448_d.JPG,1,test,3601,notabilis x lativitta,3601_CAM016448_d.JPG,major
+CAM016079,https://zenodo.org/record/3082688/files/CAM016079_d.JPG,1,test,3066,notabilis x lativitta,3066_CAM016079_d.JPG,major
+CAM016452,https://zenodo.org/record/3082688/files/CAM016452_d.JPG,1,test,3607,notabilis x lativitta,3607_CAM016452_d.JPG,major
+CAM016453,https://zenodo.org/record/3082688/files/CAM016453_d.JPG,1,test,3609,notabilis x lativitta,3609_CAM016453_d.JPG,major
+CAM016455,https://zenodo.org/record/3082688/files/CAM016455_d.JPG,1,test,3611,notabilis x lativitta,3611_CAM016455_d.JPG,major
+CAM016456,https://zenodo.org/record/3082688/files/CAM016456_d.JPG,1,test,3613,notabilis x lativitta,3613_CAM016456_d.JPG,major
+CAM016458,https://zenodo.org/record/3082688/files/CAM016458_d.JPG,1,test,3615,notabilis x lativitta,3615_CAM016458_d.JPG,major
+CAM017051,https://zenodo.org/record/3082688/files/CAM017051_d.JPG,1,test,4451,notabilis x lativitta,4451_CAM017051_d.JPG,major
+CAM016026,https://zenodo.org/record/3082688/files/CAM016026_d.JPG,1,test,2961,notabilis x lativitta,2961_CAM016026_d.JPG,major
+CAM016025,https://zenodo.org/record/3082688/files/CAM016025_d.JPG,1,test,2959,notabilis x lativitta,2959_CAM016025_d.JPG,major
+CAM016024,https://zenodo.org/record/3082688/files/CAM016024_d.JPG,1,test,2957,notabilis x lativitta,2957_CAM016024_d.JPG,major
+CAM016023,https://zenodo.org/record/3082688/files/CAM016023_d.JPG,1,test,2955,notabilis x lativitta,2955_CAM016023_d.JPG,major
+CAM016022,https://zenodo.org/record/3082688/files/CAM016022_d.JPG,1,test,2953,notabilis x lativitta,2953_CAM016022_d.JPG,major
+CAM016027,https://zenodo.org/record/3082688/files/CAM016027_d.JPG,1,test,2963,notabilis x lativitta,2963_CAM016027_d.JPG,major
+CAM017341,https://zenodo.org/record/3082688/files/CAM017341_d.JPG,1,test,4960,notabilis x lativitta,4960_CAM017341_d.JPG,major
+CAM017343,https://zenodo.org/record/3082688/files/CAM017343_d.JPG,1,test,4964,notabilis x lativitta,4964_CAM017343_d.JPG,major
+CAM017344,https://zenodo.org/record/3082688/files/CAM017344_d.JPG,1,test,4966,notabilis x lativitta,4966_CAM017344_d.JPG,major
+CAM017346,https://zenodo.org/record/3082688/files/CAM017346_d.JPG,1,test,4970,notabilis x lativitta,4970_CAM017346_d.JPG,major
+CAM017347,https://zenodo.org/record/3082688/files/CAM017347_d.JPG,1,test,4972,notabilis x lativitta,4972_CAM017347_d.JPG,major
+CAM017348,https://zenodo.org/record/3082688/files/CAM017348_d.JPG,1,test,4974,notabilis x lativitta,4974_CAM017348_d.JPG,major
+CAM017349,https://zenodo.org/record/3082688/files/CAM017349_d.JPG,1,test,4976,notabilis x lativitta,4976_CAM017349_d.JPG,major
+CAM017350,https://zenodo.org/record/3082688/files/CAM017350_d.JPG,1,test,4978,notabilis x lativitta,4978_CAM017350_d.JPG,major
+CAM016021,https://zenodo.org/record/3082688/files/CAM016021_d.JPG,1,test,2951,notabilis x lativitta,2951_CAM016021_d.JPG,major
+CAM016020,https://zenodo.org/record/3082688/files/CAM016020_d.JPG,1,test,2949,notabilis x lativitta,2949_CAM016020_d.JPG,major
+CAM017610,https://zenodo.org/record/3082688/files/CAM017610_d.JPG,1,test,5382,notabilis x lativitta,5382_CAM017610_d.JPG,major
+CAM017375,https://zenodo.org/record/3082688/files/CAM017375_d.JPG,0,test,5002,notabilis,5002_CAM017375_d.JPG,major
+CAM016014,https://zenodo.org/record/3082688/files/CAM016014_d.JPG,0,test,2937,notabilis,2937_CAM016014_d.JPG,major
+CAM017272,https://zenodo.org/record/3082688/files/CAM017272_d.JPG,0,test-2,4856,malleti,4856_CAM017272_d.JPG,mimic
+CAM017283,https://zenodo.org/record/3082688/files/CAM017283_d.JPG,0,test-2,4878,malleti,4878_CAM017283_d.JPG,mimic
+CAM017324,https://zenodo.org/record/3082688/files/CAM017324_d.JPG,0,test,4932,notabilis,4932_CAM017324_d.JPG,major
+CAM017320,https://zenodo.org/record/3082688/files/CAM017320_d.JPG,0,test,4924,notabilis,4924_CAM017320_d.JPG,major
+CAM017321,https://zenodo.org/record/3082688/files/CAM017321_d.JPG,0,test,4926,notabilis,4926_CAM017321_d.JPG,major
+CAM017322,https://zenodo.org/record/3082688/files/CAM017322_d.JPG,0,test,4928,notabilis,4928_CAM017322_d.JPG,major
+CAM017323,https://zenodo.org/record/3082688/files/CAM017323_d.JPG,0,test,4930,notabilis,4930_CAM017323_d.JPG,major
+CAM017381,https://zenodo.org/record/3082688/files/CAM017381_d.JPG,0,test-2,5012,malleti,5012_CAM017381_d.JPG,mimic
+CAM017400,https://zenodo.org/record/3082688/files/CAM017400_d.JPG,0,test-2,5043,malleti,5043_CAM017400_d.JPG,mimic
+CAM017385,https://zenodo.org/record/3082688/files/CAM017385_d.JPG,0,test-2,5020,malleti,5020_CAM017385_d.JPG,mimic
+CAM017387,https://zenodo.org/record/3082688/files/CAM017387_d.JPG,0,test-2,5024,malleti,5024_CAM017387_d.JPG,mimic
+CAM017412,https://zenodo.org/record/3082688/files/CAM017412_d.JPG,0,test-2,5061,malleti,5061_CAM017412_d.JPG,mimic
+CAM017269,https://zenodo.org/record/3082688/files/CAM017269_d.JPG,0,test-2,4850,malleti,4850_CAM017269_d.JPG,mimic
+CAM017126,https://zenodo.org/record/3082688/files/CAM017126_d.JPG,0,test-2,4581,malleti,4581_CAM017126_d.JPG,mimic
+CAM017117,https://zenodo.org/record/3082688/files/CAM017117_d.JPG,0,test-2,4563,malleti,4563_CAM017117_d.JPG,mimic
+CAM017120,https://zenodo.org/record/3082688/files/CAM017120_d.JPG,0,test-2,4569,malleti,4569_CAM017120_d.JPG,mimic
+CAM017121,https://zenodo.org/record/3082688/files/CAM017121_d.JPG,0,test-2,4571,malleti,4571_CAM017121_d.JPG,mimic
+CAM017134,https://zenodo.org/record/3082688/files/CAM017134_d.JPG,0,test-2,4597,malleti,4597_CAM017134_d.JPG,mimic
+CAM017156,https://zenodo.org/record/3082688/files/CAM017156_d.JPG,0,test-2,4637,malleti,4637_CAM017156_d.JPG,mimic
+CAM017136,https://zenodo.org/record/3082688/files/CAM017136_d.JPG,0,test-2,4601,malleti,4601_CAM017136_d.JPG,mimic
+CAM017137,https://zenodo.org/record/3082688/files/CAM017137_d.JPG,0,test-2,4603,malleti,4603_CAM017137_d.JPG,mimic
+CAM017138,https://zenodo.org/record/3082688/files/CAM017138_d.JPG,0,test-2,4605,malleti,4605_CAM017138_d.JPG,mimic
+CAM017069,https://zenodo.org/record/3082688/files/CAM017069_d.JPG,0,test-2,4487,malleti,4487_CAM017069_d.JPG,mimic
+CAM017070,https://zenodo.org/record/3082688/files/CAM017070_d.JPG,0,test-2,4489,malleti,4489_CAM017070_d.JPG,mimic
+CAM017071,https://zenodo.org/record/3082688/files/CAM017071_d.JPG,0,test-2,4491,malleti,4491_CAM017071_d.JPG,mimic
+CAM017073,https://zenodo.org/record/3082688/files/CAM017073_d.JPG,0,test-2,4495,malleti,4495_CAM017073_d.JPG,mimic
+CAM017064,https://zenodo.org/record/3082688/files/CAM017064_d.JPG,0,test-2,4477,malleti,4477_CAM017064_d.JPG,mimic
+CAM017093,https://zenodo.org/record/3082688/files/CAM017093_d.JPG,0,test-2,4527,malleti,4527_CAM017093_d.JPG,mimic
+CAM017099,https://zenodo.org/record/3082688/files/CAM017099_d.JPG,0,test-2,4537,malleti,4537_CAM017099_d.JPG,mimic
+CAM017100,https://zenodo.org/record/3082688/files/CAM017100_d.JPG,0,test-2,4539,malleti,4539_CAM017100_d.JPG,mimic
+CAM017103,https://zenodo.org/record/3082688/files/CAM017103_d.JPG,0,test-2,4543,malleti,4543_CAM017103_d.JPG,mimic
+CAM017104,https://zenodo.org/record/3082688/files/CAM017104_d.JPG,0,test-2,4545,malleti,4545_CAM017104_d.JPG,mimic
+CAM017092,https://zenodo.org/record/3082688/files/CAM017092_d.JPG,0,test-2,4525,malleti,4525_CAM017092_d.JPG,mimic
+CAM017091,https://zenodo.org/record/3082688/files/CAM017091_d.JPG,0,test-2,4523,malleti,4523_CAM017091_d.JPG,mimic
+CAM017081,https://zenodo.org/record/3082688/files/CAM017081_d.JPG,0,test-2,4503,malleti,4503_CAM017081_d.JPG,mimic
+CAM017083,https://zenodo.org/record/3082688/files/CAM017083_d.JPG,0,test-2,4507,malleti,4507_CAM017083_d.JPG,mimic
+CAM017089,https://zenodo.org/record/3082688/files/CAM017089_d.JPG,0,test-2,4519,malleti,4519_CAM017089_d.JPG,mimic
+CAM017154,https://zenodo.org/record/3082688/files/CAM017154_d.JPG,0,test-2,4633,malleti,4633_CAM017154_d.JPG,mimic
+CAM017236,https://zenodo.org/record/3082688/files/CAM017236_d.JPG,0,test,4789,notabilis,4789_CAM017236_d.JPG,major
+CAM017237,https://zenodo.org/record/3082688/files/CAM017237_d.JPG,0,test,4791,notabilis,4791_CAM017237_d.JPG,major
+CAM017238,https://zenodo.org/record/3082688/files/CAM017238_d.JPG,0,test,4793,notabilis,4793_CAM017238_d.JPG,major
+CAM017239,https://zenodo.org/record/3082688/files/CAM017239_d.JPG,0,test,4795,notabilis,4795_CAM017239_d.JPG,major
+CAM017216,https://zenodo.org/record/3082688/files/CAM017216_d.JPG,0,test,4749,notabilis,4749_CAM017216_d.JPG,major
+CAM017217,https://zenodo.org/record/3082688/files/CAM017217_d.JPG,0,test,4751,notabilis,4751_CAM017217_d.JPG,major
+CAM017219,https://zenodo.org/record/3082688/files/CAM017219_d.JPG,0,test,4755,notabilis,4755_CAM017219_d.JPG,major
+CAM017228,https://zenodo.org/record/3082688/files/CAM017228_d.JPG,0,test,4773,notabilis,4773_CAM017228_d.JPG,major
+CAM017221,https://zenodo.org/record/3082688/files/CAM017221_d.JPG,0,test,4759,notabilis,4759_CAM017221_d.JPG,major
+CAM017223,https://zenodo.org/record/3082688/files/CAM017223_d.JPG,0,test,4763,notabilis,4763_CAM017223_d.JPG,major
+CAM017227,https://zenodo.org/record/3082688/files/CAM017227_d.JPG,0,test,4771,notabilis,4771_CAM017227_d.JPG,major
+CAM017240,https://zenodo.org/record/3082688/files/CAM017240_d.JPG,0,test,4797,notabilis,4797_CAM017240_d.JPG,major
+CAM017241,https://zenodo.org/record/3082688/files/CAM017241_d.JPG,0,test,4799,notabilis,4799_CAM017241_d.JPG,major
+CAM017259,https://zenodo.org/record/3082688/files/CAM017259_d.JPG,0,test,4830,notabilis,4830_CAM017259_d.JPG,major
+CAM017260,https://zenodo.org/record/3082688/files/CAM017260_d.JPG,0,test,4832,notabilis,4832_CAM017260_d.JPG,major
+CAM017261,https://zenodo.org/record/3082688/files/CAM017261_d.JPG,0,test,4834,notabilis,4834_CAM017261_d.JPG,major
+CAM017262,https://zenodo.org/record/3082688/files/CAM017262_d.JPG,0,test,4836,notabilis,4836_CAM017262_d.JPG,major
+CAM017268,https://zenodo.org/record/3082688/files/CAM017268_d.JPG,0,test-2,4848,malleti,4848_CAM017268_d.JPG,mimic
+CAM017263,https://zenodo.org/record/3082688/files/CAM017263_d.JPG,0,test,4838,notabilis,4838_CAM017263_d.JPG,major
+CAM017254,https://zenodo.org/record/3082688/files/CAM017254_d.JPG,0,test,4825,notabilis,4825_CAM017254_d.JPG,major
+CAM017253,https://zenodo.org/record/3082688/files/CAM017253_d.JPG,0,test,4823,notabilis,4823_CAM017253_d.JPG,major
+CAM017242,https://zenodo.org/record/3082688/files/CAM017242_d.JPG,0,test,4801,notabilis,4801_CAM017242_d.JPG,major
+CAM017243,https://zenodo.org/record/3082688/files/CAM017243_d.JPG,0,test,4803,notabilis,4803_CAM017243_d.JPG,major
+CAM017244,https://zenodo.org/record/3082688/files/CAM017244_d.JPG,0,test,4805,notabilis,4805_CAM017244_d.JPG,major
+CAM017245,https://zenodo.org/record/3082688/files/CAM017245_d.JPG,0,test,4807,notabilis,4807_CAM017245_d.JPG,major
+CAM017247,https://zenodo.org/record/3082688/files/CAM017247_d.JPG,0,test,4811,notabilis,4811_CAM017247_d.JPG,major
+CAM017248,https://zenodo.org/record/3082688/files/CAM017248_d.JPG,0,test,4813,notabilis,4813_CAM017248_d.JPG,major
+CAM017249,https://zenodo.org/record/3082688/files/CAM017249_d.JPG,0,test,4815,notabilis,4815_CAM017249_d.JPG,major
+CAM017250,https://zenodo.org/record/3082688/files/CAM017250_d.JPG,0,test,4817,notabilis,4817_CAM017250_d.JPG,major
+CAM017251,https://zenodo.org/record/3082688/files/CAM017251_d.JPG,0,test,4819,notabilis,4819_CAM017251_d.JPG,major
+CAM017252,https://zenodo.org/record/3082688/files/CAM017252_d.JPG,0,test,4821,notabilis,4821_CAM017252_d.JPG,major
+CAM017246,https://zenodo.org/record/3082688/files/CAM017246_d.JPG,0,test,4809,notabilis,4809_CAM017246_d.JPG,major
+CAM017214,https://zenodo.org/record/3082688/files/CAM017214_d.JPG,0,test,4745,notabilis,4745_CAM017214_d.JPG,major
+CAM017212,https://zenodo.org/record/3082688/files/CAM017212_d.JPG,0,test,4741,notabilis,4741_CAM017212_d.JPG,major
+CAM017176,https://zenodo.org/record/3082688/files/CAM017176_d.JPG,0,test,4672,notabilis,4672_CAM017176_d.JPG,major
+CAM017177,https://zenodo.org/record/3082688/files/CAM017177_d.JPG,0,test,4674,notabilis,4674_CAM017177_d.JPG,major
+CAM017178,https://zenodo.org/record/3082688/files/CAM017178_d.JPG,0,test,4676,notabilis,4676_CAM017178_d.JPG,major
+19N0638,https://zenodo.org/record/4288311/files/19N0638_d.JPG,0,test-2,19932,malleti,19932_19N0638_d.JPG,mimic
+19N0336,https://zenodo.org/record/4288311/files/19N0336_d.JPG,0,test-2,19778,malleti,19778_19N0336_d.JPG,mimic
+19N0341,https://zenodo.org/record/4288311/files/19N0341_d.JPG,0,test-2,19780,malleti,19780_19N0341_d.JPG,mimic
+19N0372,https://zenodo.org/record/4288311/files/19N0372_d.JPG,0,test-2,19786,malleti,19786_19N0372_d.JPG,mimic
+19N0416,https://zenodo.org/record/4288311/files/19N0416_d.JPG,0,test-2,19811,malleti,19811_19N0416_d.JPG,mimic
+19N0437,https://zenodo.org/record/4288311/files/19N0437_d.JPG,0,test-2,19820,malleti,19820_19N0437_d.JPG,mimic
+19N0438,https://zenodo.org/record/4288311/files/19N0438_d.JPG,0,test-2,19822,malleti,19822_19N0438_d.JPG,mimic
+19N0330,https://zenodo.org/record/4288311/files/19N0330_d.JPG,0,test-2,19770,malleti,19770_19N0330_d.JPG,mimic
+19N0325,https://zenodo.org/record/4288311/files/19N0325_d.JPG,0,test-2,19766,malleti,19766_19N0325_d.JPG,mimic
+19N0288,https://zenodo.org/record/4288311/files/19N0288_d.JPG,0,test-2,19720,malleti,19720_19N0288_d.JPG,mimic
+19N0291,https://zenodo.org/record/4288311/files/19N0291_d.JPG,0,test-2,19722,malleti,19722_19N0291_d.JPG,mimic
+19N0298,https://zenodo.org/record/4288311/files/19N0298_d.JPG,0,test-2,19730,malleti,19730_19N0298_d.JPG,mimic
+19N0299,https://zenodo.org/record/4288311/files/19N0299_d.JPG,0,test-2,19732,malleti,19732_19N0299_d.JPG,mimic
+19N0301,https://zenodo.org/record/4288311/files/19N0301_d.JPG,0,test-2,19734,malleti,19734_19N0301_d.JPG,mimic
+19N0302,https://zenodo.org/record/4288311/files/19N0302_d.JPG,0,test-2,19736,malleti,19736_19N0302_d.JPG,mimic
+19N0439,https://zenodo.org/record/4288311/files/19N0439_d.JPG,0,test-2,19824,malleti,19824_19N0439_d.JPG,mimic
+19N0306,https://zenodo.org/record/4288311/files/19N0306_d.JPG,0,test-2,19744,malleti,19744_19N0306_d.JPG,mimic
+19N0314,https://zenodo.org/record/4288311/files/19N0314_d.JPG,0,test-2,19750,malleti,19750_19N0314_d.JPG,mimic
+19N0315,https://zenodo.org/record/4288311/files/19N0315_d.JPG,0,test-2,19752,malleti,19752_19N0315_d.JPG,mimic
+19N0317,https://zenodo.org/record/4288311/files/19N0317_d.JPG,0,test-2,19754,malleti,19754_19N0317_d.JPG,mimic
+19N0323,https://zenodo.org/record/4288311/files/19N0323_d.JPG,0,test-2,19762,malleti,19762_19N0323_d.JPG,mimic
+19N0324,https://zenodo.org/record/4288311/files/19N0324_d.JPG,0,test-2,19764,malleti,19764_19N0324_d.JPG,mimic
+19N0304,https://zenodo.org/record/4288311/files/19N0304_d.JPG,0,test-2,19740,malleti,19740_19N0304_d.JPG,mimic
+19N0575,https://zenodo.org/record/4288311/files/19N0575_d.JPG,0,test-2,19896,malleti,19896_19N0575_d.JPG,mimic
+19N0582,https://zenodo.org/record/4288311/files/19N0582_d.JPG,0,test-2,19898,malleti,19898_19N0582_d.JPG,mimic
+19N0583,https://zenodo.org/record/4288311/files/19N0583_d.JPG,0,test-2,19900,malleti,19900_19N0583_d.JPG,mimic
+19N0584,https://zenodo.org/record/4288311/files/19N0584_d.JPG,0,test-2,19902,malleti,19902_19N0584_d.JPG,mimic
+19N0599,https://zenodo.org/record/4288311/files/19N0599_d.JPG,0,test-2,19906,malleti,19906_19N0599_d.JPG,mimic
+19N0608,https://zenodo.org/record/4288311/files/19N0608_d.JPG,0,test-2,19908,malleti,19908_19N0608_d.JPG,mimic
+19N0613,https://zenodo.org/record/4288311/files/19N0613_d.JPG,0,test-2,19910,malleti,19910_19N0613_d.JPG,mimic
+19N0614,https://zenodo.org/record/4288311/files/19N0614_d.JPG,0,test-2,19912,malleti,19912_19N0614_d.JPG,mimic
+19N0615,https://zenodo.org/record/4288311/files/19N0615_d.JPG,0,test-2,19914,malleti,19914_19N0615_d.JPG,mimic
+19N0624,https://zenodo.org/record/4288311/files/19N0624_d.JPG,0,test-2,19916,malleti,19916_19N0624_d.JPG,mimic
+19N0630,https://zenodo.org/record/4288311/files/19N0630_d.JPG,0,test-2,19920,malleti,19920_19N0630_d.JPG,mimic
+19N0660,https://zenodo.org/record/4288311/files/19N0660_d.JPG,0,test-2,19950,malleti,19950_19N0660_d.JPG,mimic
+19N0659,https://zenodo.org/record/4288311/files/19N0659_d.JPG,0,test-2,19948,malleti,19948_19N0659_d.JPG,mimic
+19N0658,https://zenodo.org/record/4288311/files/19N0658_d.JPG,0,test-2,19946,malleti,19946_19N0658_d.JPG,mimic
+19N0657,https://zenodo.org/record/4288311/files/19N0657_d.JPG,0,test-2,19944,malleti,19944_19N0657_d.JPG,mimic
+19N0648,https://zenodo.org/record/4288311/files/19N0648_d.JPG,0,test-2,19942,malleti,19942_19N0648_d.JPG,mimic
+19N0646,https://zenodo.org/record/4288311/files/19N0646_d.JPG,0,test-2,19938,malleti,19938_19N0646_d.JPG,mimic
+19N0640,https://zenodo.org/record/4288311/files/19N0640_d.JPG,0,test-2,19936,malleti,19936_19N0640_d.JPG,mimic
+19N0639,https://zenodo.org/record/4288311/files/19N0639_d.JPG,0,test-2,19934,malleti,19934_19N0639_d.JPG,mimic
+19N0564,https://zenodo.org/record/4288311/files/19N0564_d.JPG,0,test-2,19890,malleti,19890_19N0564_d.JPG,mimic
+19N0635,https://zenodo.org/record/4288311/files/19N0635_d.JPG,0,test-2,19930,malleti,19930_19N0635_d.JPG,mimic
+19N0528,https://zenodo.org/record/4288311/files/19N0528_d.JPG,0,test-2,19882,malleti,19882_19N0528_d.JPG,mimic
+19N0647,https://zenodo.org/record/4288311/files/19N0647_d.JPG,0,test-2,19940,malleti,19940_19N0647_d.JPG,mimic
+19N0144,https://zenodo.org/record/4288311/files/19N0144_d.JPG,0,test-2,19433,malleti,19433_19N0144_d.JPG,mimic
+19N1063,https://zenodo.org/record/4288311/files/19N1063_d.JPG,0,test-2,20170,malleti,20170_19N1063_d.JPG,mimic
+19N1037,https://zenodo.org/record/4288311/files/19N1037_d.JPG,0,test-2,20166,malleti,20166_19N1037_d.JPG,mimic
+19N1034,https://zenodo.org/record/4288311/files/19N1034_d.JPG,0,test-2,20159,malleti,20159_19N1034_d.JPG,mimic
+19N1020,https://zenodo.org/record/4288311/files/19N1020_d.JPG,0,test-2,20155,malleti,20155_19N1020_d.JPG,mimic
+19N1018,https://zenodo.org/record/4288311/files/19N1018_d.JPG,0,test-2,20151,malleti,20151_19N1018_d.JPG,mimic
+19N1065,https://zenodo.org/record/4288311/files/19N1065_d.JPG,0,test-2,20174,malleti,20174_19N1065_d.JPG,mimic
+19N0982,https://zenodo.org/record/4288311/files/19N0982_d.JPG,0,test-2,20137,malleti,20137_19N0982_d.JPG,mimic
+19N0981,https://zenodo.org/record/4288311/files/19N0981_d.JPG,0,test-2,20135,malleti,20135_19N0981_d.JPG,mimic
+19N0957,https://zenodo.org/record/4288311/files/19N0957_d.JPG,0,test-2,20126,malleti,20126_19N0957_d.JPG,mimic
+19N0956,https://zenodo.org/record/4288311/files/19N0956_d.JPG,0,test-2,20124,malleti,20124_19N0956_d.JPG,mimic
+19N0955,https://zenodo.org/record/4288311/files/19N0955_d.JPG,0,test-2,20122,malleti,20122_19N0955_d.JPG,mimic
+19N0954,https://zenodo.org/record/4288311/files/19N0954_d.JPG,0,test-2,20120,malleti,20120_19N0954_d.JPG,mimic
+19N0953,https://zenodo.org/record/4288311/files/19N0953_d.JPG,0,test-2,20118,malleti,20118_19N0953_d.JPG,mimic
+19N0948,https://zenodo.org/record/4288311/files/19N0948_d.JPG,0,test-2,20116,malleti,20116_19N0948_d.JPG,mimic
+19N0946,https://zenodo.org/record/4288311/files/19N0946_d.JPG,0,test-2,20112,malleti,20112_19N0946_d.JPG,mimic
+19N0983,https://zenodo.org/record/4288311/files/19N0983_d.JPG,0,test-2,20139,malleti,20139_19N0983_d.JPG,mimic
+19N1095,https://zenodo.org/record/4288311/files/19N1095_d.JPG,0,test-2,20180,malleti,20180_19N1095_d.JPG,mimic
+19N1237,https://zenodo.org/record/4288311/files/19N1237_d.JPG,0,test-2,20247,malleti,20247_19N1237_d.JPG,mimic
+19N1236,https://zenodo.org/record/4288311/files/19N1236_d.JPG,0,test-2,20245,malleti,20245_19N1236_d.JPG,mimic
+15N309,https://zenodo.org/record/4289223/files/15N309_d.JPG,0,test,15228,venus,15228_15N309_d.JPG,minor
+15N323,https://zenodo.org/record/4289223/files/15N323_d.JPG,0,test,15232,venus,15232_15N323_d.JPG,minor
+15N320,https://zenodo.org/record/4289223/files/15N320_d.JPG,0,test,15230,venus,15230_15N320_d.JPG,minor
+15N104,https://zenodo.org/record/4289223/files/15N104_d.JPG,1,test,15165,venus x chestertonii,15165_15N104_d.JPG,minor
+CAM041538,https://zenodo.org/record/4291095/files/CAM041538_d.JPG,0,test,39124,lativitta,39124_CAM041538_d.JPG,major
+CAM041537,https://zenodo.org/record/4291095/files/CAM041537_d.JPG,0,test,39120,lativitta,39120_CAM041537_d.JPG,major
+CAM041536,https://zenodo.org/record/4291095/files/CAM041536_d.JPG,0,test,39116,lativitta,39116_CAM041536_d.JPG,major
+CAM041491,https://zenodo.org/record/4291095/files/CAM041491_d.JPG,0,test,38936,lativitta,38936_CAM041491_d.JPG,major
+CAM041479,https://zenodo.org/record/4291095/files/CAM041479_d.JPG,0,test,38888,lativitta,38888_CAM041479_d.JPG,major
+CAM041478,https://zenodo.org/record/4291095/files/CAM041478_d.JPG,0,test,38880,lativitta,38880_CAM041478_d.JPG,major
+CAM041476,https://zenodo.org/record/4291095/files/CAM041476_d.JPG,0,test,38872,lativitta,38872_CAM041476_d.JPG,major
+CAM041386,https://zenodo.org/record/4291095/files/CAM041386_d.JPG,0,test,38524,lativitta,38524_CAM041386_d.JPG,major
+CAM041385,https://zenodo.org/record/4291095/files/CAM041385_d.JPG,0,test,38520,lativitta,38520_CAM041385_d.JPG,major
+CAM041384,https://zenodo.org/record/4291095/files/CAM041384_d.JPG,0,test,38516,lativitta,38516_CAM041384_d.JPG,major
+CAM041383,https://zenodo.org/record/4291095/files/CAM041383_d.JPG,0,test,38512,lativitta,38512_CAM041383_d.JPG,major
+CAM041382,https://zenodo.org/record/4291095/files/CAM041382_d.JPG,0,test,38508,lativitta,38508_CAM041382_d.JPG,major
+CAM041381,https://zenodo.org/record/4291095/files/CAM041381_d.JPG,0,test,38504,lativitta,38504_CAM041381_d.JPG,major
+CAM041380,https://zenodo.org/record/4291095/files/CAM041380_d.JPG,0,test,38500,lativitta,38500_CAM041380_d.JPG,major
+CAM041379,https://zenodo.org/record/4291095/files/CAM041379_d.JPG,0,test,38496,lativitta,38496_CAM041379_d.JPG,major
+CAM041378,https://zenodo.org/record/4291095/files/CAM041378_d.JPG,0,test,38492,lativitta,38492_CAM041378_d.JPG,major
+CAM041698,https://zenodo.org/record/4291095/files/CAM041698_d.JPG,0,test,39759,lativitta,39759_CAM041698_d.JPG,major
+CAM041366,https://zenodo.org/record/4291095/files/CAM041366_d.JPG,0,test,38444,lativitta,38444_CAM041366_d.JPG,major
+CAM041365,https://zenodo.org/record/4291095/files/CAM041365_d.JPG,0,test,38440,lativitta,38440_CAM041365_d.JPG,major
+CAM041364,https://zenodo.org/record/4291095/files/CAM041364_d.JPG,0,test,38436,lativitta,38436_CAM041364_d.JPG,major
+CAM041363,https://zenodo.org/record/4291095/files/CAM041363_d.JPG,0,test,38432,lativitta,38432_CAM041363_d.JPG,major
+CAM041362,https://zenodo.org/record/4291095/files/CAM041362_d.JPG,0,test,38428,lativitta,38428_CAM041362_d.JPG,major
+CAM041361,https://zenodo.org/record/4291095/files/CAM041361_d.JPG,0,test,38424,lativitta,38424_CAM041361_d.JPG,major
+CAM041360,https://zenodo.org/record/4291095/files/CAM041360_d.JPG,0,test,38420,lativitta,38420_CAM041360_d.JPG,major
+CAM041359,https://zenodo.org/record/4291095/files/CAM041359_d.JPG,0,test,38416,lativitta,38416_CAM041359_d.JPG,major
+CAM041387,https://zenodo.org/record/4291095/files/CAM041387_d.JPG,0,test,38528,lativitta,38528_CAM041387_d.JPG,major
+CAM041586,https://zenodo.org/record/4291095/files/CAM041586_d.JPG,0,test,39311,lativitta,39311_CAM041586_d.JPG,major
+CAM041388,https://zenodo.org/record/4291095/files/CAM041388_d.JPG,0,test,38532,lativitta,38532_CAM041388_d.JPG,major
+CAM041393,https://zenodo.org/record/4291095/files/CAM041393_d.JPG,0,test,38544,lativitta,38544_CAM041393_d.JPG,major
+CAM041473,https://zenodo.org/record/4291095/files/CAM041473_d.JPG,0,test,38864,lativitta,38864_CAM041473_d.JPG,major
+CAM041472,https://zenodo.org/record/4291095/files/CAM041472_d.JPG,0,test,38860,lativitta,38860_CAM041472_d.JPG,major
+CAM041467,https://zenodo.org/record/4291095/files/CAM041467_d.JPG,0,test,38840,lativitta,38840_CAM041467_d.JPG,major
+CAM041442,https://zenodo.org/record/4291095/files/CAM041442_d.JPG,0,test,38740,lativitta,38740_CAM041442_d.JPG,major
+CAM041441,https://zenodo.org/record/4291095/files/CAM041441_d.JPG,0,test,38736,lativitta,38736_CAM041441_d.JPG,major
+CAM041440,https://zenodo.org/record/4291095/files/CAM041440_d.JPG,0,test,38732,lativitta,38732_CAM041440_d.JPG,major
+CAM041439,https://zenodo.org/record/4291095/files/CAM041439_d.JPG,0,test,38728,lativitta,38728_CAM041439_d.JPG,major
+CAM041438,https://zenodo.org/record/4291095/files/CAM041438_d.JPG,0,test,38724,lativitta,38724_CAM041438_d.JPG,major
+CAM041437,https://zenodo.org/record/4291095/files/CAM041437_d.JPG,0,test,38720,lativitta,38720_CAM041437_d.JPG,major
+CAM041436,https://zenodo.org/record/4291095/files/CAM041436_d.JPG,0,test,38716,lativitta,38716_CAM041436_d.JPG,major
+CAM041435,https://zenodo.org/record/4291095/files/CAM041435_d.JPG,0,test,38712,lativitta,38712_CAM041435_d.JPG,major
+CAM041434,https://zenodo.org/record/4291095/files/CAM041434_d.JPG,0,test,38708,lativitta,38708_CAM041434_d.JPG,major
+CAM041433,https://zenodo.org/record/4291095/files/CAM041433_d.JPG,0,test,38704,lativitta,38704_CAM041433_d.JPG,major
+CAM041432,https://zenodo.org/record/4291095/files/CAM041432_d.JPG,0,test,38700,lativitta,38700_CAM041432_d.JPG,major
+CAM041431,https://zenodo.org/record/4291095/files/CAM041431_d.JPG,0,test,38696,lativitta,38696_CAM041431_d.JPG,major
+CAM041430,https://zenodo.org/record/4291095/files/CAM041430_d.JPG,0,test,38692,lativitta,38692_CAM041430_d.JPG,major
+CAM041429,https://zenodo.org/record/4291095/files/CAM041429_d.JPG,0,test,38688,lativitta,38688_CAM041429_d.JPG,major
+CAM041428,https://zenodo.org/record/4291095/files/CAM041428_d.JPG,0,test,38684,lativitta,38684_CAM041428_d.JPG,major
+CAM041390,https://zenodo.org/record/4291095/files/CAM041390_d.JPG,0,test,38540,lativitta,38540_CAM041390_d.JPG,major
+CAM041358,https://zenodo.org/record/4291095/files/CAM041358_d.JPG,0,test,38412,lativitta,38412_CAM041358_d.JPG,major
+CAM041591,https://zenodo.org/record/4291095/files/CAM041591_d.JPG,0,test,39331,lativitta,39331_CAM041591_d.JPG,major
+CAM041667,https://zenodo.org/record/4291095/files/CAM041667_d.JPG,0,test,39635,lativitta,39635_CAM041667_d.JPG,major
+CAM041666,https://zenodo.org/record/4291095/files/CAM041666_d.JPG,0,test,39631,lativitta,39631_CAM041666_d.JPG,major
+CAM041665,https://zenodo.org/record/4291095/files/CAM041665_d.JPG,0,test,39627,lativitta,39627_CAM041665_d.JPG,major
+CAM041664,https://zenodo.org/record/4291095/files/CAM041664_d.JPG,0,test,39623,lativitta,39623_CAM041664_d.JPG,major
+CAM041663,https://zenodo.org/record/4291095/files/CAM041663_d.JPG,0,test,39619,lativitta,39619_CAM041663_d.JPG,major
+CAM041662,https://zenodo.org/record/4291095/files/CAM041662_d.JPG,0,test,39615,lativitta,39615_CAM041662_d.JPG,major
+CAM041661,https://zenodo.org/record/4291095/files/CAM041661_d.JPG,0,test,39611,lativitta,39611_CAM041661_d.JPG,major
+CAM041660,https://zenodo.org/record/4291095/files/CAM041660_d.JPG,0,test,39607,lativitta,39607_CAM041660_d.JPG,major
+CAM041659,https://zenodo.org/record/4291095/files/CAM041659_d.JPG,0,test,39603,lativitta,39603_CAM041659_d.JPG,major
+CAM041658,https://zenodo.org/record/4291095/files/CAM041658_d.JPG,0,test,39599,lativitta,39599_CAM041658_d.JPG,major
+CAM041668,https://zenodo.org/record/4291095/files/CAM041668_d.JPG,0,test,39639,lativitta,39639_CAM041668_d.JPG,major
+CAM041657,https://zenodo.org/record/4291095/files/CAM041657_d.JPG,0,test,39595,lativitta,39595_CAM041657_d.JPG,major
+CAM041655,https://zenodo.org/record/4291095/files/CAM041655_d.JPG,0,test,39587,lativitta,39587_CAM041655_d.JPG,major
+CAM041654,https://zenodo.org/record/4291095/files/CAM041654_d.JPG,0,test,39583,lativitta,39583_CAM041654_d.JPG,major
+CAM041653,https://zenodo.org/record/4291095/files/CAM041653_d.JPG,0,test,39579,lativitta,39579_CAM041653_d.JPG,major
+CAM041652,https://zenodo.org/record/4291095/files/CAM041652_d.JPG,0,test,39575,lativitta,39575_CAM041652_d.JPG,major
+CAM041651,https://zenodo.org/record/4291095/files/CAM041651_d.JPG,0,test,39571,lativitta,39571_CAM041651_d.JPG,major
+CAM041650,https://zenodo.org/record/4291095/files/CAM041650_d.JPG,0,test,39567,lativitta,39567_CAM041650_d.JPG,major
+CAM041649,https://zenodo.org/record/4291095/files/CAM041649_d.JPG,0,test,39563,lativitta,39563_CAM041649_d.JPG,major
+CAM041648,https://zenodo.org/record/4291095/files/CAM041648_d.JPG,0,test,39559,lativitta,39559_CAM041648_d.JPG,major
+CAM041647,https://zenodo.org/record/4291095/files/CAM041647_d.JPG,0,test,39555,lativitta,39555_CAM041647_d.JPG,major
+CAM041646,https://zenodo.org/record/4291095/files/CAM041646_d.JPG,0,test,39551,lativitta,39551_CAM041646_d.JPG,major
+CAM041656,https://zenodo.org/record/4291095/files/CAM041656_d.JPG,0,test,39591,lativitta,39591_CAM041656_d.JPG,major
+CAM041669,https://zenodo.org/record/4291095/files/CAM041669_d.JPG,0,test,39643,lativitta,39643_CAM041669_d.JPG,major
+CAM041670,https://zenodo.org/record/4291095/files/CAM041670_d.JPG,0,test,39647,lativitta,39647_CAM041670_d.JPG,major
+CAM041671,https://zenodo.org/record/4291095/files/CAM041671_d.JPG,0,test,39651,lativitta,39651_CAM041671_d.JPG,major
+CAM041699,https://zenodo.org/record/4291095/files/CAM041699_d.JPG,0,test,39763,lativitta,39763_CAM041699_d.JPG,major
+CAM041697,https://zenodo.org/record/4291095/files/CAM041697_d.JPG,0,test,39755,lativitta,39755_CAM041697_d.JPG,major
+CAM041696,https://zenodo.org/record/4291095/files/CAM041696_d.JPG,0,test,39751,lativitta,39751_CAM041696_d.JPG,major
+CAM041695,https://zenodo.org/record/4291095/files/CAM041695_d.JPG,0,test,39747,lativitta,39747_CAM041695_d.JPG,major
+CAM041694,https://zenodo.org/record/4291095/files/CAM041694_d.JPG,0,test,39743,lativitta,39743_CAM041694_d.JPG,major
+CAM041693,https://zenodo.org/record/4291095/files/CAM041693_d.JPG,0,test,39739,lativitta,39739_CAM041693_d.JPG,major
+CAM041692,https://zenodo.org/record/4291095/files/CAM041692_d.JPG,0,test,39735,lativitta,39735_CAM041692_d.JPG,major
+CAM041691,https://zenodo.org/record/4291095/files/CAM041691_d.JPG,0,test,39731,lativitta,39731_CAM041691_d.JPG,major
+CAM041690,https://zenodo.org/record/4291095/files/CAM041690_d.JPG,0,test,39727,lativitta,39727_CAM041690_d.JPG,major
+CAM041689,https://zenodo.org/record/4291095/files/CAM041689_d.JPG,0,test,39723,lativitta,39723_CAM041689_d.JPG,major
+CAM041685,https://zenodo.org/record/4291095/files/CAM041685_d.JPG,0,test,39707,lativitta,39707_CAM041685_d.JPG,major
+CAM041684,https://zenodo.org/record/4291095/files/CAM041684_d.JPG,0,test,39703,lativitta,39703_CAM041684_d.JPG,major
+CAM041683,https://zenodo.org/record/4291095/files/CAM041683_d.JPG,0,test,39699,lativitta,39699_CAM041683_d.JPG,major
+CAM041682,https://zenodo.org/record/4291095/files/CAM041682_d.JPG,0,test,39695,lativitta,39695_CAM041682_d.JPG,major
+CAM041680,https://zenodo.org/record/4291095/files/CAM041680_d.JPG,0,test,39687,lativitta,39687_CAM041680_d.JPG,major
+CAM041679,https://zenodo.org/record/4291095/files/CAM041679_d.JPG,0,test,39683,lativitta,39683_CAM041679_d.JPG,major
+CAM041678,https://zenodo.org/record/4291095/files/CAM041678_d.JPG,0,test,39679,lativitta,39679_CAM041678_d.JPG,major
+CAM041677,https://zenodo.org/record/4291095/files/CAM041677_d.JPG,0,test,39675,lativitta,39675_CAM041677_d.JPG,major
+CAM041676,https://zenodo.org/record/4291095/files/CAM041676_d.JPG,0,test,39671,lativitta,39671_CAM041676_d.JPG,major
+CAM041675,https://zenodo.org/record/4291095/files/CAM041675_d.JPG,0,test,39667,lativitta,39667_CAM041675_d.JPG,major
+CAM041674,https://zenodo.org/record/4291095/files/CAM041674_d.JPG,0,test,39663,lativitta,39663_CAM041674_d.JPG,major
+CAM041673,https://zenodo.org/record/4291095/files/CAM041673_d.JPG,0,test,39659,lativitta,39659_CAM041673_d.JPG,major
+CAM041672,https://zenodo.org/record/4291095/files/CAM041672_d.JPG,0,test,39655,lativitta,39655_CAM041672_d.JPG,major
+CAM041645,https://zenodo.org/record/4291095/files/CAM041645_d.JPG,0,test,39547,lativitta,39547_CAM041645_d.JPG,major
+CAM041644,https://zenodo.org/record/4291095/files/CAM041644_d.JPG,0,test,39543,lativitta,39543_CAM041644_d.JPG,major
+CAM041643,https://zenodo.org/record/4291095/files/CAM041643_d.JPG,0,test,39539,lativitta,39539_CAM041643_d.JPG,major
+CAM041642,https://zenodo.org/record/4291095/files/CAM041642_d.JPG,0,test,39535,lativitta,39535_CAM041642_d.JPG,major
+CAM041614,https://zenodo.org/record/4291095/files/CAM041614_d.JPG,0,test,39423,lativitta,39423_CAM041614_d.JPG,major
+CAM041613,https://zenodo.org/record/4291095/files/CAM041613_d.JPG,0,test,39419,lativitta,39419_CAM041613_d.JPG,major
+CAM041612,https://zenodo.org/record/4291095/files/CAM041612_d.JPG,0,test,39415,lativitta,39415_CAM041612_d.JPG,major
+CAM041611,https://zenodo.org/record/4291095/files/CAM041611_d.JPG,0,test,39411,lativitta,39411_CAM041611_d.JPG,major
+CAM041610,https://zenodo.org/record/4291095/files/CAM041610_d.JPG,0,test,39407,lativitta,39407_CAM041610_d.JPG,major
+CAM041609,https://zenodo.org/record/4291095/files/CAM041609_d.JPG,0,test,39403,lativitta,39403_CAM041609_d.JPG,major
+CAM041608,https://zenodo.org/record/4291095/files/CAM041608_d.JPG,0,test,39399,lativitta,39399_CAM041608_d.JPG,major
+CAM041607,https://zenodo.org/record/4291095/files/CAM041607_d.JPG,0,test,39395,lativitta,39395_CAM041607_d.JPG,major
+CAM041606,https://zenodo.org/record/4291095/files/CAM041606_d.JPG,0,test,39391,lativitta,39391_CAM041606_d.JPG,major
+CAM041605,https://zenodo.org/record/4291095/files/CAM041605_d.JPG,0,test,39387,lativitta,39387_CAM041605_d.JPG,major
+CAM041604,https://zenodo.org/record/4291095/files/CAM041604_d.JPG,0,test,39383,lativitta,39383_CAM041604_d.JPG,major
+CAM041603,https://zenodo.org/record/4291095/files/CAM041603_d.JPG,0,test,39379,lativitta,39379_CAM041603_d.JPG,major
+CAM041602,https://zenodo.org/record/4291095/files/CAM041602_d.JPG,0,test,39375,lativitta,39375_CAM041602_d.JPG,major
+CAM041601,https://zenodo.org/record/4291095/files/CAM041601_d.JPG,0,test,39371,lativitta,39371_CAM041601_d.JPG,major
+CAM041600,https://zenodo.org/record/4291095/files/CAM041600_d.JPG,0,test,39367,lativitta,39367_CAM041600_d.JPG,major
+CAM041599,https://zenodo.org/record/4291095/files/CAM041599_d.JPG,0,test,39363,lativitta,39363_CAM041599_d.JPG,major
+CAM041598,https://zenodo.org/record/4291095/files/CAM041598_d.JPG,0,test,39359,lativitta,39359_CAM041598_d.JPG,major
+CAM041597,https://zenodo.org/record/4291095/files/CAM041597_d.JPG,0,test,39355,lativitta,39355_CAM041597_d.JPG,major
+CAM041596,https://zenodo.org/record/4291095/files/CAM041596_d.JPG,0,test,39351,lativitta,39351_CAM041596_d.JPG,major
+CAM041595,https://zenodo.org/record/4291095/files/CAM041595_d.JPG,0,test,39347,lativitta,39347_CAM041595_d.JPG,major
+CAM041594,https://zenodo.org/record/4291095/files/CAM041594_d.JPG,0,test,39343,lativitta,39343_CAM041594_d.JPG,major
+CAM041593,https://zenodo.org/record/4291095/files/CAM041593_d.JPG,0,test,39339,lativitta,39339_CAM041593_d.JPG,major
+CAM041592,https://zenodo.org/record/4291095/files/CAM041592_d.JPG,0,test,39335,lativitta,39335_CAM041592_d.JPG,major
+CAM041615,https://zenodo.org/record/4291095/files/CAM041615_d.JPG,0,test,39427,lativitta,39427_CAM041615_d.JPG,major
+CAM041616,https://zenodo.org/record/4291095/files/CAM041616_d.JPG,0,test,39431,lativitta,39431_CAM041616_d.JPG,major
+CAM041618,https://zenodo.org/record/4291095/files/CAM041618_d.JPG,0,test,39439,lativitta,39439_CAM041618_d.JPG,major
+CAM041641,https://zenodo.org/record/4291095/files/CAM041641_d.JPG,0,test,39531,lativitta,39531_CAM041641_d.JPG,major
+CAM041640,https://zenodo.org/record/4291095/files/CAM041640_d.JPG,0,test,39527,lativitta,39527_CAM041640_d.JPG,major
+CAM041639,https://zenodo.org/record/4291095/files/CAM041639_d.JPG,0,test,39523,lativitta,39523_CAM041639_d.JPG,major
+CAM041638,https://zenodo.org/record/4291095/files/CAM041638_d.JPG,0,test,39519,lativitta,39519_CAM041638_d.JPG,major
+CAM041637,https://zenodo.org/record/4291095/files/CAM041637_d.JPG,0,test,39515,lativitta,39515_CAM041637_d.JPG,major
+CAM041636,https://zenodo.org/record/4291095/files/CAM041636_d.JPG,0,test,39511,lativitta,39511_CAM041636_d.JPG,major
+CAM041635,https://zenodo.org/record/4291095/files/CAM041635_d.JPG,0,test,39507,lativitta,39507_CAM041635_d.JPG,major
+CAM041634,https://zenodo.org/record/4291095/files/CAM041634_d.JPG,0,test,39503,lativitta,39503_CAM041634_d.JPG,major
+CAM041633,https://zenodo.org/record/4291095/files/CAM041633_d.JPG,0,test,39499,lativitta,39499_CAM041633_d.JPG,major
+CAM041632,https://zenodo.org/record/4291095/files/CAM041632_d.JPG,0,test,39495,lativitta,39495_CAM041632_d.JPG,major
+CAM041631,https://zenodo.org/record/4291095/files/CAM041631_d.JPG,0,test,39491,lativitta,39491_CAM041631_d.JPG,major
+CAM041630,https://zenodo.org/record/4291095/files/CAM041630_d.JPG,0,test,39487,lativitta,39487_CAM041630_d.JPG,major
+CAM041629,https://zenodo.org/record/4291095/files/CAM041629_d.JPG,0,test,39483,lativitta,39483_CAM041629_d.JPG,major
+CAM041628,https://zenodo.org/record/4291095/files/CAM041628_d.JPG,0,test,39479,lativitta,39479_CAM041628_d.JPG,major
+CAM041627,https://zenodo.org/record/4291095/files/CAM041627_d.JPG,0,test,39475,lativitta,39475_CAM041627_d.JPG,major
+CAM041626,https://zenodo.org/record/4291095/files/CAM041626_d.JPG,0,test,39471,lativitta,39471_CAM041626_d.JPG,major
+CAM041625,https://zenodo.org/record/4291095/files/CAM041625_d.JPG,0,test,39467,lativitta,39467_CAM041625_d.JPG,major
+CAM041624,https://zenodo.org/record/4291095/files/CAM041624_d.JPG,0,test,39463,lativitta,39463_CAM041624_d.JPG,major
+CAM041623,https://zenodo.org/record/4291095/files/CAM041623_d.JPG,0,test,39459,lativitta,39459_CAM041623_d.JPG,major
+CAM041622,https://zenodo.org/record/4291095/files/CAM041622_d.JPG,0,test,39455,lativitta,39455_CAM041622_d.JPG,major
+CAM041621,https://zenodo.org/record/4291095/files/CAM041621_d.JPG,0,test,39451,lativitta,39451_CAM041621_d.JPG,major
+CAM041620,https://zenodo.org/record/4291095/files/CAM041620_d.JPG,0,test,39447,lativitta,39447_CAM041620_d.JPG,major
+CAM041619,https://zenodo.org/record/4291095/files/CAM041619_d.JPG,0,test,39443,lativitta,39443_CAM041619_d.JPG,major
+CAM041617,https://zenodo.org/record/4291095/files/CAM041617_d.JPG,0,test,39435,lativitta,39435_CAM041617_d.JPG,major
+CAM041357,https://zenodo.org/record/4291095/files/CAM041357_d.JPG,0,test,38408,lativitta,38408_CAM041357_d.JPG,major
+CAM041389,https://zenodo.org/record/4291095/files/CAM041389_d.JPG,0,test,38536,lativitta,38536_CAM041389_d.JPG,major
+CAM041355,https://zenodo.org/record/4291095/files/CAM041355_d.JPG,0,test,38400,lativitta,38400_CAM041355_d.JPG,major
+CAM041777,https://zenodo.org/record/4291095/files/CAM041777_d.JPG,0,test,40075,lativitta,40075_CAM041777_d.JPG,major
+CAM041776,https://zenodo.org/record/4291095/files/CAM041776_d.JPG,0,test,40071,lativitta,40071_CAM041776_d.JPG,major
+CAM041775,https://zenodo.org/record/4291095/files/CAM041775_d.JPG,0,test,40067,lativitta,40067_CAM041775_d.JPG,major
+CAM041774,https://zenodo.org/record/4291095/files/CAM041774_d.JPG,0,test,40063,lativitta,40063_CAM041774_d.JPG,major
+CAM041773,https://zenodo.org/record/4291095/files/CAM041773_d.JPG,0,test,40059,lativitta,40059_CAM041773_d.JPG,major
+CAM041772,https://zenodo.org/record/4291095/files/CAM041772_d.JPG,0,test,40055,lativitta,40055_CAM041772_d.JPG,major
+CAM041771,https://zenodo.org/record/4291095/files/CAM041771_d.JPG,0,test,40051,lativitta,40051_CAM041771_d.JPG,major
+CAM041770,https://zenodo.org/record/4291095/files/CAM041770_d.JPG,0,test,40047,lativitta,40047_CAM041770_d.JPG,major
+CAM041769,https://zenodo.org/record/4291095/files/CAM041769_d.JPG,0,test,40043,lativitta,40043_CAM041769_d.JPG,major
+CAM041768,https://zenodo.org/record/4291095/files/CAM041768_d.JPG,0,test,40039,lativitta,40039_CAM041768_d.JPG,major
+CAM041767,https://zenodo.org/record/4291095/files/CAM041767_d.JPG,0,test,40035,lativitta,40035_CAM041767_d.JPG,major
+CAM041766,https://zenodo.org/record/4291095/files/CAM041766_d.JPG,0,test,40031,lativitta,40031_CAM041766_d.JPG,major
+CAM041765,https://zenodo.org/record/4291095/files/CAM041765_d.JPG,0,test,40027,lativitta,40027_CAM041765_d.JPG,major
+CAM041764,https://zenodo.org/record/4291095/files/CAM041764_d.JPG,0,test,40023,lativitta,40023_CAM041764_d.JPG,major
+CAM041763,https://zenodo.org/record/4291095/files/CAM041763_d.JPG,0,test,40019,lativitta,40019_CAM041763_d.JPG,major
+CAM041762,https://zenodo.org/record/4291095/files/CAM041762_d.JPG,0,test,40015,lativitta,40015_CAM041762_d.JPG,major
+CAM041761,https://zenodo.org/record/4291095/files/CAM041761_d.JPG,0,test,40011,lativitta,40011_CAM041761_d.JPG,major
+CAM041760,https://zenodo.org/record/4291095/files/CAM041760_d.JPG,0,test,40007,lativitta,40007_CAM041760_d.JPG,major
+CAM041759,https://zenodo.org/record/4291095/files/CAM041759_d.JPG,0,test,40003,lativitta,40003_CAM041759_d.JPG,major
+CAM041758,https://zenodo.org/record/4291095/files/CAM041758_d.JPG,0,test,39999,lativitta,39999_CAM041758_d.JPG,major
+CAM041757,https://zenodo.org/record/4291095/files/CAM041757_d.JPG,0,test,39995,lativitta,39995_CAM041757_d.JPG,major
+CAM041756,https://zenodo.org/record/4291095/files/CAM041756_d.JPG,0,test,39991,lativitta,39991_CAM041756_d.JPG,major
+CAM041755,https://zenodo.org/record/4291095/files/CAM041755_d.JPG,0,test,39987,lativitta,39987_CAM041755_d.JPG,major
+CAM041778,https://zenodo.org/record/4291095/files/CAM041778_d.JPG,0,test,40079,lativitta,40079_CAM041778_d.JPG,major
+CAM041754,https://zenodo.org/record/4291095/files/CAM041754_d.JPG,0,test,39983,lativitta,39983_CAM041754_d.JPG,major
+CAM041356,https://zenodo.org/record/4291095/files/CAM041356_d.JPG,0,test,38404,lativitta,38404_CAM041356_d.JPG,major
+CAM041781,https://zenodo.org/record/4291095/files/CAM041781_d.JPG,0,test,40091,lativitta,40091_CAM041781_d.JPG,major
+CAM041804,https://zenodo.org/record/4291095/files/CAM041804_d.JPG,0,test,40183,lativitta,40183_CAM041804_d.JPG,major
+CAM045107,https://zenodo.org/record/5526257/files/CAM045107_d.JPG,0,test,42993,cyrbia,42993_CAM045107_d.JPG,minor
+CAM045106,https://zenodo.org/record/5526257/files/CAM045106_d.JPG,0,test,42989,cyrbia,42989_CAM045106_d.JPG,minor
+CAM045105,https://zenodo.org/record/5526257/files/CAM045105_d.JPG,0,test,42985,cyrbia,42985_CAM045105_d.JPG,minor
+CAM045104,https://zenodo.org/record/5526257/files/CAM045104_d.JPG,0,test,42981,cyrbia,42981_CAM045104_d.JPG,minor
+CAM045118,https://zenodo.org/record/5526257/files/CAM045118_d.JPG,0,test,43039,cyrbia,43039_CAM045118_d.JPG,minor
+CAM045069,https://zenodo.org/record/5526257/files/CAM045069_d.JPG,0,test,42841,cyrbia,42841_CAM045069_d.JPG,minor
+CAM045068,https://zenodo.org/record/5526257/files/CAM045068_d.JPG,0,test,42837,cyrbia,42837_CAM045068_d.JPG,minor
+CAM045067,https://zenodo.org/record/5526257/files/CAM045067_d.JPG,0,test,42833,cyrbia,42833_CAM045067_d.JPG,minor
+CAM045031,https://zenodo.org/record/5526257/files/CAM045031_d.JPG,0,test,42689,cyrbia,42689_CAM045031_d.JPG,minor
+CAM045030,https://zenodo.org/record/5526257/files/CAM045030_d.JPG,0,test,42685,cyrbia,42685_CAM045030_d.JPG,minor
+CAM045029,https://zenodo.org/record/5526257/files/CAM045029_d.JPG,0,test,42681,cyrbia,42681_CAM045029_d.JPG,minor
+CAM045028,https://zenodo.org/record/5526257/files/CAM045028_d.JPG,0,test,42677,cyrbia,42677_CAM045028_d.JPG,minor
+CAM045027,https://zenodo.org/record/5526257/files/CAM045027_d.JPG,0,test,42673,cyrbia,42673_CAM045027_d.JPG,minor
+CAM045026,https://zenodo.org/record/5526257/files/CAM045026_d.JPG,0,test,42669,cyrbia,42669_CAM045026_d.JPG,minor
+CAM045025,https://zenodo.org/record/5526257/files/CAM045025_d.JPG,0,test,42665,cyrbia,42665_CAM045025_d.JPG,minor
+CAM045024,https://zenodo.org/record/5526257/files/CAM045024_d.JPG,0,test,42661,cyrbia,42661_CAM045024_d.JPG,minor
+CAM045023,https://zenodo.org/record/5526257/files/CAM045023_d.JPG,0,test,42657,cyrbia,42657_CAM045023_d.JPG,minor
+CAM045022,https://zenodo.org/record/5526257/files/CAM045022_d.JPG,0,test,42653,cyrbia,42653_CAM045022_d.JPG,minor
+CAM045021,https://zenodo.org/record/5526257/files/CAM045021_d.JPG,0,test,42649,cyrbia,42649_CAM045021_d.JPG,minor
+CAM045020,https://zenodo.org/record/5526257/files/CAM045020_d.JPG,0,test,42645,cyrbia,42645_CAM045020_d.JPG,minor
+CAM045018,https://zenodo.org/record/5526257/files/CAM045018_d.JPG,0,test,42637,cyrbia,42637_CAM045018_d.JPG,minor
+CAM045017,https://zenodo.org/record/5526257/files/CAM045017_d.JPG,0,test,42633,cyrbia,42633_CAM045017_d.JPG,minor
+CAM045032,https://zenodo.org/record/5526257/files/CAM045032_d.JPG,0,test,42693,cyrbia,42693_CAM045032_d.JPG,minor
+CAM045016,https://zenodo.org/record/5526257/files/CAM045016_d.JPG,0,test,42629,cyrbia,42629_CAM045016_d.JPG,minor
+CAM045014,https://zenodo.org/record/5526257/files/CAM045014_d.JPG,0,test,42621,cyrbia,42621_CAM045014_d.JPG,minor
+CAM045013,https://zenodo.org/record/5526257/files/CAM045013_d.JPG,0,test,42617,cyrbia,42617_CAM045013_d.JPG,minor
+CAM045012,https://zenodo.org/record/5526257/files/CAM045012_d.JPG,0,test,42613,cyrbia,42613_CAM045012_d.JPG,minor
+CAM045011,https://zenodo.org/record/5526257/files/CAM045011_d.JPG,0,test,42609,cyrbia,42609_CAM045011_d.JPG,minor
+CAM045010,https://zenodo.org/record/5526257/files/CAM045010_d.JPG,0,test,42605,cyrbia,42605_CAM045010_d.JPG,minor
+CAM045009,https://zenodo.org/record/5526257/files/CAM045009_d.JPG,0,test,42598,cyrbia,42598_CAM045009_d.JPG,minor
+CAM045008,https://zenodo.org/record/5526257/files/CAM045008_d.JPG,0,test,42595,cyrbia,42595_CAM045008_d.JPG,minor
+CAM045007,https://zenodo.org/record/5526257/files/CAM045007_d.JPG,0,test,42591,cyrbia,42591_CAM045007_d.JPG,minor
+CAM045006,https://zenodo.org/record/5526257/files/CAM045006_d.JPG,0,test,42584,cyrbia,42584_CAM045006_d.JPG,minor
+CAM045005,https://zenodo.org/record/5526257/files/CAM045005_d.JPG,0,test,42579,cyrbia,42579_CAM045005_d.JPG,minor
+CAM045004,https://zenodo.org/record/5526257/files/CAM045004_d.JPG,0,test,42575,cyrbia,42575_CAM045004_d.JPG,minor
+CAM045003,https://zenodo.org/record/5526257/files/CAM045003_d.JPG,0,test,42571,cyrbia,42571_CAM045003_d.JPG,minor
+CAM045002,https://zenodo.org/record/5526257/files/CAM045002_d.JPG,0,test,42567,cyrbia,42567_CAM045002_d.JPG,minor
+CAM045001,https://zenodo.org/record/5526257/files/CAM045001_d.JPG,0,test,42563,cyrbia,42563_CAM045001_d.JPG,minor
+CAM045015,https://zenodo.org/record/5526257/files/CAM045015_d.JPG,0,test,42625,cyrbia,42625_CAM045015_d.JPG,minor
+CAM045033,https://zenodo.org/record/5526257/files/CAM045033_d.JPG,0,test,42697,cyrbia,42697_CAM045033_d.JPG,minor
+CAM045034,https://zenodo.org/record/5526257/files/CAM045034_d.JPG,0,test,42701,cyrbia,42701_CAM045034_d.JPG,minor
+CAM045035,https://zenodo.org/record/5526257/files/CAM045035_d.JPG,0,test,42705,cyrbia,42705_CAM045035_d.JPG,minor
+CAM045066,https://zenodo.org/record/5526257/files/CAM045066_d.JPG,0,test,42829,cyrbia,42829_CAM045066_d.JPG,minor
+CAM045065,https://zenodo.org/record/5526257/files/CAM045065_d.JPG,0,test,42825,cyrbia,42825_CAM045065_d.JPG,minor
+CAM045064,https://zenodo.org/record/5526257/files/CAM045064_d.JPG,0,test,42821,cyrbia,42821_CAM045064_d.JPG,minor
+CAM045063,https://zenodo.org/record/5526257/files/CAM045063_d.JPG,0,test,42817,cyrbia,42817_CAM045063_d.JPG,minor
+CAM045062,https://zenodo.org/record/5526257/files/CAM045062_d.JPG,0,test,42813,cyrbia,42813_CAM045062_d.JPG,minor
+CAM045061,https://zenodo.org/record/5526257/files/CAM045061_d.JPG,0,test,42809,cyrbia,42809_CAM045061_d.JPG,minor
+CAM045060,https://zenodo.org/record/5526257/files/CAM045060_d.JPG,0,test,42805,cyrbia,42805_CAM045060_d.JPG,minor
+CAM045059,https://zenodo.org/record/5526257/files/CAM045059_d.JPG,0,test,42801,cyrbia,42801_CAM045059_d.JPG,minor
+CAM045058,https://zenodo.org/record/5526257/files/CAM045058_d.JPG,0,test,42797,cyrbia,42797_CAM045058_d.JPG,minor
+CAM045057,https://zenodo.org/record/5526257/files/CAM045057_d.JPG,0,test,42793,cyrbia,42793_CAM045057_d.JPG,minor
+CAM045056,https://zenodo.org/record/5526257/files/CAM045056_d.JPG,0,test,42789,cyrbia,42789_CAM045056_d.JPG,minor
+CAM045055,https://zenodo.org/record/5526257/files/CAM045055_d.JPG,0,test,42785,cyrbia,42785_CAM045055_d.JPG,minor
+CAM045054,https://zenodo.org/record/5526257/files/CAM045054_d.JPG,0,test,42781,cyrbia,42781_CAM045054_d.JPG,minor
+CAM045053,https://zenodo.org/record/5526257/files/CAM045053_d.JPG,0,test,42777,cyrbia,42777_CAM045053_d.JPG,minor
+CAM045052,https://zenodo.org/record/5526257/files/CAM045052_d.JPG,0,test,42773,cyrbia,42773_CAM045052_d.JPG,minor
+CAM045051,https://zenodo.org/record/5526257/files/CAM045051_d.JPG,0,test,42769,cyrbia,42769_CAM045051_d.JPG,minor
+CAM045050,https://zenodo.org/record/5526257/files/CAM045050_d.JPG,0,test,42765,cyrbia,42765_CAM045050_d.JPG,minor
+CAM045036,https://zenodo.org/record/5526257/files/CAM045036_d.JPG,0,test,42709,cyrbia,42709_CAM045036_d.JPG,minor
+CAM045037,https://zenodo.org/record/5526257/files/CAM045037_d.JPG,0,test,42713,cyrbia,42713_CAM045037_d.JPG,minor
+CAM045038,https://zenodo.org/record/5526257/files/CAM045038_d.JPG,0,test,42717,cyrbia,42717_CAM045038_d.JPG,minor
+CAM045039,https://zenodo.org/record/5526257/files/CAM045039_d.JPG,0,test,42721,cyrbia,42721_CAM045039_d.JPG,minor
+CAM045040,https://zenodo.org/record/5526257/files/CAM045040_d.JPG,0,test,42725,cyrbia,42725_CAM045040_d.JPG,minor
+CAM045041,https://zenodo.org/record/5526257/files/CAM045041_d.JPG,0,test,42729,cyrbia,42729_CAM045041_d.JPG,minor
+CAM045134,https://zenodo.org/record/5526257/files/CAM045134_d.JPG,0,test,43103,cyrbia,43103_CAM045134_d.JPG,minor
+CAM045042,https://zenodo.org/record/5526257/files/CAM045042_d.JPG,0,test,42733,cyrbia,42733_CAM045042_d.JPG,minor
+CAM045044,https://zenodo.org/record/5526257/files/CAM045044_d.JPG,0,test,42741,cyrbia,42741_CAM045044_d.JPG,minor
+CAM045045,https://zenodo.org/record/5526257/files/CAM045045_d.JPG,0,test,42745,cyrbia,42745_CAM045045_d.JPG,minor
+CAM045046,https://zenodo.org/record/5526257/files/CAM045046_d.JPG,0,test,42749,cyrbia,42749_CAM045046_d.JPG,minor
+CAM045047,https://zenodo.org/record/5526257/files/CAM045047_d.JPG,0,test,42753,cyrbia,42753_CAM045047_d.JPG,minor
+CAM045048,https://zenodo.org/record/5526257/files/CAM045048_d.JPG,0,test,42757,cyrbia,42757_CAM045048_d.JPG,minor
+CAM045049,https://zenodo.org/record/5526257/files/CAM045049_d.JPG,0,test,42761,cyrbia,42761_CAM045049_d.JPG,minor
+CAM045043,https://zenodo.org/record/5526257/files/CAM045043_d.JPG,0,test,42737,cyrbia,42737_CAM045043_d.JPG,minor
+CAM045135,https://zenodo.org/record/5526257/files/CAM045135_d.JPG,0,test,43107,cyrbia,43107_CAM045135_d.JPG,minor
+CAM045019,https://zenodo.org/record/5526257/files/CAM045019_d.JPG,0,test,42641,cyrbia,42641_CAM045019_d.JPG,minor
+CAM045137,https://zenodo.org/record/5526257/files/CAM045137_d.JPG,0,test,43115,cyrbia,43115_CAM045137_d.JPG,minor
+CAM045232,https://zenodo.org/record/5526257/files/CAM045232_d.JPG,0,test,43491,cyrbia,43491_CAM045232_d.JPG,minor
+CAM045233,https://zenodo.org/record/5526257/files/CAM045233_d.JPG,0,test,43495,cyrbia,43495_CAM045233_d.JPG,minor
+CAM045234,https://zenodo.org/record/5526257/files/CAM045234_d.JPG,0,test,43499,cyrbia,43499_CAM045234_d.JPG,minor
+CAM045236,https://zenodo.org/record/5526257/files/CAM045236_d.JPG,0,test,43507,cyrbia,43507_CAM045236_d.JPG,minor
+CAM045237,https://zenodo.org/record/5526257/files/CAM045237_d.JPG,0,test,43511,cyrbia,43511_CAM045237_d.JPG,minor
+CAM045238,https://zenodo.org/record/5526257/files/CAM045238_d.JPG,0,test,43515,cyrbia,43515_CAM045238_d.JPG,minor
+CAM045239,https://zenodo.org/record/5526257/files/CAM045239_d.JPG,0,test,43519,cyrbia,43519_CAM045239_d.JPG,minor
+CAM045240,https://zenodo.org/record/5526257/files/CAM045240_d.JPG,0,test,43523,cyrbia,43523_CAM045240_d.JPG,minor
+CAM045241,https://zenodo.org/record/5526257/files/CAM045241_d.JPG,0,test,43527,cyrbia,43527_CAM045241_d.JPG,minor
+CAM045242,https://zenodo.org/record/5526257/files/CAM045242_d.JPG,0,test,43531,cyrbia,43531_CAM045242_d.JPG,minor
+CAM045243,https://zenodo.org/record/5526257/files/CAM045243_d.JPG,0,test,43535,cyrbia,43535_CAM045243_d.JPG,minor
+CAM045244,https://zenodo.org/record/5526257/files/CAM045244_d.JPG,0,test,43539,cyrbia,43539_CAM045244_d.JPG,minor
+CAM045245,https://zenodo.org/record/5526257/files/CAM045245_d.JPG,0,test,43543,cyrbia,43543_CAM045245_d.JPG,minor
+CAM045246,https://zenodo.org/record/5526257/files/CAM045246_d.JPG,0,test,43547,cyrbia,43547_CAM045246_d.JPG,minor
+CAM045231,https://zenodo.org/record/5526257/files/CAM045231_d.JPG,0,test,43487,cyrbia,43487_CAM045231_d.JPG,minor
+CAM045247,https://zenodo.org/record/5526257/files/CAM045247_d.JPG,0,test,43551,cyrbia,43551_CAM045247_d.JPG,minor
+CAM045249,https://zenodo.org/record/5526257/files/CAM045249_d.JPG,0,test,43559,cyrbia,43559_CAM045249_d.JPG,minor
+CAM045250,https://zenodo.org/record/5526257/files/CAM045250_d.JPG,0,test,43563,cyrbia,43563_CAM045250_d.JPG,minor
+CAM045252,https://zenodo.org/record/5526257/files/CAM045252_d.JPG,0,test,43571,cyrbia,43571_CAM045252_d.JPG,minor
+CAM045253,https://zenodo.org/record/5526257/files/CAM045253_d.JPG,0,test,43575,cyrbia,43575_CAM045253_d.JPG,minor
+CAM045254,https://zenodo.org/record/5526257/files/CAM045254_d.JPG,0,test,43579,cyrbia,43579_CAM045254_d.JPG,minor
+CAM045255,https://zenodo.org/record/5526257/files/CAM045255_d.JPG,0,test,43583,cyrbia,43583_CAM045255_d.JPG,minor
+CAM045256,https://zenodo.org/record/5526257/files/CAM045256_d.JPG,0,test,43587,cyrbia,43587_CAM045256_d.JPG,minor
+CAM045257,https://zenodo.org/record/5526257/files/CAM045257_d.JPG,0,test,43591,cyrbia,43591_CAM045257_d.JPG,minor
+CAM045258,https://zenodo.org/record/5526257/files/CAM045258_d.JPG,0,test,43595,cyrbia,43595_CAM045258_d.JPG,minor
+CAM045259,https://zenodo.org/record/5526257/files/CAM045259_d.JPG,0,test,43599,cyrbia,43599_CAM045259_d.JPG,minor
+CAM045260,https://zenodo.org/record/5526257/files/CAM045260_d.JPG,0,test,43603,cyrbia,43603_CAM045260_d.JPG,minor
+CAM045261,https://zenodo.org/record/5526257/files/CAM045261_d.JPG,0,test,43607,cyrbia,43607_CAM045261_d.JPG,minor
+CAM036188,https://zenodo.org/record/5561246/files/CAM036188_d.JPG,0,test,41483,phyllis,41483_CAM036188_d.JPG,minor
+CAM036184,https://zenodo.org/record/5561246/files/CAM036184_d.JPG,0,test,41471,phyllis,41471_CAM036184_d.JPG,minor
+CAM036172,https://zenodo.org/record/5561246/files/CAM036172_d.JPG,0,test,41459,phyllis,41459_CAM036172_d.JPG,minor
+CAM036168,https://zenodo.org/record/5561246/files/CAM036168_d.JPG,0,test,41443,phyllis,41443_CAM036168_d.JPG,minor
+CAM036165,https://zenodo.org/record/5561246/files/CAM036165_d.JPG,0,test,41431,phyllis,41431_CAM036165_d.JPG,minor
+CAM036164,https://zenodo.org/record/5561246/files/CAM036164_d.JPG,0,test,41427,phyllis,41427_CAM036164_d.JPG,minor
+CAM036214,https://zenodo.org/record/5561246/files/CAM036214_d.JPG,0,test,41571,phyllis,41571_CAM036214_d.JPG,minor
+CAM036215,https://zenodo.org/record/5561246/files/CAM036215_d.JPG,0,test,41575,phyllis,41575_CAM036215_d.JPG,minor
+CAM036216,https://zenodo.org/record/5561246/files/CAM036216_d.JPG,0,test,41579,phyllis,41579_CAM036216_d.JPG,minor
+CAM036293,https://zenodo.org/record/5561246/files/CAM036293_d.JPG,0,test,41827,phyllis,41827_CAM036293_d.JPG,minor
+CAM036292,https://zenodo.org/record/5561246/files/CAM036292_d.JPG,0,test,41823,phyllis,41823_CAM036292_d.JPG,minor
+CAM036291,https://zenodo.org/record/5561246/files/CAM036291_d.JPG,0,test,41819,phyllis,41819_CAM036291_d.JPG,minor
+CAM036290,https://zenodo.org/record/5561246/files/CAM036290_d.JPG,0,test,41815,phyllis,41815_CAM036290_d.JPG,minor
+CAM036277,https://zenodo.org/record/5561246/files/CAM036277_d.JPG,0,test,41763,phyllis,41763_CAM036277_d.JPG,minor
+CAM036276,https://zenodo.org/record/5561246/files/CAM036276_d.JPG,0,test,41759,phyllis,41759_CAM036276_d.JPG,minor

--- a/reference_data/ref_val.csv
+++ b/reference_data/ref_val.csv
@@ -1,1176 +1,1176 @@
-CAMID,file_url,hybrid_stat,split,X,subspecies_ref,filename,ssp_indicator
-CAM041834,https://zenodo.org/record/4291095/files/CAM041834_d.JPG,0,test,40303,lativitta,40303_CAM041834_d.JPG,major
-CAM045170,https://zenodo.org/record/5526257/files/CAM045170_d.JPG,0,test,43245,cyrbia,43245_CAM045170_d.JPG,minor
-CAM041210,https://zenodo.org/record/2714333/files/CAM041210_d.JPG,0,test-2,14057,malleti,14057_CAM041210_d.JPG,mimic
-CAM045261,https://zenodo.org/record/5526257/files/CAM045261_d.JPG,0,test,43607,cyrbia,43607_CAM045261_d.JPG,minor
-CAM016653,https://zenodo.org/record/3082688/files/CAM016653_d.JPG,1,test,3841,notabilis x lativitta,3841_CAM016653_d.JPG,major
-CAM041645,https://zenodo.org/record/4291095/files/CAM041645_d.JPG,0,test,39547,lativitta,39547_CAM041645_d.JPG,major
-CAM016353,https://zenodo.org/record/4153502/files/CAM016353_D.JPG,0,test,19124,notabilis,19124_CAM016353_D.JPG,major
-CAM041656,https://zenodo.org/record/4291095/files/CAM041656_d.JPG,0,test,39591,lativitta,39591_CAM041656_d.JPG,major
-CAM009332,https://zenodo.org/record/2686762/files/CAM009332_d.JPG,0,test,10516,hydara,10516_CAM009332_d.JPG,minor
-CAM016066,https://zenodo.org/record/3082688/files/CAM016066_d.JPG,1,test-2,3040,plesseni x malleti,3040_CAM016066_d.JPG,mimic
-15N320,https://zenodo.org/record/4289223/files/15N320_d.JPG,0,test,15230,venus,15230_15N320_d.JPG,minor
-CAM045041,https://zenodo.org/record/5526257/files/CAM045041_d.JPG,0,test,42729,cyrbia,42729_CAM045041_d.JPG,minor
-CAM017039,https://zenodo.org/record/3082688/files/CAM017039_d.JPG,1,test,4431,notabilis x lativitta,4431_CAM017039_d.JPG,major
-CAM045198,https://zenodo.org/record/5526257/files/CAM045198_d.JPG,0,test,43357,cyrbia,43357_CAM045198_d.JPG,minor
-CAM041542,https://zenodo.org/record/4291095/files/CAM041542_d.JPG,0,test-2,39140,malleti,39140_CAM041542_d.JPG,mimic
-F895,https://zenodo.org/record/2555086/files/F895_d.JPG,0,test,38160,demophoon,38160_F895_d.JPG,minor
-CAM045029,https://zenodo.org/record/5526257/files/CAM045029_d.JPG,0,test,42681,cyrbia,42681_CAM045029_d.JPG,minor
-CAM045245,https://zenodo.org/record/5526257/files/CAM045245_d.JPG,0,test,43543,cyrbia,43543_CAM045245_d.JPG,minor
-CAM017280,https://zenodo.org/record/3082688/files/CAM017280_d.JPG,1,test,4872,notabilis x lativitta,4872_CAM017280_d.JPG,major
-CAM045057,https://zenodo.org/record/5526257/files/CAM045057_d.JPG,0,test,42793,cyrbia,42793_CAM045057_d.JPG,minor
-CAM016462,https://zenodo.org/record/3082688/files/CAM016462_d.JPG,1,test,3621,notabilis x lativitta,3621_CAM016462_d.JPG,major
-15N192,https://zenodo.org/record/4289223/files/15N192_d.JPG,0,test,15202,venus,15202_15N192_d.JPG,minor
-19N0336,https://zenodo.org/record/4288311/files/19N0336_d.JPG,0,test-2,19778,malleti,19778_19N0336_d.JPG,mimic
-CAM045056,https://zenodo.org/record/5526257/files/CAM045056_d.JPG,0,test,42789,cyrbia,42789_CAM045056_d.JPG,minor
-CAM041668,https://zenodo.org/record/4291095/files/CAM041668_d.JPG,0,test,39639,lativitta,39639_CAM041668_d.JPG,major
-19N1743,https://zenodo.org/record/4288311/files/19N1743_d.JPG,0,test-2,20943,malleti,20943_19N1743_d.JPG,mimic
-CAM041683,https://zenodo.org/record/4291095/files/CAM041683_d.JPG,0,test,39699,lativitta,39699_CAM041683_d.JPG,major
-19N2252,https://zenodo.org/record/4288311/files/19N2252_d.JPG,0,test-2,21935,malleti,21935_19N2252_d.JPG,mimic
-CAM009018,https://zenodo.org/record/2686762/files/CAM009018_d.JPG,0,test,10141,hydara,10141_CAM009018_d.JPG,minor
-CAM016698,https://zenodo.org/record/4153502/files/CAM016698_d.JPG,0,test-2,18940,plesseni,18940_CAM016698_d.JPG,mimic
-CAM017410,https://zenodo.org/record/3082688/files/CAM017410_d.JPG,1,test,5059,notabilis x lativitta,5059_CAM017410_d.JPG,major
-CAM016500,https://zenodo.org/record/3082688/files/CAM016500_d.JPG,1,test-2,3633,plesseni x malleti,3633_CAM016500_d.JPG,mimic
-19N2119,https://zenodo.org/record/4288311/files/19N2119_d.JPG,0,test-2,21627,malleti,21627_19N2119_d.JPG,mimic
-CAM041691,https://zenodo.org/record/4291095/files/CAM041691_d.JPG,0,test,39731,lativitta,39731_CAM041691_d.JPG,major
-CAM017604,https://zenodo.org/record/3082688/files/CAM017604_d.JPG,1,test,5370,notabilis x lativitta,5370_CAM017604_d.JPG,major
-19N0648,https://zenodo.org/record/4288311/files/19N0648_d.JPG,0,test-2,19942,malleti,19942_19N0648_d.JPG,mimic
-CAM017258,https://zenodo.org/record/4153502/files/CAM017258_d.JPG,0,test-2,19004,plesseni,19004_CAM017258_d.JPG,mimic
-CAM016455,https://zenodo.org/record/3082688/files/CAM016455_d.JPG,1,test,3611,notabilis x lativitta,3611_CAM016455_d.JPG,major
-19N2020,https://zenodo.org/record/4288311/files/19N2020_d.JPG,0,test-2,21435,malleti,21435_19N2020_d.JPG,mimic
-CAM041207,https://zenodo.org/record/2714333/files/CAM041207_d.JPG,0,test-2,14051,malleti,14051_CAM041207_d.JPG,mimic
-19N0131,https://zenodo.org/record/4288311/files/19N0131_d.JPG,0,test-2,19407,malleti,19407_19N0131_d.JPG,mimic
-19N2235,https://zenodo.org/record/4288311/files/19N2235_d.JPG,0,test-2,21867,malleti,21867_19N2235_d.JPG,mimic
-CAM017337,https://zenodo.org/record/3082688/files/CAM017337_d.JPG,1,test,4952,notabilis x lativitta,4952_CAM017337_d.JPG,major
-19N1260,https://zenodo.org/record/4288311/files/19N1260_d.JPG,0,test-2,20255,malleti,20255_19N1260_d.JPG,mimic
-CAM009195,https://zenodo.org/record/2686762/files/CAM009195_d.JPG,0,test-2,10359,plesseni,10359_CAM009195_d.JPG,mimic
-CAM041879,https://zenodo.org/record/4291095/files/CAM041879_d.JPG,0,test,40480,lativitta,40480_CAM041879_d.JPG,major
-CAM016050,https://zenodo.org/record/3082688/files/CAM016050_d.JPG,1,test-2,3009,plesseni x malleti,3009_CAM016050_d.JPG,mimic
-CAM017004,https://zenodo.org/record/3082688/files/CAM017004_d.JPG,1,test,4367,notabilis x lativitta,4367_CAM017004_d.JPG,major
-CAM016350,https://zenodo.org/record/3082688/files/CAM016350_d.JPG,1,test-2,3436,plesseni x malleti,3436_CAM016350_d.JPG,mimic
-CAM041354,https://zenodo.org/record/4291095/files/CAM041354_d.JPG,0,test,38396,lativitta,38396_CAM041354_d.JPG,major
-CAM018402,https://zenodo.org/record/2702457/files/CAM018402_d.JPG,1,test-2,11168,plesseni x malleti,11168_CAM018402_d.JPG,mimic
-19N0101,https://zenodo.org/record/4288311/files/19N0101_d.JPG,0,test-2,19347,malleti,19347_19N0101_d.JPG,mimic
-CAM016595,https://zenodo.org/record/3082688/files/CAM016595_d.JPG,0,test-2,3779,malleti,3779_CAM016595_d.JPG,mimic
-CAM041659,https://zenodo.org/record/4291095/files/CAM041659_d.JPG,0,test,39603,lativitta,39603_CAM041659_d.JPG,major
-CAM016148,https://zenodo.org/record/3082688/files/CAM016148_d.JPG,1,test,3204,notabilis x lativitta,3204_CAM016148_d.JPG,major
-CAM040038,https://zenodo.org/record/2707828/files/CAM040038_d.JPG,0,test,11756,dignus,11756_CAM040038_d.JPG,minor
-CAM040077,https://zenodo.org/record/2707828/files/CAM040077_d.JPG,0,test,11818,dignus,11818_CAM040077_d.JPG,minor
-CAM021041,https://zenodo.org/record/2702457/files/CAM021041_d.JPG,0,test,11514,amalfreda,11514_CAM021041_d.JPG,minor
-CAM041640,https://zenodo.org/record/4291095/files/CAM041640_d.JPG,0,test,39527,lativitta,39527_CAM041640_d.JPG,major
-CAM041499,https://zenodo.org/record/4291095/files/CAM041499_d.JPG,0,test-2,38968,malleti,38968_CAM041499_d.JPG,mimic
-CAM017549,https://zenodo.org/record/3082688/files/CAM017549_d.JPG,1,test-2,5288,malleti x plesseni,5288_CAM017549_d.JPG,mimic
-CAM016268,https://zenodo.org/record/3082688/files/CAM016268_d.JPG,0,test-2,3382,malleti,3382_CAM016268_d.JPG,mimic
-CAM017614,https://zenodo.org/record/3082688/files/CAM017614_d.JPG,0,test-2,5388,plesseni,5388_CAM017614_d.JPG,mimic
-CAM041200,https://zenodo.org/record/2714333/files/CAM041200_d.JPG,0,test-2,14037,malleti,14037_CAM041200_d.JPG,mimic
-CAM041731,https://zenodo.org/record/4291095/files/CAM041731_d.JPG,0,test,39891,lativitta,39891_CAM041731_d.JPG,major
-15N149,https://zenodo.org/record/4289223/files/15N149_d.JPG,0,test,14961,venus,14961_15N149_d.JPG,minor
-CAM016393,https://zenodo.org/record/3082688/files/CAM016393_d.JPG,1,test-2,3499,plesseni x malleti,3499_CAM016393_d.JPG,mimic
-19N0135,https://zenodo.org/record/4288311/files/19N0135_d.JPG,0,test-2,19415,malleti,19415_19N0135_d.JPG,mimic
-19N0630,https://zenodo.org/record/4288311/files/19N0630_d.JPG,0,test-2,19920,malleti,19920_19N0630_d.JPG,mimic
-19N0180,https://zenodo.org/record/4288311/files/19N0180_d.JPG,0,test-2,19505,malleti,19505_19N0180_d.JPG,mimic
-CAM016225,https://zenodo.org/record/3082688/files/CAM016225_d.JPG,1,test-2,3336,plesseni x malleti,3336_CAM016225_d.JPG,mimic
-CAM016026,https://zenodo.org/record/3082688/files/CAM016026_d.JPG,1,test,2961,notabilis x lativitta,2961_CAM016026_d.JPG,major
-CAM016424,https://zenodo.org/record/3082688/files/CAM016424_d.JPG,1,test-2,3559,plesseni x malleti,3559_CAM016424_d.JPG,mimic
-CAM041857,https://zenodo.org/record/4291095/files/CAM041857_d.JPG,0,test,40392,lativitta,40392_CAM041857_d.JPG,major
-CAM016656,https://zenodo.org/record/3082688/files/CAM016656_d.JPG,1,test-2,3847,plesseni x malleti,3847_CAM016656_d.JPG,mimic
-CAM041428,https://zenodo.org/record/4291095/files/CAM041428_d.JPG,0,test,38684,lativitta,38684_CAM041428_d.JPG,major
-CAM008864,https://zenodo.org/record/2686762/files/CAM008864_d.JPG,0,test,9949,hydara,9949_CAM008864_d.JPG,minor
-CAM016505,https://zenodo.org/record/3082688/files/CAM016505_d.JPG,1,test-2,3643,plesseni x malleti,3643_CAM016505_d.JPG,mimic
-CAM016588,https://zenodo.org/record/3082688/files/CAM016588_d.JPG,1,test,3767,notabilis x lativitta,3767_CAM016588_d.JPG,major
-CAM041647,https://zenodo.org/record/4291095/files/CAM041647_d.JPG,0,test,39555,lativitta,39555_CAM041647_d.JPG,major
-CAM040210,https://zenodo.org/record/2707828/files/CAM040210_d.JPG,0,test-2,12044,malleti,12044_CAM040210_d.JPG,mimic
-CAM041815,https://zenodo.org/record/4291095/files/CAM041815_d.JPG,0,test,40227,lativitta,40227_CAM041815_d.JPG,major
-CAM016646,https://zenodo.org/record/3082688/files/CAM016646_d.JPG,1,test,3827,notabilis x lativitta,3827_CAM016646_d.JPG,major
-CAM016526,https://zenodo.org/record/3082688/files/CAM016526_d.JPG,1,test,3683,notabilis x lativitta,3683_CAM016526_d.JPG,major
-CAM016540,https://zenodo.org/record/3082688/files/CAM016540_d.JPG,0,test-2,3691,malleti,3691_CAM016540_d.JPG,mimic
-CAM041027,https://zenodo.org/record/2714333/files/CAM041027_d.JPG,0,test-2,13693,malleti,13693_CAM041027_d.JPG,mimic
-19N1856,https://zenodo.org/record/4288311/files/19N1856_d.JPG,0,test-2,21111,malleti,21111_19N1856_d.JPG,mimic
-CAM016302,https://zenodo.org/record/4153502/files/CAM016302_d.JPG,1,test,18862,notabilis x lativitta,18862_CAM016302_d.JPG,major
-CAM041885,https://zenodo.org/record/4291095/files/CAM041885_d.JPG,0,test,40504,lativitta,40504_CAM041885_d.JPG,major
-CAM017253,https://zenodo.org/record/3082688/files/CAM017253_d.JPG,0,test,4823,notabilis,4823_CAM017253_d.JPG,major
-CAM041658,https://zenodo.org/record/4291095/files/CAM041658_d.JPG,0,test,39599,lativitta,39599_CAM041658_d.JPG,major
-CAM017351,https://zenodo.org/record/3082688/files/CAM017351_d.JPG,1,test-2,4980,plesseni x malleti,4980_CAM017351_d.JPG,mimic
-CAM045069,https://zenodo.org/record/5526257/files/CAM045069_d.JPG,0,test,42841,cyrbia,42841_CAM045069_d.JPG,minor
-CAM045141,https://zenodo.org/record/5526257/files/CAM045141_d.JPG,0,test,43131,cyrbia,43131_CAM045141_d.JPG,minor
-CAM017264,https://zenodo.org/record/3082688/files/CAM017264_d.JPG,1,test-2,4840,plesseni x malleti,4840_CAM017264_d.JPG,mimic
-CAM018257,https://zenodo.org/record/2702457/files/CAM018257_d.JPG,1,test-2,10986,plesseni x malleti,10986_CAM018257_d.JPG,mimic
-19N0674,https://zenodo.org/record/4288311/files/19N0674_d.JPG,0,test-2,19970,malleti,19970_19N0674_d.JPG,mimic
-CAM008985,https://zenodo.org/record/2686762/files/CAM008985_d.JPG,0,test,10075,hydara,10075_CAM008985_d.JPG,minor
-CAM041888,https://zenodo.org/record/4291095/files/CAM041888_d.JPG,0,test,40516,lativitta,40516_CAM041888_d.JPG,major
-CAM041747,https://zenodo.org/record/4291095/files/CAM041747_d.JPG,0,test,39955,lativitta,39955_CAM041747_d.JPG,major
-19N2257,https://zenodo.org/record/4288311/files/19N2257_d.JPG,0,test-2,21955,malleti,21955_19N2257_d.JPG,mimic
-CAM041843,https://zenodo.org/record/4291095/files/CAM041843_d.JPG,0,test,40339,lativitta,40339_CAM041843_d.JPG,major
-CAM041912,https://zenodo.org/record/4291095/files/CAM041912_d.JPG,0,test,40612,lativitta,40612_CAM041912_d.JPG,major
-CAM041789,https://zenodo.org/record/4291095/files/CAM041789_d.JPG,0,test,40123,lativitta,40123_CAM041789_d.JPG,major
-CAM017063,https://zenodo.org/record/3082688/files/CAM017063_d.JPG,1,test,4475,notabilis x lativitta,4475_CAM017063_d.JPG,major
-CAM045171,https://zenodo.org/record/5526257/files/CAM045171_d.JPG,0,test,43249,cyrbia,43249_CAM045171_d.JPG,minor
-15N195,https://zenodo.org/record/4289223/files/15N195_d.JPG,0,test,15208,venus,15208_15N195_d.JPG,minor
-CAM016314,https://zenodo.org/record/4153502/files/CAM016314_d.JPG,1,test,18868,notabilis x lativitta,18868_CAM016314_d.JPG,major
-CAM041839,https://zenodo.org/record/4291095/files/CAM041839_d.JPG,0,test,40323,lativitta,40323_CAM041839_d.JPG,major
-CAM041614,https://zenodo.org/record/4291095/files/CAM041614_d.JPG,0,test,39423,lativitta,39423_CAM041614_d.JPG,major
-CAM045213,https://zenodo.org/record/5526257/files/CAM045213_d.JPG,0,test,43415,cyrbia,43415_CAM045213_d.JPG,minor
-CAM016654,https://zenodo.org/record/3082688/files/CAM016654_d.JPG,1,test-2,3843,plesseni x malleti,3843_CAM016654_d.JPG,mimic
-CAM045249,https://zenodo.org/record/5526257/files/CAM045249_d.JPG,0,test,43559,cyrbia,43559_CAM045249_d.JPG,minor
-19N2025,https://zenodo.org/record/4288311/files/19N2025_d.JPG,0,test-2,21451,malleti,21451_19N2025_d.JPG,mimic
-CAM016031,https://zenodo.org/record/3082688/files/CAM016031_d.JPG,1,test,2971,notabilis x lativitta,2971_CAM016031_d.JPG,major
-CAM017134,https://zenodo.org/record/3082688/files/CAM017134_d.JPG,0,test-2,4597,malleti,4597_CAM017134_d.JPG,mimic
-CAM017619,https://zenodo.org/record/4153502/files/CAM017619_d.JPG,0,test-2,19064,plesseni,19064_CAM017619_d.JPG,mimic
-CAM017451,https://zenodo.org/record/3082688/files/CAM017451_d.JPG,1,test-2,5134,malleti x plesseni,5134_CAM017451_d.JPG,mimic
-CAM011438,https://zenodo.org/record/2550097/files/CAM011438_d.JPG,0,test-2,28244,plesseni,28244_CAM011438_d.JPG,mimic
-CAM009520,https://zenodo.org/record/2686762/files/CAM009520_d.JPG,1,test,10782,hydara x petiverana,10782_CAM009520_d.JPG,minor
-CAM017154,https://zenodo.org/record/3082688/files/CAM017154_d.JPG,0,test-2,4633,malleti,4633_CAM017154_d.JPG,mimic
-19N0097,https://zenodo.org/record/4288311/files/19N0097_d.JPG,0,test-2,19339,malleti,19339_19N0097_d.JPG,mimic
-CAM016028,https://zenodo.org/record/3082688/files/CAM016028_d.JPG,1,test,2965,notabilis x lativitta,2965_CAM016028_d.JPG,major
-CAM045183,https://zenodo.org/record/5526257/files/CAM045183_d.JPG,0,test,43297,cyrbia,43297_CAM045183_d.JPG,minor
-CAM016146,https://zenodo.org/record/3082688/files/CAM016146_d.JPG,1,test,3200,notabilis x lativitta,3200_CAM016146_d.JPG,major
-CAM045219,https://zenodo.org/record/5526257/files/CAM045219_d.JPG,0,test,43439,cyrbia,43439_CAM045219_d.JPG,minor
-CAM016137,https://zenodo.org/record/3082688/files/CAM016137_d.JPG,1,test-2,3182,plesseni x malleti,3182_CAM016137_d.JPG,mimic
-CAM016361,https://zenodo.org/record/4153502/files/CAM016361_D.JPG,0,test,19128,notabilis,19128_CAM016361_D.JPG,major
-CAM016115,https://zenodo.org/record/3082688/files/CAM016115_d.JPG,1,test,3138,notabilis x lativitta,3138_CAM016115_d.JPG,major
-CAM041782,https://zenodo.org/record/4291095/files/CAM041782_d.JPG,0,test,40095,lativitta,40095_CAM041782_d.JPG,major
-19N1179,https://zenodo.org/record/4288311/files/19N1179_d.JPG,0,test-2,20213,malleti,20213_19N1179_d.JPG,mimic
-CAM009523,https://zenodo.org/record/2686762/files/CAM009523_d.JPG,1,test,10788,hydara x petiverana,10788_CAM009523_d.JPG,minor
-19N2228,https://zenodo.org/record/4288311/files/19N2228_d.JPG,0,test-2,21839,malleti,21839_19N2228_d.JPG,mimic
-CAM040992,https://zenodo.org/record/2714333/files/CAM040992_d.JPG,0,test-2,13623,malleti,13623_CAM040992_d.JPG,mimic
-CAM045217,https://zenodo.org/record/5526257/files/CAM045217_d.JPG,0,test,43431,cyrbia,43431_CAM045217_d.JPG,minor
-CAM009006,https://zenodo.org/record/2686762/files/CAM009006_d.JPG,0,test,10117,hydara,10117_CAM009006_d.JPG,minor
-CAM017453,https://zenodo.org/record/1748277/files/CAM017453_d_whitestandard.JPG,0,test-2,15275,plesseni,15275_CAM017453_d_whitestandard.JPG,mimic
-CAM041625,https://zenodo.org/record/4291095/files/CAM041625_d.JPG,0,test,39467,lativitta,39467_CAM041625_d.JPG,major
-CAM041646,https://zenodo.org/record/4291095/files/CAM041646_d.JPG,0,test,39551,lativitta,39551_CAM041646_d.JPG,major
-CAM000231,https://zenodo.org/record/2677821/files/CAM000231_d.JPG,0,test,6288,chestertonii,6288_CAM000231_d.JPG,minor
-CAM016860,https://zenodo.org/record/3082688/files/CAM016860_d.JPG,1,test-2,4139,plesseni x malleti,4139_CAM016860_d.JPG,mimic
-19N0212,https://zenodo.org/record/4288311/files/19N0212_d.JPG,0,test-2,19569,malleti,19569_19N0212_d.JPG,mimic
-CAM045043,https://zenodo.org/record/5526257/files/CAM045043_d.JPG,0,test,42737,cyrbia,42737_CAM045043_d.JPG,minor
-19N0035,https://zenodo.org/record/4288311/files/19N0035_d.JPG,0,test-2,19210,malleti,19210_19N0035_d.JPG,mimic
-CAM040066,https://zenodo.org/record/2707828/files/CAM040066_d.JPG,0,test,11812,dignus,11812_CAM040066_d.JPG,minor
-CAM040020,https://zenodo.org/record/2707828/files/CAM040020_d.JPG,0,test-2,11724,malleti,11724_CAM040020_d.JPG,mimic
-CAM009203,https://zenodo.org/record/2686762/files/CAM009203_d.JPG,0,test-2,10375,plesseni,10375_CAM009203_d.JPG,mimic
-CAM041437,https://zenodo.org/record/4291095/files/CAM041437_d.JPG,0,test,38720,lativitta,38720_CAM041437_d.JPG,major
-CAM016177,https://zenodo.org/record/3082688/files/CAM016177_d.JPG,1,test,3262,notabilis x lativitta,3262_CAM016177_d.JPG,major
-CAM008544,https://zenodo.org/record/2684906/files/CAM008544_d.JPG,0,test-2,9440,plesseni,9440_CAM008544_d.JPG,mimic
-CAM016956,https://zenodo.org/record/3082688/files/CAM016956_d.JPG,0,test-2,4289,malleti,4289_CAM016956_d.JPG,mimic
-19N0639,https://zenodo.org/record/4288311/files/19N0639_d.JPG,0,test-2,19934,malleti,19934_19N0639_d.JPG,mimic
-CAM017309,https://zenodo.org/record/3082688/files/CAM017309_d.JPG,1,test,4904,notabilis x lativitta,4904_CAM017309_d.JPG,major
-CAM016652,https://zenodo.org/record/3082688/files/CAM016652_d.JPG,1,test,3839,notabilis x lativitta,3839_CAM016652_d.JPG,major
-CAM016828,https://zenodo.org/record/3082688/files/CAM016828_d.JPG,1,test-2,4078,plesseni x malleti,4078_CAM016828_d.JPG,mimic
-19N0089,https://zenodo.org/record/4288311/files/19N0089_d.JPG,0,test-2,19323,malleti,19323_19N0089_d.JPG,mimic
-19N1387,https://zenodo.org/record/4288311/files/19N1387_d.JPG,0,test-2,20323,malleti,20323_19N1387_d.JPG,mimic
-CAM045257,https://zenodo.org/record/5526257/files/CAM045257_d.JPG,0,test,43591,cyrbia,43591_CAM045257_d.JPG,minor
-CAM045192,https://zenodo.org/record/5526257/files/CAM045192_d.JPG,0,test,43333,cyrbia,43333_CAM045192_d.JPG,minor
-CAM017219,https://zenodo.org/record/3082688/files/CAM017219_d.JPG,0,test,4755,notabilis,4755_CAM017219_d.JPG,major
-CAM041036,https://zenodo.org/record/2714333/files/CAM041036_d.JPG,0,test-2,13711,malleti,13711_CAM041036_d.JPG,mimic
-19N2225,https://zenodo.org/record/4288311/files/19N2225_d.JPG,0,test-2,21827,malleti,21827_19N2225_d.JPG,mimic
-CAM016580,https://zenodo.org/record/3082688/files/CAM016580_d.JPG,1,test,3751,notabilis x lativitta,3751_CAM016580_d.JPG,major
-19N0177,https://zenodo.org/record/4288311/files/19N0177_d.JPG,0,test-2,19499,malleti,19499_19N0177_d.JPG,mimic
-CAM016560,https://zenodo.org/record/3082688/files/CAM016560_d.JPG,1,test,3725,notabilis x lativitta,3725_CAM016560_d.JPG,major
-19N0281,https://zenodo.org/record/4288311/files/19N0281_d.JPG,0,test-2,19708,malleti,19708_19N0281_d.JPG,mimic
-19N0056,https://zenodo.org/record/4288311/files/19N0056_d.JPG,0,test-2,19254,malleti,19254_19N0056_d.JPG,mimic
-CAM016703,https://zenodo.org/record/4153502/files/CAM016703_d.JPG,0,test,18950,notabilis,18950_CAM016703_d.JPG,major
-15N135,https://zenodo.org/record/4289223/files/15N135_d.JPG,0,test,15182,chestertonii,15182_15N135_d.JPG,minor
-CAM016734,https://zenodo.org/record/4153502/files/CAM016734_d.JPG,0,test-2,18962,plesseni,18962_CAM016734_d.JPG,mimic
-CAM040222,https://zenodo.org/record/2707828/files/CAM040222_d.JPG,0,test-2,12064,malleti,12064_CAM040222_d.JPG,mimic
-19N0299,https://zenodo.org/record/4288311/files/19N0299_d.JPG,0,test-2,19732,malleti,19732_19N0299_d.JPG,mimic
-CAM017658,https://zenodo.org/record/3082688/files/CAM017658_d.JPG,1,test-2,5396,malleti x plesseni,5396_CAM017658_d.JPG,mimic
-19N1467,https://zenodo.org/record/4288311/files/19N1467_d.JPG,0,test-2,20379,malleti,20379_19N1467_d.JPG,mimic
-19N0133,https://zenodo.org/record/4288311/files/19N0133_d.JPG,0,test-2,19411,malleti,19411_19N0133_d.JPG,mimic
-CAM016922,https://zenodo.org/record/3082688/files/CAM016922_d.JPG,1,test-2,4245,plesseni x malleti,4245_CAM016922_d.JPG,mimic
-CS003728,https://zenodo.org/record/2553501/files/CS3728 dorsal.jpeg,0,test-2,25967,malleti,25967_CS3728 dorsal.jpeg,mimic
-CAM041596,https://zenodo.org/record/4291095/files/CAM041596_d.JPG,0,test,39351,lativitta,39351_CAM041596_d.JPG,major
-CAM045105,https://zenodo.org/record/5526257/files/CAM045105_d.JPG,0,test,42985,cyrbia,42985_CAM045105_d.JPG,minor
-CAM040129,https://zenodo.org/record/2707828/files/CAM040129_d.JPG,0,test-2,11898,malleti,11898_CAM040129_d.JPG,mimic
-CAM041737,https://zenodo.org/record/4291095/files/CAM041737_d.JPG,0,test,39915,lativitta,39915_CAM041737_d.JPG,major
-19N2189,https://zenodo.org/record/4288311/files/19N2189_d.JPG,0,test-2,21723,malleti,21723_19N2189_d.JPG,mimic
-CAM045260,https://zenodo.org/record/5526257/files/CAM045260_d.JPG,0,test,43603,cyrbia,43603_CAM045260_d.JPG,minor
-CAM041900,https://zenodo.org/record/4291095/files/CAM041900_d.JPG,0,test,40564,lativitta,40564_CAM041900_d.JPG,major
-CAM041667,https://zenodo.org/record/4291095/files/CAM041667_d.JPG,0,test,39635,lativitta,39635_CAM041667_d.JPG,major
-CAM041436,https://zenodo.org/record/4291095/files/CAM041436_d.JPG,0,test,38716,lativitta,38716_CAM041436_d.JPG,major
-F849,https://zenodo.org/record/2555086/files/F849_d.JPG,0,test,38076,demophoon,38076_F849_d.JPG,minor
-CAM036231,https://zenodo.org/record/5561246/files/CAM036231_d.JPG,0,test,41635,phyllis,41635_CAM036231_d.JPG,minor
-19N0075,https://zenodo.org/record/4288311/files/19N0075_d.JPG,0,test-2,19295,malleti,19295_19N0075_d.JPG,mimic
-CAM016608,https://zenodo.org/record/3082688/files/CAM016608_d.JPG,1,test-2,3801,plesseni x malleti,3801_CAM016608_d.JPG,mimic
-CAM041771,https://zenodo.org/record/4291095/files/CAM041771_d.JPG,0,test,40051,lativitta,40051_CAM041771_d.JPG,major
-CAM017301,https://zenodo.org/record/3082688/files/CAM017301_d.JPG,1,test,4892,notabilis x lativitta,4892_CAM017301_d.JPG,major
-CAM009510,https://zenodo.org/record/2686762/files/CAM009510_d.JPG,1,test,10762,hydara x petiverana,10762_CAM009510_d.JPG,minor
-CAM008546,https://zenodo.org/record/2684906/files/CAM008546_d.JPG,0,test-2,9444,plesseni,9444_CAM008546_d.JPG,mimic
-CAM017574,https://zenodo.org/record/3082688/files/CAM017574_d.JPG,1,test-2,5322,malleti x plesseni,5322_CAM017574_d.JPG,mimic
-CAM041629,https://zenodo.org/record/4291095/files/CAM041629_d.JPG,0,test,39483,lativitta,39483_CAM041629_d.JPG,major
-CAM009442,https://zenodo.org/record/2686762/files/CAM009442_d.JPG,0,test-2,10682,plesseni,10682_CAM009442_d.JPG,mimic
-CAM018438,https://zenodo.org/record/2548678/files/CAM018438_v_whitestandard.JPG,0,test-2,18165,malleti,18165_CAM018438_v_whitestandard.JPG,mimic
-CAM016161,https://zenodo.org/record/3082688/files/CAM016161_d.JPG,1,test-2,3230,plesseni x malleti,3230_CAM016161_d.JPG,mimic
-CAM017908,https://zenodo.org/record/1748277/files/CAM017908_v_whitestandard.JPG,0,test-2,16887,malleti,16887_CAM017908_v_whitestandard.JPG,mimic
-CAM041178,https://zenodo.org/record/2714333/files/CAM041178_d.JPG,0,test-2,13993,malleti,13993_CAM041178_d.JPG,mimic
-CAM016511,https://zenodo.org/record/3082688/files/CAM016511_d.JPG,1,test-2,3655,plesseni x malleti,3655_CAM016511_d.JPG,mimic
-CAM041780,https://zenodo.org/record/4291095/files/CAM041780_d.JPG,0,test,40087,lativitta,40087_CAM041780_d.JPG,major
-CAM041580,https://zenodo.org/record/4291095/files/CAM041580_d.JPG,0,test-2,39288,malleti,39288_CAM041580_d.JPG,mimic
-CAM016662,https://zenodo.org/record/3082688/files/CAM016662_d.JPG,1,test-2,3859,plesseni x malleti,3859_CAM016662_d.JPG,mimic
-CAM009233,https://zenodo.org/record/2686762/files/CAM009233_d.JPG,0,test-2,10434,plesseni,10434_CAM009233_d.JPG,mimic
-19N0160,https://zenodo.org/record/4288311/files/19N0160_d.JPG,0,test-2,19465,malleti,19465_19N0160_d.JPG,mimic
-CAM016456,https://zenodo.org/record/3082688/files/CAM016456_d.JPG,1,test,3613,notabilis x lativitta,3613_CAM016456_d.JPG,major
-CS002276,https://zenodo.org/record/2735056/files/CS002276_d.JPG,0,test,40859,venus,40859_CS002276_d.JPG,minor
-CAM016648,https://zenodo.org/record/3082688/files/CAM016648_d.JPG,1,test,3831,notabilis x lativitta,3831_CAM016648_d.JPG,major
-CAM008865,https://zenodo.org/record/2686762/files/CAM008865_d.JPG,0,test,9951,hydara,9951_CAM008865_d.JPG,minor
-19N1908,https://zenodo.org/record/4288311/files/19N1908_d.JPG,0,test-2,21211,malleti,21211_19N1908_d.JPG,mimic
-CAM016362,https://zenodo.org/record/4153502/files/CAM016362_D.JPG,0,test,19130,notabilis,19130_CAM016362_D.JPG,major
-CAM016738,https://zenodo.org/record/4153502/files/CAM016738_d.JPG,0,test-2,18966,plesseni,18966_CAM016738_d.JPG,mimic
-19N1112,https://zenodo.org/record/4288311/files/19N1112_d.JPG,0,test-2,20190,malleti,20190_19N1112_d.JPG,mimic
-19N1426,https://zenodo.org/record/4288311/files/19N1426_d.JPG,0,test-2,20357,malleti,20357_19N1426_d.JPG,mimic
-15N101,https://zenodo.org/record/4289223/files/15N101_d.JPG,0,test,14953,venus,14953_15N101_d.JPG,minor
-CAM041557,https://zenodo.org/record/4291095/files/CAM041557_d.JPG,0,test-2,39196,malleti,39196_CAM041557_d.JPG,mimic
-19N1744,https://zenodo.org/record/4288311/files/19N1744_d.JPG,0,test-2,20947,malleti,20947_19N1744_d.JPG,mimic
-CAM041858,https://zenodo.org/record/4291095/files/CAM041858_d.JPG,0,test,40396,lativitta,40396_CAM041858_d.JPG,major
-19N0091,https://zenodo.org/record/4288311/files/19N0091_d.JPG,0,test-2,19327,malleti,19327_19N0091_d.JPG,mimic
-CAM017616,https://zenodo.org/record/4153502/files/CAM017616_d.JPG,0,test-2,19058,plesseni,19058_CAM017616_d.JPG,mimic
-CAM041661,https://zenodo.org/record/4291095/files/CAM041661_d.JPG,0,test,39611,lativitta,39611_CAM041661_d.JPG,major
-19N0026,https://zenodo.org/record/4288311/files/19N0026_d.JPG,0,test-2,19191,malleti,19191_19N0026_d.JPG,mimic
-CAM016527,https://zenodo.org/record/3082688/files/CAM016527_d.JPG,1,test,3685,notabilis x lativitta,3685_CAM016527_d.JPG,major
-CAM041819,https://zenodo.org/record/4291095/files/CAM041819_d.JPG,0,test,40243,lativitta,40243_CAM041819_d.JPG,major
-CAM017446,https://zenodo.org/record/3082688/files/CAM017446_d.JPG,1,test,5126,notabilis x lativitta,5126_CAM017446_d.JPG,major
-CAM045182,https://zenodo.org/record/5526257/files/CAM045182_d.JPG,0,test,43293,cyrbia,43293_CAM045182_d.JPG,minor
-CAM017349,https://zenodo.org/record/3082688/files/CAM017349_d.JPG,1,test,4976,notabilis x lativitta,4976_CAM017349_d.JPG,major
-CAM009313,https://zenodo.org/record/2686762/files/CAM009313_d.JPG,0,test,10478,hydara,10478_CAM009313_d.JPG,minor
-19N1813,https://zenodo.org/record/4288311/files/19N1813_d.JPG,0,test-2,21059,malleti,21059_19N1813_d.JPG,mimic
-CAM041062,https://zenodo.org/record/2714333/files/CAM041062_d.JPG,0,test-2,13763,malleti,13763_CAM041062_d.JPG,mimic
-CAM040192,https://zenodo.org/record/2707828/files/CAM040192_d.JPG,0,test-2,12012,malleti,12012_CAM040192_d.JPG,mimic
-19N0094,https://zenodo.org/record/4288311/files/19N0094_d.JPG,0,test-2,19333,malleti,19333_19N0094_d.JPG,mimic
-CAM041579,https://zenodo.org/record/4291095/files/CAM041579_d.JPG,0,test-2,39284,malleti,39284_CAM041579_d.JPG,mimic
-CAM016125,https://zenodo.org/record/3082688/files/CAM016125_d.JPG,1,test-2,3158,plesseni x malleti,3158_CAM016125_d.JPG,mimic
-CAM018250,https://zenodo.org/record/2702457/files/CAM018250_d.JPG,1,test-2,10974,plesseni x malleti,10974_CAM018250_d.JPG,mimic
-CAM041902,https://zenodo.org/record/4291095/files/CAM041902_d.JPG,0,test,40572,lativitta,40572_CAM041902_d.JPG,major
-19N0954,https://zenodo.org/record/4288311/files/19N0954_d.JPG,0,test-2,20120,malleti,20120_19N0954_d.JPG,mimic
-CAM017118,https://zenodo.org/record/3082688/files/CAM017118_d.JPG,1,test,4565,notabilis x lativitta,4565_CAM017118_d.JPG,major
-CAM041649,https://zenodo.org/record/4291095/files/CAM041649_d.JPG,0,test,39563,lativitta,39563_CAM041649_d.JPG,major
-CAM009190,https://zenodo.org/record/2686762/files/CAM009190_d.JPG,0,test-2,10349,plesseni,10349_CAM009190_d.JPG,mimic
-CAM016205,https://zenodo.org/record/3082688/files/CAM016205_d.JPG,0,test-2,3316,malleti,3316_CAM016205_d.JPG,mimic
-CAM016127,https://zenodo.org/record/3082688/files/CAM016127_d.JPG,1,test-2,3162,plesseni x malleti,3162_CAM016127_d.JPG,mimic
-CAM041882,https://zenodo.org/record/4291095/files/CAM041882_d.JPG,0,test,40492,lativitta,40492_CAM041882_d.JPG,major
-19N1810,https://zenodo.org/record/4288311/files/19N1810_d.JPG,0,test-2,21047,malleti,21047_19N1810_d.JPG,mimic
-CAM016176,https://zenodo.org/record/3082688/files/CAM016176_d.JPG,1,test,3260,notabilis x lativitta,3260_CAM016176_d.JPG,major
-CAM036255,https://zenodo.org/record/5561246/files/CAM036255_d.JPG,0,test,41699,phyllis,41699_CAM036255_d.JPG,minor
-CAM017068,https://zenodo.org/record/3082688/files/CAM017068_d.JPG,1,test-2,4485,plesseni x malleti,4485_CAM017068_d.JPG,mimic
-19N0866,https://zenodo.org/record/4288311/files/19N0866_d.JPG,0,test-2,20072,malleti,20072_19N0866_d.JPG,mimic
-CAM045027,https://zenodo.org/record/5526257/files/CAM045027_d.JPG,0,test,42673,cyrbia,42673_CAM045027_d.JPG,minor
-CAM045246,https://zenodo.org/record/5526257/files/CAM045246_d.JPG,0,test,43547,cyrbia,43547_CAM045246_d.JPG,minor
-CAM017327,https://zenodo.org/record/4153502/files/CAM017327_d.JPG,0,test-2,19010,plesseni,19010_CAM017327_d.JPG,mimic
-CAM017277,https://zenodo.org/record/3082688/files/CAM017277_d.JPG,1,test,4866,notabilis x lativitta,4866_CAM017277_d.JPG,major
-CAM041582,https://zenodo.org/record/4291095/files/CAM041582_d.JPG,0,test-2,39296,malleti,39296_CAM041582_d.JPG,mimic
-CAM041720,https://zenodo.org/record/4291095/files/CAM041720_d.JPG,0,test,39847,lativitta,39847_CAM041720_d.JPG,major
-CAM017067,https://zenodo.org/record/3082688/files/CAM017067_d.JPG,1,test-2,4483,plesseni x malleti,4483_CAM017067_d.JPG,mimic
-CAM041576,https://zenodo.org/record/4291095/files/CAM041576_d.JPG,0,test-2,39272,malleti,39272_CAM041576_d.JPG,mimic
-CAM036165,https://zenodo.org/record/5561246/files/CAM036165_d.JPG,0,test,41431,phyllis,41431_CAM036165_d.JPG,minor
-19N0242,https://zenodo.org/record/4288311/files/19N0242_d.JPG,0,test-2,19629,malleti,19629_19N0242_d.JPG,mimic
-CAM000243,https://zenodo.org/record/2677821/files/CAM000243_d.JPG,0,test,6312,chestertonii,6312_CAM000243_d.JPG,minor
-CAM017450,https://zenodo.org/record/3082688/files/CAM017450_d.JPG,1,test-2,5132,malleti x plesseni,5132_CAM017450_d.JPG,mimic
-CAM017187,https://zenodo.org/record/3082688/files/CAM017187_d.JPG,0,test-2,4694,plesseni,4694_CAM017187_d.JPG,mimic
-CAM016178,https://zenodo.org/record/3082688/files/CAM016178_d.JPG,1,test,3264,notabilis x lativitta,3264_CAM016178_d.JPG,major
-CAM017355,https://zenodo.org/record/4153502/files/CAM017355_d.JPG,0,test-2,19016,plesseni,19016_CAM017355_d.JPG,mimic
-19N1020,https://zenodo.org/record/4288311/files/19N1020_d.JPG,0,test-2,20155,malleti,20155_19N1020_d.JPG,mimic
-CAM017227,https://zenodo.org/record/3082688/files/CAM017227_d.JPG,0,test,4771,notabilis,4771_CAM017227_d.JPG,major
-CAM045172,https://zenodo.org/record/5526257/files/CAM045172_d.JPG,0,test,43253,cyrbia,43253_CAM045172_d.JPG,minor
-19N0304,https://zenodo.org/record/4288311/files/19N0304_d.JPG,0,test-2,19740,malleti,19740_19N0304_d.JPG,mimic
-19N1316,https://zenodo.org/record/4288311/files/19N1316_d.JPG,0,test-2,20271,malleti,20271_19N1316_d.JPG,mimic
-CAM040171,https://zenodo.org/record/2707828/files/CAM040171_d.JPG,0,test-2,11972,malleti,11972_CAM040171_d.JPG,mimic
-CAM041804,https://zenodo.org/record/4291095/files/CAM041804_d.JPG,0,test,40183,lativitta,40183_CAM041804_d.JPG,major
-CAM016035,https://zenodo.org/record/3082688/files/CAM016035_d.JPG,1,test,2979,notabilis x lativitta,2979_CAM016035_d.JPG,major
-CAM017607,https://zenodo.org/record/3082688/files/CAM017607_d.JPG,1,test,5376,notabilis x lativitta,5376_CAM017607_d.JPG,major
-CAM016308,https://zenodo.org/record/4153502/files/CAM016308_D.JPG,1,test,19110,notabilis x lativitta,19110_CAM016308_D.JPG,major
-CAM016407,https://zenodo.org/record/3082688/files/CAM016407_d.JPG,1,test-2,3525,plesseni x malleti,3525_CAM016407_d.JPG,mimic
-CAM045168,https://zenodo.org/record/5526257/files/CAM045168_d.JPG,0,test,43237,cyrbia,43237_CAM045168_d.JPG,minor
-19N0175,https://zenodo.org/record/4288311/files/19N0175_d.JPG,0,test-2,19495,malleti,19495_19N0175_d.JPG,mimic
-CAM041368,https://zenodo.org/record/4291095/files/CAM041368_d.JPG,0,test-2,38452,malleti,38452_CAM041368_d.JPG,mimic
-CAM016712,https://zenodo.org/record/4153502/files/CAM016712_d.JPG,0,test,18960,notabilis,18960_CAM016712_d.JPG,major
-CAM016693,https://zenodo.org/record/4153502/files/CAM016693_d.JPG,0,test-2,18930,plesseni,18930_CAM016693_d.JPG,mimic
-CAM041432,https://zenodo.org/record/4291095/files/CAM041432_d.JPG,0,test,38700,lativitta,38700_CAM041432_d.JPG,major
-CAM040284,https://zenodo.org/record/2707828/files/CAM040284_d.JPG,0,test-2,12184,malleti,12184_CAM040284_d.JPG,mimic
-CAM021060,https://zenodo.org/record/2702457/files/CAM021060_d.JPG,0,test,11549,erato,11549_CAM021060_d.JPG,minor
-CAM009194,https://zenodo.org/record/2686762/files/CAM009194_d.JPG,0,test-2,10357,plesseni,10357_CAM009194_d.JPG,mimic
-CAM009534,https://zenodo.org/record/2686762/files/CAM009534_d.JPG,0,test,10810,petiverana,10810_CAM009534_d.JPG,minor
-F794,https://zenodo.org/record/2555086/files/F794_d.JPG,0,test,38040,demophoon,38040_F794_d.JPG,minor
-19N0955,https://zenodo.org/record/4288311/files/19N0955_d.JPG,0,test-2,20122,malleti,20122_19N0955_d.JPG,mimic
-CAM045174,https://zenodo.org/record/5526257/files/CAM045174_d.JPG,0,test,43261,cyrbia,43261_CAM045174_d.JPG,minor
-CAM017261,https://zenodo.org/record/3082688/files/CAM017261_d.JPG,0,test,4834,notabilis,4834_CAM017261_d.JPG,major
-19N1195,https://zenodo.org/record/4288311/files/19N1195_d.JPG,0,test-2,20223,malleti,20223_19N1195_d.JPG,mimic
-CAM041385,https://zenodo.org/record/4291095/files/CAM041385_d.JPG,0,test,38520,lativitta,38520_CAM041385_d.JPG,major
-CAM041844,https://zenodo.org/record/4291095/files/CAM041844_d.JPG,0,test,40343,lativitta,40343_CAM041844_d.JPG,major
-CAM017083,https://zenodo.org/record/3082688/files/CAM017083_d.JPG,0,test-2,4507,malleti,4507_CAM017083_d.JPG,mimic
-CAM016690,https://zenodo.org/record/4153502/files/CAM016690_d.JPG,0,test-2,18924,plesseni,18924_CAM016690_d.JPG,mimic
-19N1446,https://zenodo.org/record/4288311/files/19N1446_d.JPG,0,test-2,20371,malleti,20371_19N1446_d.JPG,mimic
-CAM041807,https://zenodo.org/record/4291095/files/CAM041807_d.JPG,0,test,40195,lativitta,40195_CAM041807_d.JPG,major
-19N0660,https://zenodo.org/record/4288311/files/19N0660_d.JPG,0,test-2,19950,malleti,19950_19N0660_d.JPG,mimic
-CAM017376,https://zenodo.org/record/4153502/files/CAM017376_d.JPG,0,test-2,19038,plesseni,19038_CAM017376_d.JPG,mimic
-CAM045104,https://zenodo.org/record/5526257/files/CAM045104_d.JPG,0,test,42981,cyrbia,42981_CAM045104_d.JPG,minor
-CAM041728,https://zenodo.org/record/4291095/files/CAM041728_d.JPG,0,test,39879,lativitta,39879_CAM041728_d.JPG,major
-CAM036230,https://zenodo.org/record/5561246/files/CAM036230_d.JPG,0,test,41631,phyllis,41631_CAM036230_d.JPG,minor
-CAM017437,https://zenodo.org/record/3082688/files/CAM017437_d.JPG,1,test-2,5109,plesseni x malleti,5109_CAM017437_d.JPG,mimic
-CAM017347,https://zenodo.org/record/3082688/files/CAM017347_d.JPG,1,test,4972,notabilis x lativitta,4972_CAM017347_d.JPG,major
-19N0255,https://zenodo.org/record/4288311/files/19N0255_d.JPG,0,test-2,19655,malleti,19655_19N0255_d.JPG,mimic
-CS003660,https://zenodo.org/record/2735056/files/CS003660_d.JPG,0,test,41075,venus,41075_CS003660_d.JPG,minor
-CAM016168,https://zenodo.org/record/3082688/files/CAM016168_d.JPG,1,test,3244,notabilis x lativitta,3244_CAM016168_d.JPG,major
-CAM040267,https://zenodo.org/record/2707828/files/CAM040267_d.JPG,0,test-2,12150,malleti,12150_CAM040267_d.JPG,mimic
-CAM017276,https://zenodo.org/record/3082688/files/CAM017276_d.JPG,1,test,4864,notabilis x lativitta,4864_CAM017276_d.JPG,major
-CAM045068,https://zenodo.org/record/5526257/files/CAM045068_d.JPG,0,test,42837,cyrbia,42837_CAM045068_d.JPG,minor
-CAM018520,https://zenodo.org/record/2702457/files/CAM018520_d.JPG,1,test-2,11375,malleti x plesseni,11375_CAM018520_d.JPG,mimic
-19N2078,https://zenodo.org/record/4288311/files/19N2078_d.JPG,0,test-2,21567,malleti,21567_19N2078_d.JPG,mimic
-19N1398,https://zenodo.org/record/4288311/files/19N1398_d.JPG,0,test-2,20339,malleti,20339_19N1398_d.JPG,mimic
-19N2027,https://zenodo.org/record/4288311/files/19N2027_d.JPG,0,test-2,21459,malleti,21459_19N2027_d.JPG,mimic
-CAM040197,https://zenodo.org/record/2707828/files/CAM040197_d.JPG,0,test-2,12020,malleti,12020_CAM040197_d.JPG,mimic
-19N0646,https://zenodo.org/record/4288311/files/19N0646_d.JPG,0,test-2,19938,malleti,19938_19N0646_d.JPG,mimic
-CAM017267,https://zenodo.org/record/3082688/files/CAM017267_d.JPG,1,test-2,4846,plesseni x malleti,4846_CAM017267_d.JPG,mimic
-19N0332,https://zenodo.org/record/4288311/files/19N0332_d.JPG,0,test,19774,erato,19774_19N0332_d.JPG,minor
-CAM017069,https://zenodo.org/record/3082688/files/CAM017069_d.JPG,0,test-2,4487,malleti,4487_CAM017069_d.JPG,mimic
-CAM016149,https://zenodo.org/record/3082688/files/CAM016149_d.JPG,1,test,3206,notabilis x lativitta,3206_CAM016149_d.JPG,major
-CAM016195,https://zenodo.org/record/3082688/files/CAM016195_d.JPG,1,test-2,3298,plesseni x malleti,3298_CAM016195_d.JPG,mimic
-CAM018294,https://zenodo.org/record/2702457/files/CAM018294_d.JPG,1,test-2,11030,plesseni x malleti,11030_CAM018294_d.JPG,mimic
-CAM011449,https://zenodo.org/record/2550097/files/CAM011449_d.JPG,0,test-2,28288,plesseni,28288_CAM011449_d.JPG,mimic
-CAM000169,https://zenodo.org/record/2677821/files/CAM000169_d.JPG,0,test,6170,chestertonii,6170_CAM000169_d.JPG,minor
-CAM016792,https://zenodo.org/record/3082688/files/CAM016792_d.JPG,1,test-2,4006,plesseni x malleti,4006_CAM016792_d.JPG,mimic
-19N0106,https://zenodo.org/record/4288311/files/19N0106_d.JPG,0,test-2,19357,malleti,19357_19N0106_d.JPG,mimic
-CAM016032,https://zenodo.org/record/3082688/files/CAM016032_d.JPG,1,test,2973,notabilis x lativitta,2973_CAM016032_d.JPG,major
-CAM045055,https://zenodo.org/record/5526257/files/CAM045055_d.JPG,0,test,42785,cyrbia,42785_CAM045055_d.JPG,minor
-CS003544,https://zenodo.org/record/2553501/files/CS3544 dorsal.jpeg,0,test-2,25941,malleti,25941_CS3544 dorsal.jpeg,mimic
-CAM045135,https://zenodo.org/record/5526257/files/CAM045135_d.JPG,0,test,43107,cyrbia,43107_CAM045135_d.JPG,minor
-CAM017213,https://zenodo.org/record/3082688/files/CAM017213_d.JPG,0,test,4743,notabilis,4743_CAM017213_d.JPG,major
-CAM017144,https://zenodo.org/record/3082688/files/CAM017144_d.JPG,1,test,4613,notabilis x lativitta,4613_CAM017144_d.JPG,major
-CAM016686,https://zenodo.org/record/4153502/files/CAM016686_d.JPG,0,test-2,18916,plesseni,18916_CAM016686_d.JPG,mimic
-CAM040294,https://zenodo.org/record/2707828/files/CAM040294_d.JPG,0,test-2,12204,malleti,12204_CAM040294_d.JPG,mimic
-CAM017103,https://zenodo.org/record/3082688/files/CAM017103_d.JPG,0,test-2,4543,malleti,4543_CAM017103_d.JPG,mimic
-19N0759,https://zenodo.org/record/4288311/files/19N0759_d.JPG,0,test-2,20024,malleti,20024_19N0759_d.JPG,mimic
-CAM016542,https://zenodo.org/record/3082688/files/CAM016542_d.JPG,0,test-2,3695,malleti,3695_CAM016542_d.JPG,mimic
-19N2279,https://zenodo.org/record/4288311/files/19N2279_d.JPG,0,test-2,22043,malleti,22043_19N2279_d.JPG,mimic
-CS003830,https://zenodo.org/record/2553501/files/CS3830 dorsal.jpeg,0,test-2,25987,malleti,25987_CS3830 dorsal.jpeg,mimic
-CAM041606,https://zenodo.org/record/4291095/files/CAM041606_d.JPG,0,test,39391,lativitta,39391_CAM041606_d.JPG,major
-CAM045158,https://zenodo.org/record/5526257/files/CAM045158_d.JPG,0,test,43197,cyrbia,43197_CAM045158_d.JPG,minor
-CAM016753,https://zenodo.org/record/3082688/files/CAM016753_d.JPG,1,test-2,3942,plesseni x malleti,3942_CAM016753_d.JPG,mimic
-CAM041384,https://zenodo.org/record/4291095/files/CAM041384_d.JPG,0,test,38516,lativitta,38516_CAM041384_d.JPG,major
-CAM017263,https://zenodo.org/record/3082688/files/CAM017263_d.JPG,0,test,4838,notabilis,4838_CAM017263_d.JPG,major
-19N1912,https://zenodo.org/record/4288311/files/19N1912_d.JPG,0,test-2,21219,malleti,21219_19N1912_d.JPG,mimic
-CAM045150,https://zenodo.org/record/5526257/files/CAM045150_d.JPG,0,test,43167,cyrbia,43167_CAM045150_d.JPG,minor
-CAM045061,https://zenodo.org/record/5526257/files/CAM045061_d.JPG,0,test,42809,cyrbia,42809_CAM045061_d.JPG,minor
-19N2250,https://zenodo.org/record/4288311/files/19N2250_d.JPG,0,test-2,21927,malleti,21927_19N2250_d.JPG,mimic
-CAM045035,https://zenodo.org/record/5526257/files/CAM045035_d.JPG,0,test,42705,cyrbia,42705_CAM045035_d.JPG,minor
-CAM045039,https://zenodo.org/record/5526257/files/CAM045039_d.JPG,0,test,42721,cyrbia,42721_CAM045039_d.JPG,minor
-15N136,https://zenodo.org/record/4289223/files/15N136_d.JPG,0,test,15184,chestertonii,15184_15N136_d.JPG,minor
-CAM017314,https://zenodo.org/record/3082688/files/CAM017314_d.JPG,1,test,4912,notabilis x lativitta,4912_CAM017314_d.JPG,major
-CAM041355,https://zenodo.org/record/4291095/files/CAM041355_d.JPG,0,test,38400,lativitta,38400_CAM041355_d.JPG,major
-CAM045255,https://zenodo.org/record/5526257/files/CAM045255_d.JPG,0,test,43583,cyrbia,43583_CAM045255_d.JPG,minor
-CAM041875,https://zenodo.org/record/4291095/files/CAM041875_d.JPG,0,test,40464,lativitta,40464_CAM041875_d.JPG,major
-CAM016154,https://zenodo.org/record/3082688/files/CAM016154_d.JPG,1,test,3216,notabilis x lativitta,3216_CAM016154_d.JPG,major
-CS001002,https://zenodo.org/record/2553501/files/CS1002 dorsal.jpeg,0,test-2,25591,malleti,25591_CS1002 dorsal.jpeg,mimic
-19N0323,https://zenodo.org/record/4288311/files/19N0323_d.JPG,0,test-2,19762,malleti,19762_19N0323_d.JPG,mimic
-19N0102,https://zenodo.org/record/4288311/files/19N0102_d.JPG,0,test-2,19349,malleti,19349_19N0102_d.JPG,mimic
-CAM000057,https://zenodo.org/record/2677821/files/CAM000057_d.JPG,1,test,5949,chestertonii x venus,5949_CAM000057_d.JPG,minor
-19N2011,https://zenodo.org/record/4288311/files/19N2011_d.JPG,0,test-2,21415,malleti,21415_19N2011_d.JPG,mimic
-CAM017265,https://zenodo.org/record/3082688/files/CAM017265_d.JPG,1,test,4842,notabilis x lativitta,4842_CAM017265_d.JPG,major
-19N2270,https://zenodo.org/record/4288311/files/19N2270_d.JPG,0,test-2,22007,malleti,22007_19N2270_d.JPG,mimic
-CAM017266,https://zenodo.org/record/3082688/files/CAM017266_d.JPG,1,test,4844,notabilis x lativitta,4844_CAM017266_d.JPG,major
-CAM017303,https://zenodo.org/record/3082688/files/CAM017303_d.JPG,1,test,4896,notabilis x lativitta,4896_CAM017303_d.JPG,major
-CAM017054,https://zenodo.org/record/3082688/files/CAM017054_d.JPG,1,test,4457,notabilis x lativitta,4457_CAM017054_d.JPG,major
-CAM018285,https://zenodo.org/record/2702457/files/CAM018285_d.JPG,1,test-2,11022,plesseni x malleti,11022_CAM018285_d.JPG,mimic
-19N1909,https://zenodo.org/record/4288311/files/19N1909_d.JPG,0,test-2,21215,malleti,21215_19N1909_d.JPG,mimic
-CAM016924,https://zenodo.org/record/3082688/files/CAM016924_d.JPG,1,test,4249,notabilis x lativitta,4249_CAM016924_d.JPG,major
-CAM016004,https://zenodo.org/record/4153502/files/CAM016004_d.JPG,0,test-2,18849,plesseni,18849_CAM016004_d.JPG,mimic
-CAM040018,https://zenodo.org/record/2707828/files/CAM040018_d.JPG,0,test,11720,dignus,11720_CAM040018_d.JPG,minor
-15N193,https://zenodo.org/record/4289223/files/15N193_d.JPG,0,test,15204,venus,15204_15N193_d.JPG,minor
-CAM016598,https://zenodo.org/record/3082688/files/CAM016598_d.JPG,0,test-2,3783,malleti,3783_CAM016598_d.JPG,mimic
-CAM040039,https://zenodo.org/record/2707828/files/CAM040039_d.JPG,0,test,11758,dignus,11758_CAM040039_d.JPG,minor
-19N1945,https://zenodo.org/record/4288311/files/19N1945_d.JPG,0,test-2,21275,malleti,21275_19N1945_d.JPG,mimic
-CAM016102,https://zenodo.org/record/3082688/files/CAM016102_d.JPG,1,test,3112,notabilis x lativitta,3112_CAM016102_d.JPG,major
-CAM016610,https://zenodo.org/record/3082688/files/CAM016610_d.JPG,0,test-2,3805,malleti,3805_CAM016610_d.JPG,mimic
-CAM017372,https://zenodo.org/record/4153502/files/CAM017372_d.JPG,0,test-2,19034,plesseni,19034_CAM017372_d.JPG,mimic
-CAM045223,https://zenodo.org/record/5526257/files/CAM045223_d.JPG,0,test,43455,cyrbia,43455_CAM045223_d.JPG,minor
-CAM016998,https://zenodo.org/record/3082688/files/CAM016998_d.JPG,1,test,4355,notabilis x lativitta,4355_CAM016998_d.JPG,major
-CAM040281,https://zenodo.org/record/2707828/files/CAM040281_d.JPG,0,test-2,12178,malleti,12178_CAM040281_d.JPG,mimic
-19N0278,https://zenodo.org/record/4288311/files/19N0278_d.JPG,0,test-2,19702,malleti,19702_19N0278_d.JPG,mimic
-CAM017330,https://zenodo.org/record/3082688/files/CAM017330_d.JPG,1,test,4938,notabilis x lativitta,4938_CAM017330_d.JPG,major
-CAM018353,https://zenodo.org/record/2548678/files/CAM018353_v_whitestandard.JPG,0,test-2,17829,malleti,17829_CAM018353_v_whitestandard.JPG,mimic
-CAM017037,https://zenodo.org/record/3082688/files/CAM017037_d.JPG,1,test,4427,notabilis x lativitta,4427_CAM017037_d.JPG,major
-CAM016448,https://zenodo.org/record/3082688/files/CAM016448_d.JPG,1,test,3601,notabilis x lativitta,3601_CAM016448_d.JPG,major
-CAM017192,https://zenodo.org/record/3082688/files/CAM017192_d.JPG,1,test,4704,notabilis x lativitta,4704_CAM017192_d.JPG,major
-15N309,https://zenodo.org/record/4289223/files/15N309_d.JPG,0,test,15228,venus,15228_15N309_d.JPG,minor
-CAM045060,https://zenodo.org/record/5526257/files/CAM045060_d.JPG,0,test,42805,cyrbia,42805_CAM045060_d.JPG,minor
-CAM040282,https://zenodo.org/record/2707828/files/CAM040282_d.JPG,0,test-2,12180,malleti,12180_CAM040282_d.JPG,mimic
-CAM041828,https://zenodo.org/record/4291095/files/CAM041828_d.JPG,0,test,40279,lativitta,40279_CAM041828_d.JPG,major
-CAM016043,https://zenodo.org/record/3082688/files/CAM016043_d.JPG,1,test-2,2995,plesseni x malleti,2995_CAM016043_d.JPG,mimic
-19N0288,https://zenodo.org/record/4288311/files/19N0288_d.JPG,0,test-2,19720,malleti,19720_19N0288_d.JPG,mimic
-19N1348,https://zenodo.org/record/4288311/files/19N1348_d.JPG,0,test-2,20287,malleti,20287_19N1348_d.JPG,mimic
-CAM016863,https://zenodo.org/record/3082688/files/CAM016863_d.JPG,1,test-2,4145,plesseni x malleti,4145_CAM016863_d.JPG,mimic
-19N0107,https://zenodo.org/record/4288311/files/19N0107_d.JPG,0,test-2,19359,malleti,19359_19N0107_d.JPG,mimic
-CAM017074,https://zenodo.org/record/3082688/files/CAM017074_d.JPG,1,test,4497,notabilis x lativitta,4497_CAM017074_d.JPG,major
-CAM016036,https://zenodo.org/record/3082688/files/CAM016036_d.JPG,1,test-2,2981,plesseni x malleti,2981_CAM016036_d.JPG,mimic
-CAM009407,https://zenodo.org/record/2686762/files/CAM009407_d.JPG,0,test-2,10612,malleti,10612_CAM009407_d.JPG,mimic
-CAM016861,https://zenodo.org/record/3082688/files/CAM016861_d.JPG,1,test-2,4141,plesseni x malleti,4141_CAM016861_d.JPG,mimic
-CAM017141,https://zenodo.org/record/3082688/files/CAM017141_d.JPG,1,test,4607,notabilis x lativitta,4607_CAM017141_d.JPG,major
-CAM045155,https://zenodo.org/record/5526257/files/CAM045155_d.JPG,0,test,43187,cyrbia,43187_CAM045155_d.JPG,minor
-CAM017185,https://zenodo.org/record/3082688/files/CAM017185_d.JPG,0,test-2,4690,plesseni,4690_CAM017185_d.JPG,mimic
-CAM041718,https://zenodo.org/record/4291095/files/CAM041718_d.JPG,0,test,39839,lativitta,39839_CAM041718_d.JPG,major
-CAM016184,https://zenodo.org/record/3082688/files/CAM016184_d.JPG,1,test,3276,notabilis x lativitta,3276_CAM016184_d.JPG,major
-CAM041174,https://zenodo.org/record/2714333/files/CAM041174_d.JPG,0,test-2,13985,malleti,13985_CAM041174_d.JPG,mimic
-CAM045036,https://zenodo.org/record/5526257/files/CAM045036_d.JPG,0,test,42709,cyrbia,42709_CAM045036_d.JPG,minor
-CAM017070,https://zenodo.org/record/3082688/files/CAM017070_d.JPG,0,test-2,4489,malleti,4489_CAM017070_d.JPG,mimic
-F907,https://zenodo.org/record/2555086/files/F907_d.JPG,0,test,38184,demophoon,38184_F907_d.JPG,minor
-CAM041657,https://zenodo.org/record/4291095/files/CAM041657_d.JPG,0,test,39595,lativitta,39595_CAM041657_d.JPG,major
-CAM017228,https://zenodo.org/record/3082688/files/CAM017228_d.JPG,0,test,4773,notabilis,4773_CAM017228_d.JPG,major
-CAM016001,https://zenodo.org/record/4153502/files/CAM016001_d.JPG,0,test-2,18843,plesseni,18843_CAM016001_d.JPG,mimic
-CAM018365,https://zenodo.org/record/2702457/files/CAM018365_d.JPG,1,test-2,11130,malleti x plesseni,11130_CAM018365_d.JPG,mimic
-CAM041741,https://zenodo.org/record/4291095/files/CAM041741_d.JPG,0,test,39931,lativitta,39931_CAM041741_d.JPG,major
-CAM017145,https://zenodo.org/record/3082688/files/CAM017145_d.JPG,1,test,4615,notabilis x lativitta,4615_CAM017145_d.JPG,major
-CAM016315,https://zenodo.org/record/4153502/files/CAM016315_D.JPG,0,test,19116,notabilis,19116_CAM016315_D.JPG,major
-CAM041525,https://zenodo.org/record/4291095/files/CAM041525_d.JPG,0,test-2,39072,malleti,39072_CAM041525_d.JPG,mimic
-CAM040258,https://zenodo.org/record/2707828/files/CAM040258_d.JPG,0,test-2,12132,malleti,12132_CAM040258_d.JPG,mimic
-CAM041547,https://zenodo.org/record/4291095/files/CAM041547_d.JPG,0,test-2,39160,malleti,39160_CAM041547_d.JPG,mimic
-CAM016293,https://zenodo.org/record/2553977/files/16293_H_melpomene_plesseni_D.JPG.jpg,0,test-2,26047,plesseni,26047_16293_H_melpomene_plesseni_D.JPG.jpg,mimic
-F809,https://zenodo.org/record/2555086/files/F809_d.JPG,0,test,38048,demophoon,38048_F809_d.JPG,minor
-CAM016170,https://zenodo.org/record/3082688/files/CAM016170_d.JPG,1,test,3248,notabilis x lativitta,3248_CAM016170_d.JPG,major
-19N1333,https://zenodo.org/record/4288311/files/19N1333_d.JPG,0,test-2,20281,malleti,20281_19N1333_d.JPG,mimic
-19N0528,https://zenodo.org/record/4288311/files/19N0528_d.JPG,0,test-2,19882,malleti,19882_19N0528_d.JPG,mimic
-15N115,https://zenodo.org/record/4289223/files/15N115_d.JPG,0,test,14955,venus,14955_15N115_d.JPG,minor
-CAM016644,https://zenodo.org/record/3082688/files/CAM016644_d.JPG,1,test,3823,notabilis x lativitta,3823_CAM016644_d.JPG,major
-CAM041713,https://zenodo.org/record/4291095/files/CAM041713_d.JPG,0,test,39819,lativitta,39819_CAM041713_d.JPG,major
-CAM041052,https://zenodo.org/record/2714333/files/CAM041052_d.JPG,0,test-2,13743,malleti,13743_CAM041052_d.JPG,mimic
-CAM016826,https://zenodo.org/record/3082688/files/CAM016826_d.JPG,1,test-2,4074,plesseni x malleti,4074_CAM016826_d.JPG,mimic
-19N2118,https://zenodo.org/record/4288311/files/19N2118_d.JPG,0,test-2,21623,malleti,21623_19N2118_d.JPG,mimic
-CAM009309,https://zenodo.org/record/2686762/files/CAM009309_d.JPG,0,test,10470,hydara,10470_CAM009309_d.JPG,minor
-CAM017236,https://zenodo.org/record/3082688/files/CAM017236_d.JPG,0,test,4789,notabilis,4789_CAM017236_d.JPG,major
-19N2144,https://zenodo.org/record/4288311/files/19N2144_d.JPG,0,test-2,21679,malleti,21679_19N2144_d.JPG,mimic
-CAM045254,https://zenodo.org/record/5526257/files/CAM045254_d.JPG,0,test,43579,cyrbia,43579_CAM045254_d.JPG,minor
-CAM009188,https://zenodo.org/record/2686762/files/CAM009188_d.JPG,0,test-2,10345,plesseni,10345_CAM009188_d.JPG,mimic
-F864,https://zenodo.org/record/2555086/files/F864_d.JPG,0,test,38104,demophoon,38104_F864_d.JPG,minor
-CAM016521,https://zenodo.org/record/3082688/files/CAM016521_d.JPG,1,test,3673,notabilis x lativitta,3673_CAM016521_d.JPG,major
-CAM016913,https://zenodo.org/record/4153502/files/CAM016913_d.JPG,0,test-2,18988,plesseni,18988_CAM016913_d.JPG,mimic
-CAM040149,https://zenodo.org/record/2707828/files/CAM040149_d.JPG,0,test-2,11934,malleti,11934_CAM040149_d.JPG,mimic
-19N0280,https://zenodo.org/record/4288311/files/19N0280_d.JPG,0,test-2,19706,malleti,19706_19N0280_d.JPG,mimic
-CS002277,https://zenodo.org/record/2735056/files/CS002277_d.JPG,0,test,40863,venus,40863_CS002277_d.JPG,minor
-19N0372,https://zenodo.org/record/4288311/files/19N0372_d.JPG,0,test-2,19786,malleti,19786_19N0372_d.JPG,mimic
-CAM045175,https://zenodo.org/record/5526257/files/CAM045175_d.JPG,0,test,43265,cyrbia,43265_CAM045175_d.JPG,minor
-CAM041390,https://zenodo.org/record/4291095/files/CAM041390_d.JPG,0,test,38540,lativitta,38540_CAM041390_d.JPG,major
-19N0983,https://zenodo.org/record/4288311/files/19N0983_d.JPG,0,test-2,20139,malleti,20139_19N0983_d.JPG,mimic
-CAM045045,https://zenodo.org/record/5526257/files/CAM045045_d.JPG,0,test,42745,cyrbia,42745_CAM045045_d.JPG,minor
-CAM016100,https://zenodo.org/record/3082688/files/CAM016100_d.JPG,1,test-2,3108,plesseni x malleti,3108_CAM016100_d.JPG,mimic
-19N0150,https://zenodo.org/record/4288311/files/19N0150_d.JPG,0,test-2,19445,malleti,19445_19N0150_d.JPG,mimic
-CAM041706,https://zenodo.org/record/4291095/files/CAM041706_d.JPG,0,test,39791,lativitta,39791_CAM041706_d.JPG,major
-CAM017199,https://zenodo.org/record/3082688/files/CAM017199_d.JPG,0,test,4717,notabilis,4717_CAM017199_d.JPG,major
-CAM045022,https://zenodo.org/record/5526257/files/CAM045022_d.JPG,0,test,42653,cyrbia,42653_CAM045022_d.JPG,minor
-CAM041693,https://zenodo.org/record/4291095/files/CAM041693_d.JPG,0,test,39739,lativitta,39739_CAM041693_d.JPG,major
-CAM017250,https://zenodo.org/record/3082688/files/CAM017250_d.JPG,0,test,4817,notabilis,4817_CAM017250_d.JPG,major
-CAM036290,https://zenodo.org/record/5561246/files/CAM036290_d.JPG,0,test,41815,phyllis,41815_CAM036290_d.JPG,minor
-19N1212,https://zenodo.org/record/4288311/files/19N1212_d.JPG,0,test-2,20231,malleti,20231_19N1212_d.JPG,mimic
-CAM036214,https://zenodo.org/record/5561246/files/CAM036214_d.JPG,0,test,41571,phyllis,41571_CAM036214_d.JPG,minor
-CAM017084,https://zenodo.org/record/3082688/files/CAM017084_d.JPG,1,test-2,4509,plesseni x malleti,4509_CAM017084_d.JPG,mimic
-CAM045003,https://zenodo.org/record/5526257/files/CAM045003_d.JPG,0,test,42571,cyrbia,42571_CAM045003_d.JPG,minor
-CAM041380,https://zenodo.org/record/4291095/files/CAM041380_d.JPG,0,test,38500,lativitta,38500_CAM041380_d.JPG,major
-CAM016305,https://zenodo.org/record/4153502/files/CAM016305_d.JPG,0,test,18864,notabilis,18864_CAM016305_d.JPG,major
-19N1377,https://zenodo.org/record/4288311/files/19N1377_d.JPG,0,test-2,20309,malleti,20309_19N1377_d.JPG,mimic
-F866,https://zenodo.org/record/2555086/files/F866_d.JPG,0,test,38112,demophoon,38112_F866_d.JPG,minor
-CAM040253,https://zenodo.org/record/2707828/files/CAM040253_d.JPG,0,test-2,12122,malleti,12122_CAM040253_d.JPG,mimic
-CAM016317,https://zenodo.org/record/4153502/files/CAM016317_D.JPG,1,test,19120,notabilis x lativitta,19120_CAM016317_D.JPG,major
-CAM045264,https://zenodo.org/record/5526257/files/CAM045264_d.JPG,0,test,43619,cyrbia,43619_CAM045264_d.JPG,minor
-CAM016458,https://zenodo.org/record/3082688/files/CAM016458_d.JPG,1,test,3615,notabilis x lativitta,3615_CAM016458_d.JPG,major
-CAM016073,https://zenodo.org/record/3082688/files/CAM016073_d.JPG,0,test-2,3054,plesseni,3054_CAM016073_d.JPG,mimic
-CAM016541,https://zenodo.org/record/3082688/files/CAM016541_d.JPG,0,test-2,3693,malleti,3693_CAM016541_d.JPG,mimic
-19N1389,https://zenodo.org/record/4288311/files/19N1389_d.JPG,0,test-2,20327,malleti,20327_19N1389_d.JPG,mimic
-CAM017776,https://zenodo.org/record/3082688/files/CAM017776_d.JPG,1,test-2,5540,malleti x plesseni,5540_CAM017776_d.JPG,mimic
-CAM016506,https://zenodo.org/record/3082688/files/CAM016506_d.JPG,0,test-2,3645,malleti,3645_CAM016506_d.JPG,mimic
-19N0061,https://zenodo.org/record/4288311/files/19N0061_d.JPG,0,test-2,19267,malleti,19267_19N0061_d.JPG,mimic
-CAM016042,https://zenodo.org/record/3082688/files/CAM016042_d.JPG,1,test-2,2993,plesseni x malleti,2993_CAM016042_d.JPG,mimic
-CAM017178,https://zenodo.org/record/3082688/files/CAM017178_d.JPG,0,test,4676,notabilis,4676_CAM017178_d.JPG,major
-CAM045136,https://zenodo.org/record/5526257/files/CAM045136_d.JPG,0,test,43111,cyrbia,43111_CAM045136_d.JPG,minor
-F8621,https://zenodo.org/record/2555086/files/F8621_d.JPG,0,test,38392,demophoon,38392_F8621_d.JPG,minor
-CS000586,https://zenodo.org/record/2553501/files/CS586 dorsal.jpeg,0,test-2,26005,malleti,26005_CS586 dorsal.jpeg,mimic
-CAM016251,https://zenodo.org/record/3082688/files/CAM016251_d.JPG,1,test-2,3362,plesseni x malleti,3362_CAM016251_d.JPG,mimic
-CAM017296,https://zenodo.org/record/3082688/files/CAM017296_d.JPG,1,test,4884,notabilis x lativitta,4884_CAM017296_d.JPG,major
-19N0015,https://zenodo.org/record/4288311/files/19N0015_d.JPG,0,test-2,19169,malleti,19169_19N0015_d.JPG,mimic
-CAM045226,https://zenodo.org/record/5526257/files/CAM045226_d.JPG,0,test,43467,cyrbia,43467_CAM045226_d.JPG,minor
-CAM017215,https://zenodo.org/record/3082688/files/CAM017215_d.JPG,1,test,4747,notabilis x lativitta,4747_CAM017215_d.JPG,major
-CAM016098,https://zenodo.org/record/3082688/files/CAM016098_d.JPG,1,test-2,3104,plesseni x malleti,3104_CAM016098_d.JPG,mimic
-CAM041611,https://zenodo.org/record/4291095/files/CAM041611_d.JPG,0,test,39411,lativitta,39411_CAM041611_d.JPG,major
-CAM009553,https://zenodo.org/record/2686762/files/CAM009553_d.JPG,1,test,10848,hydara x petiverana,10848_CAM009553_d.JPG,minor
-CAM041884,https://zenodo.org/record/4291095/files/CAM041884_d.JPG,0,test,40500,lativitta,40500_CAM041884_d.JPG,major
-CAM041429,https://zenodo.org/record/4291095/files/CAM041429_d.JPG,0,test,38688,lativitta,38688_CAM041429_d.JPG,major
-CAM009310,https://zenodo.org/record/2686762/files/CAM009310_d.JPG,0,test,10472,hydara,10472_CAM009310_d.JPG,minor
-CAM017867,https://zenodo.org/record/3082688/files/CAM017867_d.JPG,1,test-2,5661,malleti x plesseni,5661_CAM017867_d.JPG,mimic
-CAM017282,https://zenodo.org/record/3082688/files/CAM017282_d.JPG,1,test-2,4876,plesseni x malleti,4876_CAM017282_d.JPG,mimic
-CAM041654,https://zenodo.org/record/4291095/files/CAM041654_d.JPG,0,test,39583,lativitta,39583_CAM041654_d.JPG,major
-CAM045167,https://zenodo.org/record/5526257/files/CAM045167_d.JPG,0,test,43233,cyrbia,43233_CAM045167_d.JPG,minor
-CAM036188,https://zenodo.org/record/5561246/files/CAM036188_d.JPG,0,test,41483,phyllis,41483_CAM036188_d.JPG,minor
-CAM041595,https://zenodo.org/record/4291095/files/CAM041595_d.JPG,0,test,39347,lativitta,39347_CAM041595_d.JPG,major
-CAM017019,https://zenodo.org/record/3082688/files/CAM017019_d.JPG,0,test-2,4393,malleti,4393_CAM017019_d.JPG,mimic
-CAM000239,https://zenodo.org/record/2677821/files/CAM000239_d.JPG,0,test,6304,chestertonii,6304_CAM000239_d.JPG,minor
-CAM016005,https://zenodo.org/record/4153502/files/CAM016005_d.JPG,0,test-2,18851,plesseni,18851_CAM016005_d.JPG,mimic
-CAM041736,https://zenodo.org/record/4291095/files/CAM041736_d.JPG,0,test,39911,lativitta,39911_CAM041736_d.JPG,major
-CAM016139,https://zenodo.org/record/3082688/files/CAM016139_d.JPG,1,test,3186,notabilis x lativitta,3186_CAM016139_d.JPG,major
-CAM017356,https://zenodo.org/record/4153502/files/CAM017356_d.JPG,0,test-2,19018,plesseni,19018_CAM017356_d.JPG,mimic
-CAM041841,https://zenodo.org/record/4291095/files/CAM041841_d.JPG,0,test,40331,lativitta,40331_CAM041841_d.JPG,major
-CAM016809,https://zenodo.org/record/3082688/files/CAM016809_d.JPG,1,test-2,4040,plesseni x malleti,4040_CAM016809_d.JPG,mimic
-CAM016452,https://zenodo.org/record/3082688/files/CAM016452_d.JPG,1,test,3607,notabilis x lativitta,3607_CAM016452_d.JPG,major
-CAM011411,https://zenodo.org/record/2550097/files/CAM011411_d.JPG,0,test-2,28144,plesseni,28144_CAM011411_d.JPG,mimic
-19N1110,https://zenodo.org/record/4288311/files/19N1110_d.JPG,0,test-2,20186,malleti,20186_19N1110_d.JPG,mimic
-19N0746,https://zenodo.org/record/4288311/files/19N0746_d.JPG,0,test-2,20022,malleti,20022_19N0746_d.JPG,mimic
-CAM009161,https://zenodo.org/record/2686762/files/CAM009161_d.JPG,0,test-2,10291,plesseni,10291_CAM009161_d.JPG,mimic
-CAM045262,https://zenodo.org/record/5526257/files/CAM045262_d.JPG,0,test,43611,cyrbia,43611_CAM045262_d.JPG,minor
-CAM017454,https://zenodo.org/record/3082688/files/CAM017454_d.JPG,1,test-2,5138,plesseni x malleti,5138_CAM017454_d.JPG,mimic
-CAM016164,https://zenodo.org/record/3082688/files/CAM016164_d.JPG,1,test,3236,notabilis x lativitta,3236_CAM016164_d.JPG,major
-CAM016990,https://zenodo.org/record/3082688/files/CAM016990_d.JPG,0,test-2,4342,malleti,4342_CAM016990_d.JPG,mimic
-19N0095,https://zenodo.org/record/4288311/files/19N0095_d.JPG,0,test-2,19335,malleti,19335_19N0095_d.JPG,mimic
-CAM017773,https://zenodo.org/record/3082688/files/CAM017773_d.JPG,1,test,5534,lativitta x notabilis,5534_CAM017773_d.JPG,major
-CAM041873,https://zenodo.org/record/4291095/files/CAM041873_d.JPG,0,test,40456,lativitta,40456_CAM041873_d.JPG,major
-19N0115,https://zenodo.org/record/4288311/files/19N0115_d.JPG,0,test-2,19375,malleti,19375_19N0115_d.JPG,mimic
-19N1763,https://zenodo.org/record/4288311/files/19N1763_d.JPG,0,test-2,20979,malleti,20979_19N1763_d.JPG,mimic
-CAM041431,https://zenodo.org/record/4291095/files/CAM041431_d.JPG,0,test,38696,lativitta,38696_CAM041431_d.JPG,major
-CAM016323,https://zenodo.org/record/3082688/files/CAM016323_d.JPG,0,test-2,3420,plesseni,3420_CAM016323_d.JPG,mimic
-CAM017620,https://zenodo.org/record/4153502/files/CAM017620_d.JPG,0,test-2,19066,plesseni,19066_CAM017620_d.JPG,mimic
-CAM041768,https://zenodo.org/record/4291095/files/CAM041768_d.JPG,0,test,40039,lativitta,40039_CAM041768_d.JPG,major
-CAM040023,https://zenodo.org/record/2707828/files/CAM040023_d.JPG,0,test-2,11730,malleti,11730_CAM040023_d.JPG,mimic
-CAM041655,https://zenodo.org/record/4291095/files/CAM041655_d.JPG,0,test,39587,lativitta,39587_CAM041655_d.JPG,major
-19N1063,https://zenodo.org/record/4288311/files/19N1063_d.JPG,0,test-2,20170,malleti,20170_19N1063_d.JPG,mimic
-CAM017704,https://zenodo.org/record/1748277/files/CAM017704_d_whitestandard.JPG,0,test-2,16079,plesseni,16079_CAM017704_d_whitestandard.JPG,mimic
-CAM041773,https://zenodo.org/record/4291095/files/CAM041773_d.JPG,0,test,40059,lativitta,40059_CAM041773_d.JPG,major
-CAM045019,https://zenodo.org/record/5526257/files/CAM045019_d.JPG,0,test,42641,cyrbia,42641_CAM045019_d.JPG,minor
-CAM041886,https://zenodo.org/record/4291095/files/CAM041886_d.JPG,0,test,40508,lativitta,40508_CAM041886_d.JPG,major
-CAM016356,https://zenodo.org/record/4153502/files/CAM016356_D.JPG,0,test,19126,notabilis,19126_CAM016356_D.JPG,major
-CAM016034,https://zenodo.org/record/3082688/files/CAM016034_d.JPG,1,test,2977,notabilis x lativitta,2977_CAM016034_d.JPG,major
-CAM016234,https://zenodo.org/record/3082688/files/CAM016234_d.JPG,0,test-2,3344,malleti,3344_CAM016234_d.JPG,mimic
-19N1850,https://zenodo.org/record/4288311/files/19N1850_d.JPG,0,test-2,21103,malleti,21103_19N1850_d.JPG,mimic
-CAM017692,https://zenodo.org/record/3082688/files/CAM017692_d.JPG,1,test-2,5448,malleti x plesseni,5448_CAM017692_d.JPG,mimic
-CAM016145,https://zenodo.org/record/3082688/files/CAM016145_d.JPG,1,test,3198,notabilis x lativitta,3198_CAM016145_d.JPG,major
-CAM017238,https://zenodo.org/record/3082688/files/CAM017238_d.JPG,0,test,4793,notabilis,4793_CAM017238_d.JPG,major
-19N0715,https://zenodo.org/record/4288311/files/19N0715_d.JPG,0,test-2,20008,malleti,20008_19N0715_d.JPG,mimic
-CAM016122,https://zenodo.org/record/3082688/files/CAM016122_d.JPG,1,test-2,3152,plesseni x malleti,3152_CAM016122_d.JPG,mimic
-CAM016023,https://zenodo.org/record/3082688/files/CAM016023_d.JPG,1,test,2955,notabilis x lativitta,2955_CAM016023_d.JPG,major
-CAM045177,https://zenodo.org/record/5526257/files/CAM045177_d.JPG,0,test,43273,cyrbia,43273_CAM045177_d.JPG,minor
-CAM041715,https://zenodo.org/record/4291095/files/CAM041715_d.JPG,0,test,39827,lativitta,39827_CAM041715_d.JPG,major
-15N113,https://zenodo.org/record/4289223/files/15N113_d.JPG,0,test,15173,venus,15173_15N113_d.JPG,minor
-CAM016906,https://zenodo.org/record/4153502/files/CAM016906_d.JPG,0,test-2,18976,plesseni,18976_CAM016906_d.JPG,mimic
-CAM016295,https://zenodo.org/record/3082688/files/CAM016295_d.JPG,0,test-2,3406,plesseni,3406_CAM016295_d.JPG,mimic
-CS003109,https://zenodo.org/record/2553501/files/CS3109 dorsal.jpeg,0,test-2,25847,malleti,25847_CS3109 dorsal.jpeg,mimic
-CAM017127,https://zenodo.org/record/3082688/files/CAM017127_d.JPG,1,test,4583,notabilis x lativitta,4583_CAM017127_d.JPG,major
-CAM016021,https://zenodo.org/record/3082688/files/CAM016021_d.JPG,1,test,2951,notabilis x lativitta,2951_CAM016021_d.JPG,major
-CAM017087,https://zenodo.org/record/3082688/files/CAM017087_d.JPG,1,test,4515,notabilis x lativitta,4515_CAM017087_d.JPG,major
-CAM021054,https://zenodo.org/record/2702457/files/CAM021054_d.JPG,1,test,11540,hydara x erato,11540_CAM021054_d.JPG,minor
-CAM041219,https://zenodo.org/record/2714333/files/CAM041219_d.JPG,0,test-2,14075,malleti,14075_CAM041219_d.JPG,mimic
-CAM017287,https://zenodo.org/record/3082688/files/CAM017287_d.JPG,1,test,4882,notabilis x lativitta,4882_CAM017287_d.JPG,major
-CAM016174,https://zenodo.org/record/3082688/files/CAM016174_d.JPG,1,test,3256,notabilis x lativitta,3256_CAM016174_d.JPG,major
-CAM016567,https://zenodo.org/record/3082688/files/CAM016567_d.JPG,0,test-2,3739,malleti,3739_CAM016567_d.JPG,mimic
-CAM041618,https://zenodo.org/record/4291095/files/CAM041618_d.JPG,0,test,39439,lativitta,39439_CAM041618_d.JPG,major
-CAM017163,https://zenodo.org/record/3082688/files/CAM017163_d.JPG,1,test,4649,notabilis x lativitta,4649_CAM017163_d.JPG,major
-CAM016696,https://zenodo.org/record/4153502/files/CAM016696_d.JPG,0,test-2,18936,plesseni,18936_CAM016696_d.JPG,mimic
-CAM041438,https://zenodo.org/record/4291095/files/CAM041438_d.JPG,0,test,38724,lativitta,38724_CAM041438_d.JPG,major
-CAM016969,https://zenodo.org/record/3082688/files/CAM016969_d.JPG,1,test,4308,notabilis x lativitta,4308_CAM016969_d.JPG,major
-CAM041363,https://zenodo.org/record/4291095/files/CAM041363_d.JPG,0,test,38432,lativitta,38432_CAM041363_d.JPG,major
-CAM017615,https://zenodo.org/record/4153502/files/CAM017615_d.JPG,0,test-2,19056,plesseni,19056_CAM017615_d.JPG,mimic
-CAM041276,https://zenodo.org/record/2714333/files/CAM041276_d.JPG,0,test-2,14188,malleti,14188_CAM041276_d.JPG,mimic
-CAM009306,https://zenodo.org/record/2686762/files/CAM009306_d.JPG,0,test,10464,hydara,10464_CAM009306_d.JPG,minor
-CAM016151,https://zenodo.org/record/3082688/files/CAM016151_d.JPG,1,test,3210,notabilis x lativitta,3210_CAM016151_d.JPG,major
-CAM017053,https://zenodo.org/record/3082688/files/CAM017053_d.JPG,1,test-2,4455,plesseni x malleti,4455_CAM017053_d.JPG,mimic
-CAM017747,https://zenodo.org/record/3082688/files/CAM017747_d.JPG,1,test-2,5504,malleti x plesseni,5504_CAM017747_d.JPG,mimic
-19N0667,https://zenodo.org/record/4288311/files/19N0667_d.JPG,0,test-2,19958,malleti,19958_19N0667_d.JPG,mimic
-CAM041604,https://zenodo.org/record/4291095/files/CAM041604_d.JPG,0,test,39383,lativitta,39383_CAM041604_d.JPG,major
-CAM045173,https://zenodo.org/record/5526257/files/CAM045173_d.JPG,0,test,43257,cyrbia,43257_CAM045173_d.JPG,minor
-CAM016544,https://zenodo.org/record/3082688/files/CAM016544_d.JPG,0,test-2,3697,malleti,3697_CAM016544_d.JPG,mimic
-CAM041613,https://zenodo.org/record/4291095/files/CAM041613_d.JPG,0,test,39419,lativitta,39419_CAM041613_d.JPG,major
-19N2260,https://zenodo.org/record/4288311/files/19N2260_d.JPG,0,test-2,21967,malleti,21967_19N2260_d.JPG,mimic
-CAM017033,https://zenodo.org/record/3082688/files/CAM017033_d.JPG,1,test,4421,notabilis x lativitta,4421_CAM017033_d.JPG,major
-CAM017089,https://zenodo.org/record/3082688/files/CAM017089_d.JPG,0,test-2,4519,malleti,4519_CAM017089_d.JPG,mimic
-19N2082,https://zenodo.org/record/4288311/files/19N2082_d.JPG,0,test-2,21579,malleti,21579_19N2082_d.JPG,mimic
-CAM016428,https://zenodo.org/record/3082688/files/CAM016428_d.JPG,1,test-2,3567,plesseni x malleti,3567_CAM016428_d.JPG,mimic
-CAM017315,https://zenodo.org/record/3082688/files/CAM017315_d.JPG,1,test,4914,notabilis x lativitta,4914_CAM017315_d.JPG,major
-CAM017179,https://zenodo.org/record/3082688/files/CAM017179_d.JPG,0,test,4678,notabilis,4678_CAM017179_d.JPG,major
-CAM009228,https://zenodo.org/record/2686762/files/CAM009228_d.JPG,0,test-2,10424,plesseni,10424_CAM009228_d.JPG,mimic
-19N0946,https://zenodo.org/record/4288311/files/19N0946_d.JPG,0,test-2,20112,malleti,20112_19N0946_d.JPG,mimic
-CAM016702,https://zenodo.org/record/4153502/files/CAM016702_d.JPG,0,test,18948,notabilis,18948_CAM016702_d.JPG,major
-19N0673,https://zenodo.org/record/4288311/files/19N0673_d.JPG,0,test-2,19968,malleti,19968_19N0673_d.JPG,mimic
-CAM017398,https://zenodo.org/record/3082688/files/CAM017398_d.JPG,1,test,5039,notabilis x lativitta,5039_CAM017398_d.JPG,major
-CAM016117,https://zenodo.org/record/3082688/files/CAM016117_d.JPG,1,test-2,3142,plesseni x malleti,3142_CAM016117_d.JPG,mimic
-F858,https://zenodo.org/record/2555086/files/F858_d.JPG,0,test,38096,demophoon,38096_F858_d.JPG,minor
-19N0809,https://zenodo.org/record/4288311/files/19N0809_d.JPG,0,test-2,20034,malleti,20034_19N0809_d.JPG,mimic
-CAM045218,https://zenodo.org/record/5526257/files/CAM045218_d.JPG,0,test,43435,cyrbia,43435_CAM045218_d.JPG,minor
-CAM016024,https://zenodo.org/record/3082688/files/CAM016024_d.JPG,1,test,2957,notabilis x lativitta,2957_CAM016024_d.JPG,major
-CAM017703,https://zenodo.org/record/3082688/files/CAM017703_d.JPG,1,test,5458,lativitta x notabilis,5458_CAM017703_d.JPG,major
-CS000583,https://zenodo.org/record/2553501/files/CS583 dorsal.jpeg,0,test-2,26003,malleti,26003_CS583 dorsal.jpeg,mimic
-CAM017123,https://zenodo.org/record/3082688/files/CAM017123_d.JPG,1,test-2,4575,plesseni x malleti,4575_CAM017123_d.JPG,mimic
-CAM017000,https://zenodo.org/record/3082688/files/CAM017000_d.JPG,1,test,4359,notabilis x lativitta,4359_CAM017000_d.JPG,major
-19N1997,https://zenodo.org/record/4288311/files/19N1997_d.JPG,0,test-2,21387,malleti,21387_19N1997_d.JPG,mimic
-CAM016313,https://zenodo.org/record/3082688/files/CAM016313_d.JPG,1,test-2,3418,plesseni x malleti,3418_CAM016313_d.JPG,mimic
-CAM041697,https://zenodo.org/record/4291095/files/CAM041697_d.JPG,0,test,39755,lativitta,39755_CAM041697_d.JPG,major
-CAM041216,https://zenodo.org/record/2714333/files/CAM041216_d.JPG,0,test-2,14069,malleti,14069_CAM041216_d.JPG,mimic
-CAM016765,https://zenodo.org/record/3082688/files/CAM016765_d.JPG,1,test-2,3966,plesseni x malleti,3966_CAM016765_d.JPG,mimic
-19N0647,https://zenodo.org/record/4288311/files/19N0647_d.JPG,0,test-2,19940,malleti,19940_19N0647_d.JPG,mimic
-19N0033,https://zenodo.org/record/4288311/files/19N0033_d.JPG,0,test-2,19206,malleti,19206_19N0033_d.JPG,mimic
-CAM017085,https://zenodo.org/record/3082688/files/CAM017085_d.JPG,1,test,4511,notabilis x lativitta,4511_CAM017085_d.JPG,major
-CAM045186,https://zenodo.org/record/5526257/files/CAM045186_d.JPG,0,test,43309,cyrbia,43309_CAM045186_d.JPG,minor
-19N0012,https://zenodo.org/record/4288311/files/19N0012_d.JPG,0,test-2,19163,malleti,19163_19N0012_d.JPG,mimic
-CAM041435,https://zenodo.org/record/4291095/files/CAM041435_d.JPG,0,test,38712,lativitta,38712_CAM041435_d.JPG,major
-CAM041765,https://zenodo.org/record/4291095/files/CAM041765_d.JPG,0,test,40027,lativitta,40027_CAM041765_d.JPG,major
-19N0666,https://zenodo.org/record/4288311/files/19N0666_d.JPG,0,test-2,19956,malleti,19956_19N0666_d.JPG,mimic
-CAM041051,https://zenodo.org/record/2714333/files/CAM041051_d.JPG,0,test-2,13741,malleti,13741_CAM041051_d.JPG,mimic
-CAM021031,https://zenodo.org/record/2702457/files/CAM021031_d.JPG,1,test,11496,hydara x amalfreda,11496_CAM021031_d.JPG,minor
-CAM009438,https://zenodo.org/record/2686762/files/CAM009438_d.JPG,0,test-2,10674,plesseni,10674_CAM009438_d.JPG,mimic
-CAM017408,https://zenodo.org/record/3082688/files/CAM017408_d.JPG,1,test,5057,notabilis x lativitta,5057_CAM017408_d.JPG,major
-CAM045066,https://zenodo.org/record/5526257/files/CAM045066_d.JPG,0,test,42829,cyrbia,42829_CAM045066_d.JPG,minor
-CAM009321,https://zenodo.org/record/2686762/files/CAM009321_d.JPG,0,test,10494,hydara,10494_CAM009321_d.JPG,minor
-CAM016659,https://zenodo.org/record/3082688/files/CAM016659_d.JPG,1,test-2,3853,plesseni x malleti,3853_CAM016659_d.JPG,mimic
-CAM041727,https://zenodo.org/record/4291095/files/CAM041727_d.JPG,0,test,39875,lativitta,39875_CAM041727_d.JPG,major
-CAM041608,https://zenodo.org/record/4291095/files/CAM041608_d.JPG,0,test,39399,lativitta,39399_CAM041608_d.JPG,major
-CAM009206,https://zenodo.org/record/2686762/files/CAM009206_d.JPG,0,test-2,10381,plesseni,10381_CAM009206_d.JPG,mimic
-19N2253,https://zenodo.org/record/4288311/files/19N2253_d.JPG,0,test-2,21939,malleti,21939_19N2253_d.JPG,mimic
-CAM041892,https://zenodo.org/record/4291095/files/CAM041892_d.JPG,0,test,40532,lativitta,40532_CAM041892_d.JPG,major
-CAM017217,https://zenodo.org/record/3082688/files/CAM017217_d.JPG,0,test,4751,notabilis,4751_CAM017217_d.JPG,major
-19N0437,https://zenodo.org/record/4288311/files/19N0437_d.JPG,0,test-2,19820,malleti,19820_19N0437_d.JPG,mimic
-CAM041627,https://zenodo.org/record/4291095/files/CAM041627_d.JPG,0,test,39475,lativitta,39475_CAM041627_d.JPG,major
-CAM016408,https://zenodo.org/record/3082688/files/CAM016408_d.JPG,1,test-2,3527,plesseni x malleti,3527_CAM016408_d.JPG,mimic
-CAM045015,https://zenodo.org/record/5526257/files/CAM045015_d.JPG,0,test,42625,cyrbia,42625_CAM045015_d.JPG,minor
-CAM041209,https://zenodo.org/record/2714333/files/CAM041209_d.JPG,0,test-2,14055,malleti,14055_CAM041209_d.JPG,mimic
-CAM041822,https://zenodo.org/record/4291095/files/CAM041822_d.JPG,0,test,40255,lativitta,40255_CAM041822_d.JPG,major
-CAM041883,https://zenodo.org/record/4291095/files/CAM041883_d.JPG,0,test,40496,lativitta,40496_CAM041883_d.JPG,major
-F846,https://zenodo.org/record/2555086/files/F846_d.JPG,0,test,38068,demophoon,38068_F846_d.JPG,minor
-CAM017324,https://zenodo.org/record/3082688/files/CAM017324_d.JPG,0,test,4932,notabilis,4932_CAM017324_d.JPG,major
-CAM041838,https://zenodo.org/record/4291095/files/CAM041838_d.JPG,0,test,40319,lativitta,40319_CAM041838_d.JPG,major
-CAM041897,https://zenodo.org/record/4291095/files/CAM041897_d.JPG,0,test,40552,lativitta,40552_CAM041897_d.JPG,major
-CAM017302,https://zenodo.org/record/3082688/files/CAM017302_d.JPG,1,test,4894,notabilis x lativitta,4894_CAM017302_d.JPG,major
-CAM017136,https://zenodo.org/record/3082688/files/CAM017136_d.JPG,0,test-2,4601,malleti,4601_CAM017136_d.JPG,mimic
-CAM017427,https://zenodo.org/record/3082688/files/CAM017427_d.JPG,1,test,5091,notabilis x lativitta,5091_CAM017427_d.JPG,major
-19N1932,https://zenodo.org/record/4288311/files/19N1932_d.JPG,0,test-2,21251,malleti,21251_19N1932_d.JPG,mimic
-CAM041906,https://zenodo.org/record/4291095/files/CAM041906_d.JPG,0,test,40588,lativitta,40588_CAM041906_d.JPG,major
-CAM016232,https://zenodo.org/record/4153502/files/CAM016232_D.JPG,1,test,19086,notabilis x lativitta,19086_CAM016232_D.JPG,major
-CAM016699,https://zenodo.org/record/4153502/files/CAM016699_d.JPG,0,test-2,18942,plesseni,18942_CAM016699_d.JPG,mimic
-CAM041801,https://zenodo.org/record/4291095/files/CAM041801_d.JPG,0,test,40171,lativitta,40171_CAM041801_d.JPG,major
-CAM045058,https://zenodo.org/record/5526257/files/CAM045058_d.JPG,0,test,42797,cyrbia,42797_CAM045058_d.JPG,minor
-CAM120448,https://zenodo.org/record/2813153/files/CAM120448_d.JPG,0,test-2,14885,malleti,14885_CAM120448_d.JPG,mimic
-F837,https://zenodo.org/record/2555086/files/F837_d.JPG,0,test,38060,demophoon,38060_F837_d.JPG,minor
-CAM016907,https://zenodo.org/record/4153502/files/CAM016907_d.JPG,0,test-2,18978,plesseni,18978_CAM016907_d.JPG,mimic
-CAM016404,https://zenodo.org/record/3082688/files/CAM016404_d.JPG,0,test-2,3519,plesseni,3519_CAM016404_d.JPG,mimic
-CAM017344,https://zenodo.org/record/3082688/files/CAM017344_d.JPG,1,test,4966,notabilis x lativitta,4966_CAM017344_d.JPG,major
-CAM011443,https://zenodo.org/record/2550097/files/CAM011443_d.JPG,0,test-2,28264,plesseni,28264_CAM011443_d.JPG,mimic
-CAM016640,https://zenodo.org/record/4153502/files/CAM016640_d.JPG,1,test,18906,notabilis x lativitta,18906_CAM016640_d.JPG,major
-19N2079,https://zenodo.org/record/4288311/files/19N2079_d.JPG,0,test-2,21571,malleti,21571_19N2079_d.JPG,mimic
-CAM041753,https://zenodo.org/record/4291095/files/CAM041753_d.JPG,0,test,39979,lativitta,39979_CAM041753_d.JPG,major
-CAM016955,https://zenodo.org/record/3082688/files/CAM016955_d.JPG,0,test-2,4287,malleti,4287_CAM016955_d.JPG,mimic
-19N0279,https://zenodo.org/record/4288311/files/19N0279_d.JPG,0,test-2,19704,malleti,19704_19N0279_d.JPG,mimic
-CAM016642,https://zenodo.org/record/4153502/files/CAM016642_d.JPG,1,test,18908,notabilis x lativitta,18908_CAM016642_d.JPG,major
-CAM009191,https://zenodo.org/record/2686762/files/CAM009191_d.JPG,0,test-2,10351,plesseni,10351_CAM009191_d.JPG,mimic
-CAM045064,https://zenodo.org/record/5526257/files/CAM045064_d.JPG,0,test,42821,cyrbia,42821_CAM045064_d.JPG,minor
-CAM016094,https://zenodo.org/record/3082688/files/CAM016094_d.JPG,1,test,3096,notabilis x lativitta,3096_CAM016094_d.JPG,major
-CAM017022,https://zenodo.org/record/3082688/files/CAM017022_d.JPG,1,test,4399,notabilis x lativitta,4399_CAM017022_d.JPG,major
-CAM017030,https://zenodo.org/record/3082688/files/CAM017030_d.JPG,0,test-2,4415,malleti,4415_CAM017030_d.JPG,mimic
-CAM008867,https://zenodo.org/record/2686762/files/CAM008867_d.JPG,0,test,9955,hydara,9955_CAM008867_d.JPG,minor
-CAM041217,https://zenodo.org/record/2714333/files/CAM041217_d.JPG,0,test-2,14071,malleti,14071_CAM041217_d.JPG,mimic
-CAM041896,https://zenodo.org/record/4291095/files/CAM041896_d.JPG,0,test,40548,lativitta,40548_CAM041896_d.JPG,major
-CAM008161,https://zenodo.org/record/2684906/files/CAM008161_d.JPG,0,test-2,8768,malleti,8768_CAM008161_d.JPG,mimic
-CAM045134,https://zenodo.org/record/5526257/files/CAM045134_d.JPG,0,test,43103,cyrbia,43103_CAM045134_d.JPG,minor
-19N0658,https://zenodo.org/record/4288311/files/19N0658_d.JPG,0,test-2,19946,malleti,19946_19N0658_d.JPG,mimic
-CAM017034,https://zenodo.org/record/3082688/files/CAM017034_d.JPG,1,test,4423,notabilis x lativitta,4423_CAM017034_d.JPG,major
-CAM041851,https://zenodo.org/record/4291095/files/CAM041851_d.JPG,0,test,40371,lativitta,40371_CAM041851_d.JPG,major
-CAM016457,https://zenodo.org/record/4153502/files/CAM016457_d.JPG,1,test,18882,notabilis x lativitta,18882_CAM016457_d.JPG,major
-CAM017237,https://zenodo.org/record/3082688/files/CAM017237_d.JPG,0,test,4791,notabilis,4791_CAM017237_d.JPG,major
-CAM016547,https://zenodo.org/record/3082688/files/CAM016547_d.JPG,0,test-2,3703,malleti,3703_CAM016547_d.JPG,mimic
-CAM017363,https://zenodo.org/record/4153502/files/CAM017363_d.JPG,0,test-2,19022,plesseni,19022_CAM017363_d.JPG,mimic
-CAM040078,https://zenodo.org/record/2707828/files/CAM040078_d.JPG,0,test,11820,dignus,11820_CAM040078_d.JPG,minor
-CAM016086,https://zenodo.org/record/3082688/files/CAM016086_d.JPG,1,test-2,3080,plesseni x malleti,3080_CAM016086_d.JPG,mimic
-19N1762,https://zenodo.org/record/4288311/files/19N1762_d.JPG,0,test-2,20975,malleti,20975_19N1762_d.JPG,mimic
-CAM009320,https://zenodo.org/record/2686762/files/CAM009320_d.JPG,0,test,10492,hydara,10492_CAM009320_d.JPG,minor
-CAM017420,https://zenodo.org/record/3082688/files/CAM017420_d.JPG,1,test,5077,notabilis x lativitta,5077_CAM017420_d.JPG,major
-CAM017421,https://zenodo.org/record/3082688/files/CAM017421_d.JPG,1,test,5079,notabilis x lativitta,5079_CAM017421_d.JPG,major
-CAM041746,https://zenodo.org/record/4291095/files/CAM041746_d.JPG,0,test,39951,lativitta,39951_CAM041746_d.JPG,major
-CAM016512,https://zenodo.org/record/3082688/files/CAM016512_d.JPG,1,test,3657,notabilis x lativitta,3657_CAM016512_d.JPG,major
-CAM017441,https://zenodo.org/record/3082688/files/CAM017441_d.JPG,1,test,5117,notabilis x lativitta,5117_CAM017441_d.JPG,major
-CAM045040,https://zenodo.org/record/5526257/files/CAM045040_d.JPG,0,test,42725,cyrbia,42725_CAM045040_d.JPG,minor
-CAM041598,https://zenodo.org/record/4291095/files/CAM041598_d.JPG,0,test,39359,lativitta,39359_CAM041598_d.JPG,major
-19N2283,https://zenodo.org/record/4288311/files/19N2283_d.JPG,0,test-2,22059,malleti,22059_19N2283_d.JPG,mimic
-CAM045139,https://zenodo.org/record/5526257/files/CAM045139_d.JPG,0,test,43123,cyrbia,43123_CAM045139_d.JPG,minor
-CAM016196,https://zenodo.org/record/3082688/files/CAM016196_d.JPG,1,test-2,3300,plesseni x malleti,3300_CAM016196_d.JPG,mimic
-CAM041633,https://zenodo.org/record/4291095/files/CAM041633_d.JPG,0,test,39499,lativitta,39499_CAM041633_d.JPG,major
-CAM017223,https://zenodo.org/record/3082688/files/CAM017223_d.JPG,0,test,4763,notabilis,4763_CAM017223_d.JPG,major
-CAM016163,https://zenodo.org/record/3082688/files/CAM016163_d.JPG,1,test,3234,notabilis x lativitta,3234_CAM016163_d.JPG,major
-CS002311,https://zenodo.org/record/2553501/files/CS2311 dorsal.jpeg,0,test-2,25701,malleti,25701_CS2311 dorsal.jpeg,mimic
-CAM045138,https://zenodo.org/record/5526257/files/CAM045138_d.JPG,0,test,43119,cyrbia,43119_CAM045138_d.JPG,minor
-19N2115,https://zenodo.org/record/4288311/files/19N2115_d.JPG,0,test-2,21611,malleti,21611_19N2115_d.JPG,mimic
-19N1158,https://zenodo.org/record/4288311/files/19N1158_d.JPG,0,test-2,20204,malleti,20204_19N1158_d.JPG,mimic
-CAM041223,https://zenodo.org/record/2714333/files/CAM041223_d.JPG,0,test-2,14083,malleti,14083_CAM041223_d.JPG,mimic
-CAM041177,https://zenodo.org/record/2714333/files/CAM041177_d.JPG,0,test-2,13991,malleti,13991_CAM041177_d.JPG,mimic
-CAM016707,https://zenodo.org/record/4153502/files/CAM016707_d.JPG,0,test,18956,notabilis,18956_CAM016707_d.JPG,major
-CAM045210,https://zenodo.org/record/5526257/files/CAM045210_d.JPG,0,test,43403,cyrbia,43403_CAM045210_d.JPG,minor
-CAM016280,https://zenodo.org/record/3082688/files/CAM016280_d.JPG,0,test-2,3394,plesseni,3394_CAM016280_d.JPG,mimic
-CAM017456,https://zenodo.org/record/3082688/files/CAM017456_d.JPG,1,test-2,5140,malleti x plesseni,5140_CAM017456_d.JPG,mimic
-CAM016192,https://zenodo.org/record/3082688/files/CAM016192_d.JPG,1,test,3292,notabilis x lativitta,3292_CAM016192_d.JPG,major
-19N2068,https://zenodo.org/record/4288311/files/19N2068_d.JPG,0,test-2,21547,malleti,21547_19N2068_d.JPG,mimic
-19N0700,https://zenodo.org/record/4288311/files/19N0700_d.JPG,0,test-2,19996,malleti,19996_19N0700_d.JPG,mimic
-CAM045263,https://zenodo.org/record/5526257/files/CAM045263_d.JPG,0,test,43615,cyrbia,43615_CAM045263_d.JPG,minor
-CAM016546,https://zenodo.org/record/3082688/files/CAM016546_d.JPG,0,test-2,3701,malleti,3701_CAM016546_d.JPG,mimic
-CAM016132,https://zenodo.org/record/3082688/files/CAM016132_d.JPG,1,test-2,3172,plesseni x malleti,3172_CAM016132_d.JPG,mimic
-19N1771,https://zenodo.org/record/4288311/files/19N1771_d.JPG,0,test-2,20999,malleti,20999_19N1771_d.JPG,mimic
-CAM016410,https://zenodo.org/record/3082688/files/CAM016410_d.JPG,1,test,3531,notabilis x lativitta,3531_CAM016410_d.JPG,major
-CAM018447,https://zenodo.org/record/2548678/files/CAM018447_v_whitestandard.JPG,0,test-2,18201,plesseni,18201_CAM018447_v_whitestandard.JPG,mimic
-CAM016859,https://zenodo.org/record/3082688/files/CAM016859_d.JPG,1,test-2,4137,plesseni x malleti,4137_CAM016859_d.JPG,mimic
-CAM016157,https://zenodo.org/record/3082688/files/CAM016157_d.JPG,1,test,3222,notabilis x lativitta,3222_CAM016157_d.JPG,major
-CAM041672,https://zenodo.org/record/4291095/files/CAM041672_d.JPG,0,test,39655,lativitta,39655_CAM041672_d.JPG,major
-CAM018528,https://zenodo.org/record/2548678/files/CAM018528_v_whitestandard.JPG,0,test-2,18525,malleti,18525_CAM018528_v_whitestandard.JPG,mimic
-19N0162,https://zenodo.org/record/4288311/files/19N0162_d.JPG,0,test-2,19469,malleti,19469_19N0162_d.JPG,mimic
-CAM041740,https://zenodo.org/record/4291095/files/CAM041740_d.JPG,0,test,39927,lativitta,39927_CAM041740_d.JPG,major
-CAM041864,https://zenodo.org/record/4291095/files/CAM041864_d.JPG,0,test,40420,lativitta,40420_CAM041864_d.JPG,major
-CAM016099,https://zenodo.org/record/3082688/files/CAM016099_d.JPG,1,test,3106,notabilis x lativitta,3106_CAM016099_d.JPG,major
-19N0261,https://zenodo.org/record/4288311/files/19N0261_d.JPG,0,test-2,19667,malleti,19667_19N0261_d.JPG,mimic
-CAM016460,https://zenodo.org/record/4153502/files/CAM016460_d.JPG,1,test,18884,notabilis x lativitta,18884_CAM016460_d.JPG,major
-CAM008163,https://zenodo.org/record/2684906/files/CAM008163_d.JPG,0,test-2,8772,malleti,8772_CAM008163_d.JPG,mimic
-CAM009551,https://zenodo.org/record/2686762/files/CAM009551_d.JPG,1,test,10844,hydara x petiverana,10844_CAM009551_d.JPG,minor
-CAM016105,https://zenodo.org/record/3082688/files/CAM016105_d.JPG,1,test,3118,notabilis x lativitta,3118_CAM016105_d.JPG,major
-CAM040245,https://zenodo.org/record/2707828/files/CAM040245_d.JPG,0,test-2,12106,malleti,12106_CAM040245_d.JPG,mimic
-CAM016522,https://zenodo.org/record/3082688/files/CAM016522_d.JPG,1,test,3675,notabilis x lativitta,3675_CAM016522_d.JPG,major
-CAM016551,https://zenodo.org/record/3082688/files/CAM016551_d.JPG,0,test-2,3711,malleti,3711_CAM016551_d.JPG,mimic
-CAM040172,https://zenodo.org/record/2707828/files/CAM040172_d.JPG,0,test-2,11974,malleti,11974_CAM040172_d.JPG,mimic
-CAM017133,https://zenodo.org/record/3082688/files/CAM017133_d.JPG,1,test,4595,notabilis x lativitta,4595_CAM017133_d.JPG,major
-CAM017835,https://zenodo.org/record/3082688/files/CAM017835_d.JPG,1,test-2,5615,plesseni x malleti,5615_CAM017835_d.JPG,mimic
-15N120,https://zenodo.org/record/4289223/files/15N120_d.JPG,0,test,15174,venus,15174_15N120_d.JPG,minor
-CAM016113,https://zenodo.org/record/3082688/files/CAM016113_d.JPG,0,test-2,3134,plesseni,3134_CAM016113_d.JPG,mimic
-CAM041695,https://zenodo.org/record/4291095/files/CAM041695_d.JPG,0,test,39747,lativitta,39747_CAM041695_d.JPG,major
-CAM045145,https://zenodo.org/record/5526257/files/CAM045145_d.JPG,0,test,43147,cyrbia,43147_CAM045145_d.JPG,minor
-CAM017339,https://zenodo.org/record/3082688/files/CAM017339_d.JPG,1,test,4956,notabilis x lativitta,4956_CAM017339_d.JPG,major
-CAM041035,https://zenodo.org/record/2714333/files/CAM041035_d.JPG,0,test-2,13709,malleti,13709_CAM041035_d.JPG,mimic
-CAM018466,https://zenodo.org/record/2702457/files/CAM018466_d.JPG,1,test-2,11274,plesseni x malleti,11274_CAM018466_d.JPG,mimic
-19N0137,https://zenodo.org/record/4288311/files/19N0137_d.JPG,0,test-2,19419,malleti,19419_19N0137_d.JPG,mimic
-CAM041221,https://zenodo.org/record/2714333/files/CAM041221_d.JPG,0,test-2,14079,malleti,14079_CAM041221_d.JPG,mimic
-19N0712,https://zenodo.org/record/4288311/files/19N0712_d.JPG,0,test-2,20002,malleti,20002_19N0712_d.JPG,mimic
-CAM041621,https://zenodo.org/record/4291095/files/CAM041621_d.JPG,0,test,39451,lativitta,39451_CAM041621_d.JPG,major
-CAM036229,https://zenodo.org/record/5561246/files/CAM036229_d.JPG,0,test,41627,phyllis,41627_CAM036229_d.JPG,minor
-CAM017244,https://zenodo.org/record/3082688/files/CAM017244_d.JPG,0,test,4805,notabilis,4805_CAM017244_d.JPG,major
-CAM016121,https://zenodo.org/record/3082688/files/CAM016121_d.JPG,1,test,3150,notabilis x lativitta,3150_CAM016121_d.JPG,major
-CAM041911,https://zenodo.org/record/4291095/files/CAM041911_d.JPG,0,test,40608,lativitta,40608_CAM041911_d.JPG,major
-19N0897,https://zenodo.org/record/4288311/files/19N0897_d.JPG,0,test-2,20090,malleti,20090_19N0897_d.JPG,mimic
-CAM017602,https://zenodo.org/record/3082688/files/CAM017602_d.JPG,1,test,5366,notabilis x lativitta,5366_CAM017602_d.JPG,major
-CAM016187,https://zenodo.org/record/3082688/files/CAM016187_d.JPG,1,test,3282,notabilis x lativitta,3282_CAM016187_d.JPG,major
-CAM041763,https://zenodo.org/record/4291095/files/CAM041763_d.JPG,0,test,40019,lativitta,40019_CAM041763_d.JPG,major
-CAM016374,https://zenodo.org/record/3082688/files/CAM016374_d.JPG,0,test-2,3462,plesseni,3462_CAM016374_d.JPG,mimic
-CAM041774,https://zenodo.org/record/4291095/files/CAM041774_d.JPG,0,test,40063,lativitta,40063_CAM041774_d.JPG,major
-CAM041823,https://zenodo.org/record/4291095/files/CAM041823_d.JPG,0,test,40259,lativitta,40259_CAM041823_d.JPG,major
-CAM017442,https://zenodo.org/record/3082688/files/CAM017442_d.JPG,1,test,5119,notabilis x lativitta,5119_CAM017442_d.JPG,major
-CAM041739,https://zenodo.org/record/4291095/files/CAM041739_d.JPG,0,test,39923,lativitta,39923_CAM041739_d.JPG,major
-CAM041053,https://zenodo.org/record/2714333/files/CAM041053_d.JPG,0,test-2,13745,malleti,13745_CAM041053_d.JPG,mimic
-CAM045161,https://zenodo.org/record/5526257/files/CAM045161_d.JPG,0,test,43209,cyrbia,43209_CAM045161_d.JPG,minor
-CAM016126,https://zenodo.org/record/3082688/files/CAM016126_d.JPG,1,test-2,3160,plesseni x malleti,3160_CAM016126_d.JPG,mimic
-CAM041690,https://zenodo.org/record/4291095/files/CAM041690_d.JPG,0,test,39727,lativitta,39727_CAM041690_d.JPG,major
-CAM016324,https://zenodo.org/record/3082688/files/CAM016324_d.JPG,0,test-2,3422,plesseni,3422_CAM016324_d.JPG,mimic
-CAM041650,https://zenodo.org/record/4291095/files/CAM041650_d.JPG,0,test,39567,lativitta,39567_CAM041650_d.JPG,major
-CAM017232,https://zenodo.org/record/3082688/files/CAM017232_d.JPG,1,test-2,4781,plesseni x malleti,4781_CAM017232_d.JPG,mimic
-CAM017259,https://zenodo.org/record/3082688/files/CAM017259_d.JPG,0,test,4830,notabilis,4830_CAM017259_d.JPG,major
-CAM045250,https://zenodo.org/record/5526257/files/CAM045250_d.JPG,0,test,43563,cyrbia,43563_CAM045250_d.JPG,minor
-19N0956,https://zenodo.org/record/4288311/files/19N0956_d.JPG,0,test-2,20124,malleti,20124_19N0956_d.JPG,mimic
-CAM016557,https://zenodo.org/record/3082688/files/CAM016557_d.JPG,1,test,3719,notabilis x lativitta,3719_CAM016557_d.JPG,major
-CAM017156,https://zenodo.org/record/3082688/files/CAM017156_d.JPG,0,test-2,4637,malleti,4637_CAM017156_d.JPG,mimic
-CAM016236,https://zenodo.org/record/4153502/files/CAM016236_D.JPG,1,test,19090,notabilis x lativitta,19090_CAM016236_D.JPG,major
-CAM041060,https://zenodo.org/record/2714333/files/CAM041060_d.JPG,0,test-2,13759,malleti,13759_CAM041060_d.JPG,mimic
-CAM041871,https://zenodo.org/record/4291095/files/CAM041871_d.JPG,0,test,40448,lativitta,40448_CAM041871_d.JPG,major
-CAM041872,https://zenodo.org/record/4291095/files/CAM041872_d.JPG,0,test,40452,lativitta,40452_CAM041872_d.JPG,major
-CAM041620,https://zenodo.org/record/4291095/files/CAM041620_d.JPG,0,test,39447,lativitta,39447_CAM041620_d.JPG,major
-CAM041863,https://zenodo.org/record/4291095/files/CAM041863_d.JPG,0,test,40416,lativitta,40416_CAM041863_d.JPG,major
-CAM016087,https://zenodo.org/record/3082688/files/CAM016087_d.JPG,1,test-2,3082,plesseni x malleti,3082_CAM016087_d.JPG,mimic
-CAM016322,https://zenodo.org/record/4153502/files/CAM016322_d.JPG,0,test,18870,notabilis,18870_CAM016322_d.JPG,major
-CAM016378,https://zenodo.org/record/3082688/files/CAM016378_d.JPG,0,test-2,3470,plesseni,3470_CAM016378_d.JPG,mimic
-CAM017239,https://zenodo.org/record/3082688/files/CAM017239_d.JPG,0,test,4795,notabilis,4795_CAM017239_d.JPG,major
-CAM016978,https://zenodo.org/record/3082688/files/CAM016978_d.JPG,1,test,4326,notabilis x lativitta,4326_CAM016978_d.JPG,major
-CAM041772,https://zenodo.org/record/4291095/files/CAM041772_d.JPG,0,test,40055,lativitta,40055_CAM041772_d.JPG,major
-CAM017057,https://zenodo.org/record/3082688/files/CAM017057_d.JPG,1,test,4463,notabilis x lativitta,4463_CAM017057_d.JPG,major
-CAM041891,https://zenodo.org/record/4291095/files/CAM041891_d.JPG,0,test,40528,lativitta,40528_CAM041891_d.JPG,major
-CAM016507,https://zenodo.org/record/3082688/files/CAM016507_d.JPG,1,test,3647,notabilis x lativitta,3647_CAM016507_d.JPG,major
-CAM045211,https://zenodo.org/record/5526257/files/CAM045211_d.JPG,0,test,43407,cyrbia,43407_CAM045211_d.JPG,minor
-CAM017222,https://zenodo.org/record/3082688/files/CAM017222_d.JPG,1,test,4761,notabilis x lativitta,4761_CAM017222_d.JPG,major
-CAM045200,https://zenodo.org/record/5526257/files/CAM045200_d.JPG,0,test,43365,cyrbia,43365_CAM045200_d.JPG,minor
-CAM009546,https://zenodo.org/record/2686762/files/CAM009546_d.JPG,1,test,10834,hydara x petiverana,10834_CAM009546_d.JPG,minor
-CAM045137,https://zenodo.org/record/5526257/files/CAM045137_d.JPG,0,test,43115,cyrbia,43115_CAM045137_d.JPG,minor
-CAM041479,https://zenodo.org/record/4291095/files/CAM041479_d.JPG,0,test,38888,lativitta,38888_CAM041479_d.JPG,major
-CAM041599,https://zenodo.org/record/4291095/files/CAM041599_d.JPG,0,test,39363,lativitta,39363_CAM041599_d.JPG,major
-CAM017412,https://zenodo.org/record/3082688/files/CAM017412_d.JPG,0,test-2,5061,malleti,5061_CAM017412_d.JPG,mimic
-CAM041809,https://zenodo.org/record/4291095/files/CAM041809_d.JPG,0,test,40203,lativitta,40203_CAM041809_d.JPG,major
-CAM041825,https://zenodo.org/record/4291095/files/CAM041825_d.JPG,0,test,40267,lativitta,40267_CAM041825_d.JPG,major
-CAM017023,https://zenodo.org/record/3082688/files/CAM017023_d.JPG,1,test,4401,notabilis x lativitta,4401_CAM017023_d.JPG,major
-CAM041777,https://zenodo.org/record/4291095/files/CAM041777_d.JPG,0,test,40075,lativitta,40075_CAM041777_d.JPG,major
-19N2141,https://zenodo.org/record/4288311/files/19N2141_d.JPG,0,test-2,21667,malleti,21667_19N2141_d.JPG,mimic
-CAM041369,https://zenodo.org/record/4291095/files/CAM041369_d.JPG,0,test-2,38456,malleti,38456_CAM041369_d.JPG,mimic
-CAM021029,https://zenodo.org/record/2702457/files/CAM021029_d.JPG,1,test,11492,hydara x amalfreda,11492_CAM021029_d.JPG,minor
-CAM041894,https://zenodo.org/record/4291095/files/CAM041894_d.JPG,0,test,40540,lativitta,40540_CAM041894_d.JPG,major
-CAM040298,https://zenodo.org/record/2707828/files/CAM040298_d.JPG,0,test-2,12212,malleti,12212_CAM040298_d.JPG,mimic
-CAM016247,https://zenodo.org/record/3082688/files/CAM016247_d.JPG,0,test-2,3356,plesseni,3356_CAM016247_d.JPG,mimic
-CAM016118,https://zenodo.org/record/3082688/files/CAM016118_d.JPG,1,test-2,3144,plesseni x malleti,3144_CAM016118_d.JPG,mimic
-CAM040180,https://zenodo.org/record/2707828/files/CAM040180_d.JPG,0,test-2,11990,malleti,11990_CAM040180_d.JPG,mimic
-CAM016092,https://zenodo.org/record/3082688/files/CAM016092_d.JPG,1,test-2,3092,plesseni x malleti,3092_CAM016092_d.JPG,mimic
-19N2230,https://zenodo.org/record/4288311/files/19N2230_d.JPG,0,test-2,21847,malleti,21847_19N2230_d.JPG,mimic
-CAM041767,https://zenodo.org/record/4291095/files/CAM041767_d.JPG,0,test,40035,lativitta,40035_CAM041767_d.JPG,major
-CAM017214,https://zenodo.org/record/3082688/files/CAM017214_d.JPG,0,test,4745,notabilis,4745_CAM017214_d.JPG,major
-CAM009003,https://zenodo.org/record/2686762/files/CAM009003_d.JPG,0,test,10111,hydara,10111_CAM009003_d.JPG,minor
-CAM041813,https://zenodo.org/record/4291095/files/CAM041813_d.JPG,0,test,40219,lativitta,40219_CAM041813_d.JPG,major
-CS003709,https://zenodo.org/record/2553501/files/CS3709 dorsal.jpeg,0,test-2,25965,malleti,25965_CS3709 dorsal.jpeg,mimic
-CAM045146,https://zenodo.org/record/5526257/files/CAM045146_d.JPG,0,test,43151,cyrbia,43151_CAM045146_d.JPG,minor
-CAM017384,https://zenodo.org/record/3082688/files/CAM017384_d.JPG,1,test-2,5018,plesseni x malleti,5018_CAM017384_d.JPG,mimic
-19N0246,https://zenodo.org/record/4288311/files/19N0246_d.JPG,0,test-2,19637,malleti,19637_19N0246_d.JPG,mimic
-CAM017333,https://zenodo.org/record/3082688/files/CAM017333_d.JPG,1,test,4944,notabilis x lativitta,4944_CAM017333_d.JPG,major
-19N1236,https://zenodo.org/record/4288311/files/19N1236_d.JPG,0,test-2,20245,malleti,20245_19N1236_d.JPG,mimic
-19N0034,https://zenodo.org/record/4288311/files/19N0034_d.JPG,0,test-2,19208,malleti,19208_19N0034_d.JPG,mimic
-CAM017055,https://zenodo.org/record/3082688/files/CAM017055_d.JPG,1,test,4459,notabilis x lativitta,4459_CAM017055_d.JPG,major
-CAM045248,https://zenodo.org/record/5526257/files/CAM045248_d.JPG,0,test,43555,cyrbia,43555_CAM045248_d.JPG,minor
-CAM016040,https://zenodo.org/record/3082688/files/CAM016040_d.JPG,1,test,2989,notabilis x lativitta,2989_CAM016040_d.JPG,major
-CAM017350,https://zenodo.org/record/3082688/files/CAM017350_d.JPG,1,test,4978,notabilis x lativitta,4978_CAM017350_d.JPG,major
-CAM017226,https://zenodo.org/record/3082688/files/CAM017226_d.JPG,1,test,4769,notabilis x lativitta,4769_CAM017226_d.JPG,major
-CS003542,https://zenodo.org/record/2553501/files/CS3542 dorsal.jpeg,0,test-2,25937,malleti,25937_CS3542 dorsal.jpeg,mimic
-19N1238,https://zenodo.org/record/4288311/files/19N1238_d.JPG,0,test,20249,erato,20249_19N1238_d.JPG,minor
-CAM016582,https://zenodo.org/record/3082688/files/CAM016582_d.JPG,1,test,3755,notabilis x lativitta,3755_CAM016582_d.JPG,major
-CAM009524,https://zenodo.org/record/2686762/files/CAM009524_d.JPG,0,test,10790,petiverana,10790_CAM009524_d.JPG,minor
-CAM017153,https://zenodo.org/record/3082688/files/CAM017153_d.JPG,1,test-2,4631,plesseni x malleti,4631_CAM017153_d.JPG,mimic
-CAM018309,https://zenodo.org/record/2702457/files/CAM018309_d.JPG,1,test-2,11052,plesseni x malleti,11052_CAM018309_d.JPG,mimic
-CAM016156,https://zenodo.org/record/3082688/files/CAM016156_d.JPG,1,test,3220,notabilis x lativitta,3220_CAM016156_d.JPG,major
-CAM017247,https://zenodo.org/record/3082688/files/CAM017247_d.JPG,0,test,4811,notabilis,4811_CAM017247_d.JPG,major
-CAM016846,https://zenodo.org/record/3082688/files/CAM016846_d.JPG,1,test-2,4111,plesseni x malleti,4111_CAM016846_d.JPG,mimic
-19N0867,https://zenodo.org/record/4288311/files/19N0867_d.JPG,0,test-2,20074,malleti,20074_19N0867_d.JPG,mimic
-CAM017328,https://zenodo.org/record/3082688/files/CAM017328_d.JPG,1,test,4934,notabilis x lativitta,4934_CAM017328_d.JPG,major
-19N1983,https://zenodo.org/record/4288311/files/19N1983_d.JPG,0,test-2,21347,malleti,21347_19N1983_d.JPG,mimic
-CAM041637,https://zenodo.org/record/4291095/files/CAM041637_d.JPG,0,test,39515,lativitta,39515_CAM041637_d.JPG,major
-CAM016689,https://zenodo.org/record/4153502/files/CAM016689_d.JPG,0,test-2,18922,plesseni,18922_CAM016689_d.JPG,mimic
-19N1381,https://zenodo.org/record/4288311/files/19N1381_d.JPG,0,test-2,20317,malleti,20317_19N1381_d.JPG,mimic
-CAM009156,https://zenodo.org/record/2686762/files/CAM009156_d.JPG,0,test-2,10281,plesseni,10281_CAM009156_d.JPG,mimic
-CAM009424,https://zenodo.org/record/2686762/files/CAM009424_d.JPG,0,test-2,10646,plesseni,10646_CAM009424_d.JPG,mimic
-19N0205,https://zenodo.org/record/4288311/files/19N0205_d.JPG,0,test-2,19555,malleti,19555_19N0205_d.JPG,mimic
-CAM017313,https://zenodo.org/record/4153502/files/CAM017313_d.JPG,1,test-2,19006,plesseni x malleti,19006_CAM017313_d.JPG,mimic
-CAM009126,https://zenodo.org/record/2686762/files/CAM009126_d.JPG,0,test,10221,etylus,10221_CAM009126_d.JPG,minor
-CAM041730,https://zenodo.org/record/4291095/files/CAM041730_d.JPG,0,test,39887,lativitta,39887_CAM041730_d.JPG,major
-19N2166,https://zenodo.org/record/4288311/files/19N2166_d.JPG,0,test-2,21699,malleti,21699_19N2166_d.JPG,mimic
-CAM045190,https://zenodo.org/record/5526257/files/CAM045190_d.JPG,0,test,43325,cyrbia,43325_CAM045190_d.JPG,minor
-CAM041643,https://zenodo.org/record/4291095/files/CAM041643_d.JPG,0,test,39539,lativitta,39539_CAM041643_d.JPG,major
-CAM017001,https://zenodo.org/record/3082688/files/CAM017001_d.JPG,1,test,4361,notabilis x lativitta,4361_CAM017001_d.JPG,major
-CAM041678,https://zenodo.org/record/4291095/files/CAM041678_d.JPG,0,test,39679,lativitta,39679_CAM041678_d.JPG,major
-CAM041811,https://zenodo.org/record/4291095/files/CAM041811_d.JPG,0,test,40211,lativitta,40211_CAM041811_d.JPG,major
-19N0187,https://zenodo.org/record/4288311/files/19N0187_d.JPG,0,test-2,19519,malleti,19519_19N0187_d.JPG,mimic
-CAM041833,https://zenodo.org/record/4291095/files/CAM041833_d.JPG,0,test,40299,lativitta,40299_CAM041833_d.JPG,major
-CAM016027,https://zenodo.org/record/3082688/files/CAM016027_d.JPG,1,test,2963,notabilis x lativitta,2963_CAM016027_d.JPG,major
-CAM017455,https://zenodo.org/record/1748277/files/CAM017455_d_whitestandard.JPG,0,test-2,15283,malleti,15283_CAM017455_d_whitestandard.JPG,mimic
-CAM017129,https://zenodo.org/record/3082688/files/CAM017129_d.JPG,1,test,4587,notabilis x lativitta,4587_CAM017129_d.JPG,major
-CAM041660,https://zenodo.org/record/4291095/files/CAM041660_d.JPG,0,test,39607,lativitta,39607_CAM041660_d.JPG,major
-CAM010089,https://zenodo.org/record/2549524/files/CAM010089_d.JPG,0,test-2,26347,malleti,26347_CAM010089_d.JPG,mimic
-CAM008866,https://zenodo.org/record/2686762/files/CAM008866_d.JPG,0,test,9953,hydara,9953_CAM008866_d.JPG,minor
-CAM041275,https://zenodo.org/record/2714333/files/CAM041275_d.JPG,0,test-2,14186,malleti,14186_CAM041275_d.JPG,mimic
-CAM017002,https://zenodo.org/record/3082688/files/CAM017002_d.JPG,1,test,4363,notabilis x lativitta,4363_CAM017002_d.JPG,major
-CAM016055,https://zenodo.org/record/3082688/files/CAM016055_d.JPG,1,test-2,3019,plesseni x malleti,3019_CAM016055_d.JPG,mimic
-CAM017426,https://zenodo.org/record/3082688/files/CAM017426_d.JPG,1,test,5089,notabilis x lativitta,5089_CAM017426_d.JPG,major
-CAM041458,https://zenodo.org/record/4291095/files/CAM041458_d.JPG,0,test-2,38804,malleti,38804_CAM041458_d.JPG,mimic
-CAM016517,https://zenodo.org/record/3082688/files/CAM016517_d.JPG,1,test,3667,notabilis x lativitta,3667_CAM016517_d.JPG,major
-CAM009544,https://zenodo.org/record/2686762/files/CAM009544_d.JPG,1,test,10830,hydara x petiverana,10830_CAM009544_d.JPG,minor
-CAM017148,https://zenodo.org/record/3082688/files/CAM017148_d.JPG,1,test,4621,notabilis x lativitta,4621_CAM017148_d.JPG,major
-CAM041147,https://zenodo.org/record/2714333/files/CAM041147_d.JPG,0,test-2,13931,malleti,13931_CAM041147_d.JPG,mimic
-CAM009417,https://zenodo.org/record/2686762/files/CAM009417_d.JPG,0,test-2,10632,plesseni,10632_CAM009417_d.JPG,mimic
-CAM017252,https://zenodo.org/record/3082688/files/CAM017252_d.JPG,0,test,4821,notabilis,4821_CAM017252_d.JPG,major
-CAM009237,https://zenodo.org/record/2686762/files/CAM009237_d.JPG,0,test-2,10442,plesseni,10442_CAM009237_d.JPG,mimic
-19N1861,https://zenodo.org/record/4288311/files/19N1861_d.JPG,0,test-2,21123,malleti,21123_19N1861_d.JPG,mimic
-CAM017618,https://zenodo.org/record/4153502/files/CAM017618_d.JPG,0,test-2,19062,plesseni,19062_CAM017618_d.JPG,mimic
-CAM041588,https://zenodo.org/record/4291095/files/CAM041588_d.JPG,0,test-2,39319,malleti,39319_CAM041588_d.JPG,mimic
-CAM017032,https://zenodo.org/record/3082688/files/CAM017032_d.JPG,1,test,4419,notabilis x lativitta,4419_CAM017032_d.JPG,major
-CAM040297,https://zenodo.org/record/2707828/files/CAM040297_d.JPG,0,test-2,12210,malleti,12210_CAM040297_d.JPG,mimic
-CAM036168,https://zenodo.org/record/5561246/files/CAM036168_d.JPG,0,test,41443,phyllis,41443_CAM036168_d.JPG,minor
-CAM041439,https://zenodo.org/record/4291095/files/CAM041439_d.JPG,0,test,38728,lativitta,38728_CAM041439_d.JPG,major
-CAM017311,https://zenodo.org/record/3082688/files/CAM017311_d.JPG,1,test,4908,notabilis x lativitta,4908_CAM017311_d.JPG,major
-19N1769,https://zenodo.org/record/4288311/files/19N1769_d.JPG,0,test-2,20991,malleti,20991_19N1769_d.JPG,mimic
-CAM045166,https://zenodo.org/record/5526257/files/CAM045166_d.JPG,0,test,43229,cyrbia,43229_CAM045166_d.JPG,minor
-19N0691,https://zenodo.org/record/4288311/files/19N0691_d.JPG,0,test-2,19984,malleti,19984_19N0691_d.JPG,mimic
-CAM000230,https://zenodo.org/record/2677821/files/CAM000230_d.JPG,0,test,6286,chestertonii,6286_CAM000230_d.JPG,minor
-CAM041497,https://zenodo.org/record/4291095/files/CAM041497_d.JPG,0,test-2,38960,malleti,38960_CAM041497_d.JPG,mimic
-CAM009230,https://zenodo.org/record/2686762/files/CAM009230_d.JPG,0,test-2,10428,plesseni,10428_CAM009230_d.JPG,mimic
-CAM041712,https://zenodo.org/record/4291095/files/CAM041712_d.JPG,0,test,39815,lativitta,39815_CAM041712_d.JPG,major
-19N2237,https://zenodo.org/record/4288311/files/19N2237_d.JPG,0,test-2,21875,malleti,21875_19N2237_d.JPG,mimic
-CAM009158,https://zenodo.org/record/2686762/files/CAM009158_d.JPG,0,test-2,10285,plesseni,10285_CAM009158_d.JPG,mimic
-CAM017159,https://zenodo.org/record/3082688/files/CAM017159_d.JPG,1,test,4643,notabilis x lativitta,4643_CAM017159_d.JPG,major
-19N2127,https://zenodo.org/record/4288311/files/19N2127_d.JPG,0,test-2,21647,malleti,21647_19N2127_d.JPG,mimic
-CAM016509,https://zenodo.org/record/3082688/files/CAM016509_d.JPG,1,test-2,3651,plesseni x malleti,3651_CAM016509_d.JPG,mimic
-CAM016084,https://zenodo.org/record/3082688/files/CAM016084_d.JPG,1,test-2,3076,plesseni x malleti,3076_CAM016084_d.JPG,mimic
-CAM016065,https://zenodo.org/record/3082688/files/CAM016065_d.JPG,1,test-2,3038,plesseni x malleti,3038_CAM016065_d.JPG,mimic
-CAM045195,https://zenodo.org/record/5526257/files/CAM045195_d.JPG,0,test,43345,cyrbia,43345_CAM045195_d.JPG,minor
-CAM016566,https://zenodo.org/record/3082688/files/CAM016566_d.JPG,1,test,3737,notabilis x lativitta,3737_CAM016566_d.JPG,major
-19N0123,https://zenodo.org/record/4288311/files/19N0123_d.JPG,0,test-2,19391,malleti,19391_19N0123_d.JPG,mimic
-CAM017125,https://zenodo.org/record/3082688/files/CAM017125_d.JPG,1,test-2,4579,plesseni x malleti,4579_CAM017125_d.JPG,mimic
-19N0169,https://zenodo.org/record/4288311/files/19N0169_d.JPG,0,test-2,19483,malleti,19483_19N0169_d.JPG,mimic
-CAM045021,https://zenodo.org/record/5526257/files/CAM045021_d.JPG,0,test,42649,cyrbia,42649_CAM045021_d.JPG,minor
-CAM041743,https://zenodo.org/record/4291095/files/CAM041743_d.JPG,0,test,39939,lativitta,39939_CAM041743_d.JPG,major
-CAM017092,https://zenodo.org/record/3082688/files/CAM017092_d.JPG,0,test-2,4525,malleti,4525_CAM017092_d.JPG,mimic
-15N111,https://zenodo.org/record/4289223/files/15N111_d.JPG,0,test,15169,venus,15169_15N111_d.JPG,minor
-CAM041517,https://zenodo.org/record/4291095/files/CAM041517_d.JPG,0,test-2,39040,malleti,39040_CAM041517_d.JPG,mimic
-19N0863,https://zenodo.org/record/4288311/files/19N0863_d.JPG,0,test-2,20066,malleti,20066_19N0863_d.JPG,mimic
-CAM017605,https://zenodo.org/record/3082688/files/CAM017605_d.JPG,1,test-2,5372,plesseni x malleti,5372_CAM017605_d.JPG,mimic
-CAM045020,https://zenodo.org/record/5526257/files/CAM045020_d.JPG,0,test,42645,cyrbia,42645_CAM045020_d.JPG,minor
-CAM016821,https://zenodo.org/record/3082688/files/CAM016821_d.JPG,1,test-2,4064,plesseni x malleti,4064_CAM016821_d.JPG,mimic
-CAM016190,https://zenodo.org/record/3082688/files/CAM016190_d.JPG,0,test-2,3288,malleti,3288_CAM016190_d.JPG,mimic
-CAM009234,https://zenodo.org/record/2686762/files/CAM009234_d.JPG,0,test-2,10436,plesseni,10436_CAM009234_d.JPG,mimic
-CAM016167,https://zenodo.org/record/3082688/files/CAM016167_d.JPG,1,test,3242,notabilis x lativitta,3242_CAM016167_d.JPG,major
-CAM009307,https://zenodo.org/record/2686762/files/CAM009307_d.JPG,0,test,10466,hydara,10466_CAM009307_d.JPG,minor
-CAM017174,https://zenodo.org/record/3082688/files/CAM017174_d.JPG,0,test,4669,notabilis,4669_CAM017174_d.JPG,major
-CAM045231,https://zenodo.org/record/5526257/files/CAM045231_d.JPG,0,test,43487,cyrbia,43487_CAM045231_d.JPG,minor
-CAM041862,https://zenodo.org/record/4291095/files/CAM041862_d.JPG,0,test,40412,lativitta,40412_CAM041862_d.JPG,major
-CAM041204,https://zenodo.org/record/2714333/files/CAM041204_d.JPG,0,test-2,14045,malleti,14045_CAM041204_d.JPG,mimic
-CAM041806,https://zenodo.org/record/4291095/files/CAM041806_d.JPG,0,test,40191,lativitta,40191_CAM041806_d.JPG,major
-CAM041371,https://zenodo.org/record/4291095/files/CAM041371_d.JPG,0,test-2,38464,malleti,38464_CAM041371_d.JPG,mimic
-CAM045209,https://zenodo.org/record/5526257/files/CAM045209_d.JPG,0,test,43399,cyrbia,43399_CAM045209_d.JPG,minor
-CAM120557,https://zenodo.org/record/2813153/files/CAM120557_d.JPG,0,test-2,14891,malleti,14891_CAM120557_d.JPG,mimic
-CAM016181,https://zenodo.org/record/3082688/files/CAM016181_d.JPG,1,test,3270,notabilis x lativitta,3270_CAM016181_d.JPG,major
-CS001321,https://zenodo.org/record/2553501/files/CS1321 dorsal.jpeg,0,test-2,25627,malleti,25627_CS1321 dorsal.jpeg,mimic
-CAM045148,https://zenodo.org/record/5526257/files/CAM045148_d.JPG,0,test,43159,cyrbia,43159_CAM045148_d.JPG,minor
-CAM000170,https://zenodo.org/record/2677821/files/CAM000170_d.JPG,0,test,6172,chestertonii,6172_CAM000170_d.JPG,minor
-CAM017180,https://zenodo.org/record/3082688/files/CAM017180_d.JPG,0,test,4680,notabilis,4680_CAM017180_d.JPG,major
-CAM010077,https://zenodo.org/record/2549524/files/CAM010077_d.JPG,0,test-2,26327,malleti,26327_CAM010077_d.JPG,mimic
-CAM017621,https://zenodo.org/record/4153502/files/CAM017621_d.JPG,0,test-2,19068,plesseni,19068_CAM017621_d.JPG,mimic
-CAM045270,https://zenodo.org/record/5526257/files/CAM045270_d.JPG,0,test,43643,cyrbia,43643_CAM045270_d.JPG,minor
-CAM017158,https://zenodo.org/record/3082688/files/CAM017158_d.JPG,1,test,4641,notabilis x lativitta,4641_CAM017158_d.JPG,major
-CAM017257,https://zenodo.org/record/3082688/files/CAM017257_d.JPG,1,test-2,4828,plesseni x malleti,4828_CAM017257_d.JPG,mimic
-19N1761,https://zenodo.org/record/4288311/files/19N1761_d.JPG,0,test-2,20971,malleti,20971_19N1761_d.JPG,mimic
-CAM017612,https://zenodo.org/record/3082688/files/CAM017612_d.JPG,1,test-2,5386,plesseni x malleti,5386_CAM017612_d.JPG,mimic
-19N2224,https://zenodo.org/record/4288311/files/19N2224_d.JPG,0,test-2,21823,malleti,21823_19N2224_d.JPG,mimic
-19N1888,https://zenodo.org/record/4288311/files/19N1888_d.JPG,0,test-2,21171,malleti,21171_19N1888_d.JPG,mimic
-CAM009526,https://zenodo.org/record/2686762/files/CAM009526_d.JPG,1,test,10794,hydara x petiverana,10794_CAM009526_d.JPG,minor
-CAM041605,https://zenodo.org/record/4291095/files/CAM041605_d.JPG,0,test,39387,lativitta,39387_CAM041605_d.JPG,major
-CAM016649,https://zenodo.org/record/3082688/files/CAM016649_d.JPG,1,test,3833,notabilis x lativitta,3833_CAM016649_d.JPG,major
-CAM045229,https://zenodo.org/record/5526257/files/CAM045229_d.JPG,0,test,43479,cyrbia,43479_CAM045229_d.JPG,minor
-CAM016228,https://zenodo.org/record/3082688/files/CAM016228_d.JPG,1,test-2,3340,plesseni x malleti,3340_CAM016228_d.JPG,mimic
-CAM016033,https://zenodo.org/record/3082688/files/CAM016033_d.JPG,1,test,2975,notabilis x lativitta,2975_CAM016033_d.JPG,major
-CS002274,https://zenodo.org/record/2735056/files/CS002274_d.JPG,0,test,40851,venus,40851_CS002274_d.JPG,minor
-CAM041601,https://zenodo.org/record/4291095/files/CAM041601_d.JPG,0,test,39371,lativitta,39371_CAM041601_d.JPG,major
-CAM018315,https://zenodo.org/record/2702457/files/CAM018315_d.JPG,1,test-2,11060,plesseni x malleti,11060_CAM018315_d.JPG,mimic
-CAM040295,https://zenodo.org/record/2707828/files/CAM040295_d.JPG,0,test-2,12206,malleti,12206_CAM040295_d.JPG,mimic
-CAM017188,https://zenodo.org/record/3082688/files/CAM017188_d.JPG,0,test,4696,notabilis,4696_CAM017188_d.JPG,major
-CAM036232,https://zenodo.org/record/5561246/files/CAM036232_d.JPG,0,test,41639,phyllis,41639_CAM036232_d.JPG,minor
-CAM017325,https://zenodo.org/record/4153502/files/CAM017325_d.JPG,0,test-2,19008,plesseni,19008_CAM017325_d.JPG,mimic
-19N2158,https://zenodo.org/record/4288311/files/19N2158_d.JPG,0,test-2,21687,malleti,21687_19N2158_d.JPG,mimic
-CAM017240,https://zenodo.org/record/3082688/files/CAM017240_d.JPG,0,test,4797,notabilis,4797_CAM017240_d.JPG,major
-CAM040266,https://zenodo.org/record/2707828/files/CAM040266_d.JPG,0,test-2,12148,malleti,12148_CAM040266_d.JPG,mimic
-CAM018529,https://zenodo.org/record/2702457/files/CAM018529_d.JPG,1,test-2,11389,malleti x plesseni,11389_CAM018529_d.JPG,mimic
-CAM045154,https://zenodo.org/record/5526257/files/CAM045154_d.JPG,0,test,43183,cyrbia,43183_CAM045154_d.JPG,minor
-CAM041855,https://zenodo.org/record/4291095/files/CAM041855_d.JPG,0,test,40384,lativitta,40384_CAM041855_d.JPG,major
-F868,https://zenodo.org/record/2555086/files/F868_d.JPG,0,test,38120,demophoon,38120_F868_d.JPG,minor
-CAM009189,https://zenodo.org/record/2686762/files/CAM009189_d.JPG,0,test-2,10347,plesseni,10347_CAM009189_d.JPG,mimic
-19N2249,https://zenodo.org/record/4288311/files/19N2249_d.JPG,0,test-2,21923,malleti,21923_19N2249_d.JPG,mimic
-CAM041817,https://zenodo.org/record/4291095/files/CAM041817_d.JPG,0,test,40235,lativitta,40235_CAM041817_d.JPG,major
-CAM045007,https://zenodo.org/record/5526257/files/CAM045007_d.JPG,0,test,42591,cyrbia,42591_CAM045007_d.JPG,minor
-CAM011428,https://zenodo.org/record/2550097/files/CAM011428_d.JPG,0,test-2,28212,malleti,28212_CAM011428_d.JPG,mimic
-CAM040731,https://zenodo.org/record/2714333/files/CAM040731_d.JPG,0,test-2,13093,malleti,13093_CAM040731_d.JPG,mimic
-CAM041711,https://zenodo.org/record/4291095/files/CAM041711_d.JPG,0,test,39811,lativitta,39811_CAM041711_d.JPG,major
-CAM017274,https://zenodo.org/record/3082688/files/CAM017274_d.JPG,1,test,4860,notabilis x lativitta,4860_CAM017274_d.JPG,major
-CAM017114,https://zenodo.org/record/3082688/files/CAM017114_d.JPG,1,test,4557,notabilis x lativitta,4557_CAM017114_d.JPG,major
-CAM017109,https://zenodo.org/record/3082688/files/CAM017109_d.JPG,1,test,4547,notabilis x lativitta,4547_CAM017109_d.JPG,major
-CAM016423,https://zenodo.org/record/3082688/files/CAM016423_d.JPG,1,test,3557,notabilis x lativitta,3557_CAM016423_d.JPG,major
-CAM016683,https://zenodo.org/record/4153502/files/CAM016683_d.JPG,0,test-2,18910,plesseni,18910_CAM016683_d.JPG,mimic
-CAM000233,https://zenodo.org/record/2677821/files/CAM000233_d.JPG,0,test,6292,chestertonii,6292_CAM000233_d.JPG,minor
-CAM045160,https://zenodo.org/record/5526257/files/CAM045160_d.JPG,0,test,43205,cyrbia,43205_CAM045160_d.JPG,minor
-CAM018295,https://zenodo.org/record/2702457/files/CAM018295_d.JPG,1,test-2,11032,plesseni x malleti,11032_CAM018295_d.JPG,mimic
-CAM017331,https://zenodo.org/record/3082688/files/CAM017331_d.JPG,1,test,4940,notabilis x lativitta,4940_CAM017331_d.JPG,major
-CAM016316,https://zenodo.org/record/4153502/files/CAM016316_D.JPG,1,test,19118,notabilis x lativitta,19118_CAM016316_D.JPG,major
-CAM045032,https://zenodo.org/record/5526257/files/CAM045032_d.JPG,0,test,42693,cyrbia,42693_CAM045032_d.JPG,minor
-CAM017041,https://zenodo.org/record/3082688/files/CAM017041_d.JPG,0,test-2,4435,malleti,4435_CAM017041_d.JPG,mimic
-CAM017608,https://zenodo.org/record/3082688/files/CAM017608_d.JPG,1,test,5378,notabilis x lativitta,5378_CAM017608_d.JPG,major
-CAM041360,https://zenodo.org/record/4291095/files/CAM041360_d.JPG,0,test,38420,lativitta,38420_CAM041360_d.JPG,major
-CAM041719,https://zenodo.org/record/4291095/files/CAM041719_d.JPG,0,test,39843,lativitta,39843_CAM041719_d.JPG,major
-19N2273,https://zenodo.org/record/4288311/files/19N2273_d.JPG,0,test-2,22019,malleti,22019_19N2273_d.JPG,mimic
-CAM045201,https://zenodo.org/record/5526257/files/CAM045201_d.JPG,0,test,43367,cyrbia,43367_CAM045201_d.JPG,minor
-CAM017091,https://zenodo.org/record/3082688/files/CAM017091_d.JPG,0,test-2,4523,malleti,4523_CAM017091_d.JPG,mimic
-CAM041367,https://zenodo.org/record/4291095/files/CAM041367_d.JPG,0,test-2,38448,malleti,38448_CAM041367_d.JPG,mimic
-CAM016545,https://zenodo.org/record/3082688/files/CAM016545_d.JPG,0,test-2,3699,malleti,3699_CAM016545_d.JPG,mimic
-CAM040198,https://zenodo.org/record/2707828/files/CAM040198_d.JPG,0,test-2,12022,malleti,12022_CAM040198_d.JPG,mimic
-CAM036172,https://zenodo.org/record/5561246/files/CAM036172_d.JPG,0,test,41459,phyllis,41459_CAM036172_d.JPG,minor
-CAM017365,https://zenodo.org/record/4153502/files/CAM017365_d.JPG,0,test-2,19026,plesseni,19026_CAM017365_d.JPG,mimic
-CAM017316,https://zenodo.org/record/3082688/files/CAM017316_d.JPG,1,test,4916,notabilis x lativitta,4916_CAM017316_d.JPG,major
-CAM045054,https://zenodo.org/record/5526257/files/CAM045054_d.JPG,0,test,42781,cyrbia,42781_CAM045054_d.JPG,minor
-CAM045244,https://zenodo.org/record/5526257/files/CAM045244_d.JPG,0,test,43539,cyrbia,43539_CAM045244_d.JPG,minor
-CAM000236,https://zenodo.org/record/2677821/files/CAM000236_d.JPG,0,test,6298,chestertonii,6298_CAM000236_d.JPG,minor
-CAM017319,https://zenodo.org/record/3082688/files/CAM017319_d.JPG,1,test,4922,notabilis x lativitta,4922_CAM017319_d.JPG,major
-CAM045033,https://zenodo.org/record/5526257/files/CAM045033_d.JPG,0,test,42697,cyrbia,42697_CAM045033_d.JPG,minor
-CAM017308,https://zenodo.org/record/3082688/files/CAM017308_d.JPG,1,test,4902,notabilis x lativitta,4902_CAM017308_d.JPG,major
-CAM041850,https://zenodo.org/record/4291095/files/CAM041850_d.JPG,0,test,40367,lativitta,40367_CAM041850_d.JPG,major
-CAM045011,https://zenodo.org/record/5526257/files/CAM045011_d.JPG,0,test,42609,cyrbia,42609_CAM045011_d.JPG,minor
-CAM045243,https://zenodo.org/record/5526257/files/CAM045243_d.JPG,0,test,43535,cyrbia,43535_CAM045243_d.JPG,minor
-CAM016020,https://zenodo.org/record/3082688/files/CAM016020_d.JPG,1,test,2949,notabilis x lativitta,2949_CAM016020_d.JPG,major
-F824,https://zenodo.org/record/2555086/files/F824_d.JPG,0,test,38052,demophoon,38052_F824_d.JPG,minor
-CAM016655,https://zenodo.org/record/3082688/files/CAM016655_d.JPG,1,test-2,3845,plesseni x malleti,3845_CAM016655_d.JPG,mimic
-CAM016171,https://zenodo.org/record/3082688/files/CAM016171_d.JPG,1,test,3250,notabilis x lativitta,3250_CAM016171_d.JPG,major
-CAM016022,https://zenodo.org/record/3082688/files/CAM016022_d.JPG,1,test,2953,notabilis x lativitta,2953_CAM016022_d.JPG,major
-CAM041702,https://zenodo.org/record/4291095/files/CAM041702_d.JPG,0,test,39775,lativitta,39775_CAM041702_d.JPG,major
-CAM016645,https://zenodo.org/record/3082688/files/CAM016645_d.JPG,1,test,3825,notabilis x lativitta,3825_CAM016645_d.JPG,major
-CAM016309,https://zenodo.org/record/3082688/files/CAM016309_d.JPG,1,test-2,3414,plesseni x malleti,3414_CAM016309_d.JPG,mimic
-CAM018482,https://zenodo.org/record/2702457/files/CAM018482_d.JPG,1,test-2,11305,plesseni x malleti,11305_CAM018482_d.JPG,mimic
-CAM041781,https://zenodo.org/record/4291095/files/CAM041781_d.JPG,0,test,40091,lativitta,40091_CAM041781_d.JPG,major
-CAM017748,https://zenodo.org/record/3082688/files/CAM017748_d.JPG,1,test,5506,lativitta x notabilis,5506_CAM017748_d.JPG,major
-CAM041787,https://zenodo.org/record/4291095/files/CAM041787_d.JPG,0,test,40115,lativitta,40115_CAM041787_d.JPG,major
-15N146,https://zenodo.org/record/4289223/files/15N146_d.JPG,0,test,14959,venus,14959_15N146_d.JPG,minor
-CAM021028,https://zenodo.org/record/2702457/files/CAM021028_d.JPG,1,test,11490,hydara x amalfreda,11490_CAM021028_d.JPG,minor
-CAM041890,https://zenodo.org/record/4291095/files/CAM041890_d.JPG,0,test,40524,lativitta,40524_CAM041890_d.JPG,major
-CAM041904,https://zenodo.org/record/4291095/files/CAM041904_d.JPG,0,test,40580,lativitta,40580_CAM041904_d.JPG,major
-CAM041639,https://zenodo.org/record/4291095/files/CAM041639_d.JPG,0,test,39523,lativitta,39523_CAM041639_d.JPG,major
-CAM016096,https://zenodo.org/record/3082688/files/CAM016096_d.JPG,1,test,3100,notabilis x lativitta,3100_CAM016096_d.JPG,major
-CAM017603,https://zenodo.org/record/3082688/files/CAM017603_d.JPG,1,test,5368,notabilis x lativitta,5368_CAM017603_d.JPG,major
-CAM016183,https://zenodo.org/record/3082688/files/CAM016183_d.JPG,1,test,3274,notabilis x lativitta,3274_CAM016183_d.JPG,major
-CAM045008,https://zenodo.org/record/5526257/files/CAM045008_d.JPG,0,test,42595,cyrbia,42595_CAM045008_d.JPG,minor
-19N1393,https://zenodo.org/record/4288311/files/19N1393_d.JPG,0,test-2,20331,malleti,20331_19N1393_d.JPG,mimic
-CAM016282,https://zenodo.org/record/3082688/files/CAM016282_d.JPG,0,test-2,3396,plesseni,3396_CAM016282_d.JPG,mimic
-CAM008539,https://zenodo.org/record/2684906/files/CAM008539_d.JPG,0,test-2,9432,plesseni,9432_CAM008539_d.JPG,mimic
-CAM016785,https://zenodo.org/record/3082688/files/CAM016785_d.JPG,1,test-2,3992,plesseni x malleti,3992_CAM016785_d.JPG,mimic
-19N2259,https://zenodo.org/record/4288311/files/19N2259_d.JPG,0,test-2,21963,malleti,21963_19N2259_d.JPG,mimic
-CAM045001,https://zenodo.org/record/5526257/files/CAM045001_d.JPG,0,test,42563,cyrbia,42563_CAM045001_d.JPG,minor
-CAM017713,https://zenodo.org/record/3082688/files/CAM017713_d.JPG,1,test,5466,lativitta x notabilis,5466_CAM017713_d.JPG,major
-CAM040263,https://zenodo.org/record/2707828/files/CAM040263_d.JPG,0,test-2,12142,malleti,12142_CAM040263_d.JPG,mimic
-F875,https://zenodo.org/record/2555086/files/F875_d.JPG,0,test,38136,demophoon,38136_F875_d.JPG,minor
-CAM041357,https://zenodo.org/record/4291095/files/CAM041357_d.JPG,0,test,38408,lativitta,38408_CAM041357_d.JPG,major
-CAM016849,https://zenodo.org/record/3082688/files/CAM016849_d.JPG,1,test-2,4117,plesseni x malleti,4117_CAM016849_d.JPG,mimic
-CAM016130,https://zenodo.org/record/3082688/files/CAM016130_d.JPG,1,test-2,3168,plesseni x malleti,3168_CAM016130_d.JPG,mimic
-CAM017104,https://zenodo.org/record/3082688/files/CAM017104_d.JPG,0,test-2,4545,malleti,4545_CAM017104_d.JPG,mimic
-CAM016672,https://zenodo.org/record/3082688/files/CAM016672_d.JPG,1,test-2,3878,plesseni x malleti,3878_CAM016672_d.JPG,mimic
-CAM041769,https://zenodo.org/record/4291095/files/CAM041769_d.JPG,0,test,40043,lativitta,40043_CAM041769_d.JPG,major
-CAM016602,https://zenodo.org/record/3082688/files/CAM016602_d.JPG,1,test-2,3791,plesseni x malleti,3791_CAM016602_d.JPG,mimic
-19N1864,https://zenodo.org/record/4288311/files/19N1864_d.JPG,0,test-2,21131,malleti,21131_19N1864_d.JPG,mimic
-CAM041064,https://zenodo.org/record/2714333/files/CAM041064_d.JPG,0,test-2,13767,malleti,13767_CAM041064_d.JPG,mimic
-CAM041212,https://zenodo.org/record/2714333/files/CAM041212_d.JPG,0,test-2,14061,malleti,14061_CAM041212_d.JPG,mimic
-19N1646,https://zenodo.org/record/4288311/files/19N1646_d.JPG,0,test-2,20835,malleti,20835_19N1646_d.JPG,mimic
-19N2229,https://zenodo.org/record/4288311/files/19N2229_d.JPG,0,test-2,21843,malleti,21843_19N2229_d.JPG,mimic
-CAM045024,https://zenodo.org/record/5526257/files/CAM045024_d.JPG,0,test,42661,cyrbia,42661_CAM045024_d.JPG,minor
-CAM017248,https://zenodo.org/record/3082688/files/CAM017248_d.JPG,0,test,4813,notabilis,4813_CAM017248_d.JPG,major
-CAM045050,https://zenodo.org/record/5526257/files/CAM045050_d.JPG,0,test,42765,cyrbia,42765_CAM045050_d.JPG,minor
-CAM009568,https://zenodo.org/record/2686762/files/CAM009568_d.JPG,1,test,10878,hydara x petiverana,10878_CAM009568_d.JPG,minor
-CAM008226,https://zenodo.org/record/2684906/files/CAM008226_d.JPG,0,test-2,8895,malleti,8895_CAM008226_d.JPG,mimic
-CAM017190,https://zenodo.org/record/3082688/files/CAM017190_d.JPG,0,test,4700,notabilis,4700_CAM017190_d.JPG,major
-CAM040259,https://zenodo.org/record/2707828/files/CAM040259_d.JPG,0,test-2,12134,malleti,12134_CAM040259_d.JPG,mimic
-CAM016819,https://zenodo.org/record/3082688/files/CAM016819_d.JPG,1,test-2,4060,plesseni x malleti,4060_CAM016819_d.JPG,mimic
-CAM009300,https://zenodo.org/record/2686762/files/CAM009300_d.JPG,0,test,10452,hydara,10452_CAM009300_d.JPG,minor
-CAM009429,https://zenodo.org/record/2686762/files/CAM009429_d.JPG,0,test-2,10656,plesseni,10656_CAM009429_d.JPG,mimic
-CAM017235,https://zenodo.org/record/3082688/files/CAM017235_d.JPG,1,test,4787,notabilis x lativitta,4787_CAM017235_d.JPG,major
-CAM016186,https://zenodo.org/record/3082688/files/CAM016186_d.JPG,1,test,3280,notabilis x lativitta,3280_CAM016186_d.JPG,major
-CAM041682,https://zenodo.org/record/4291095/files/CAM041682_d.JPG,0,test,39695,lativitta,39695_CAM041682_d.JPG,major
-CAM016141,https://zenodo.org/record/3082688/files/CAM016141_d.JPG,1,test-2,3190,plesseni x malleti,3190_CAM016141_d.JPG,mimic
-19N1471,https://zenodo.org/record/4288311/files/19N1471_d.JPG,0,test-2,20381,malleti,20381_19N1471_d.JPG,mimic
-CAM041000,https://zenodo.org/record/2714333/files/CAM041000_d.JPG,0,test-2,13639,malleti,13639_CAM041000_d.JPG,mimic
-CAM041818,https://zenodo.org/record/4291095/files/CAM041818_d.JPG,0,test,40239,lativitta,40239_CAM041818_d.JPG,major
-CAM009304,https://zenodo.org/record/2686762/files/CAM009304_d.JPG,0,test,10460,hydara,10460_CAM009304_d.JPG,minor
-CAM041434,https://zenodo.org/record/4291095/files/CAM041434_d.JPG,0,test,38708,lativitta,38708_CAM041434_d.JPG,major
-CAM021073,https://zenodo.org/record/2702457/files/CAM021073_d.JPG,0,test,11575,erato,11575_CAM021073_d.JPG,minor
-19N1349,https://zenodo.org/record/4288311/files/19N1349_d.JPG,0,test-2,20289,malleti,20289_19N1349_d.JPG,mimic
-19N1907,https://zenodo.org/record/4288311/files/19N1907_d.JPG,0,test-2,21207,malleti,21207_19N1907_d.JPG,mimic
-CAM041732,https://zenodo.org/record/4291095/files/CAM041732_d.JPG,0,test,39895,lativitta,39895_CAM041732_d.JPG,major
-19N0068,https://zenodo.org/record/4288311/files/19N0068_d.JPG,0,test-2,19281,malleti,19281_19N0068_d.JPG,mimic
-CAM017051,https://zenodo.org/record/3082688/files/CAM017051_d.JPG,1,test,4451,notabilis x lativitta,4451_CAM017051_d.JPG,major
-CAM041359,https://zenodo.org/record/4291095/files/CAM041359_d.JPG,0,test,38416,lativitta,38416_CAM041359_d.JPG,major
-19N0076,https://zenodo.org/record/4288311/files/19N0076_d.JPG,0,test-2,19297,malleti,19297_19N0076_d.JPG,mimic
-19N0153,https://zenodo.org/record/4288311/files/19N0153_d.JPG,0,test-2,19451,malleti,19451_19N0153_d.JPG,mimic
-19N0981,https://zenodo.org/record/4288311/files/19N0981_d.JPG,0,test-2,20135,malleti,20135_19N0981_d.JPG,mimic
-CAM041093,https://zenodo.org/record/2714333/files/CAM041093_d.JPG,0,test-2,13824,malleti,13824_CAM041093_d.JPG,mimic
-CAM040269,https://zenodo.org/record/2707828/files/CAM040269_d.JPG,0,test-2,12154,malleti,12154_CAM040269_d.JPG,mimic
-CAM041880,https://zenodo.org/record/4291095/files/CAM041880_d.JPG,0,test,40484,lativitta,40484_CAM041880_d.JPG,major
-CAM000238,https://zenodo.org/record/2677821/files/CAM000238_d.JPG,0,test,6302,chestertonii,6302_CAM000238_d.JPG,minor
-CAM018268,https://zenodo.org/record/2548678/files/CAM018268_v_whitestandard.JPG,0,test-2,17501,plesseni,17501_CAM018268_v_whitestandard.JPG,mimic
-CAM016466,https://zenodo.org/record/3082688/files/CAM016466_d.JPG,1,test,3629,notabilis x lativitta,3629_CAM016466_d.JPG,major
-19N0613,https://zenodo.org/record/4288311/files/19N0613_d.JPG,0,test-2,19910,malleti,19910_19N0613_d.JPG,mimic
-CAM041831,https://zenodo.org/record/4291095/files/CAM041831_d.JPG,0,test,40291,lativitta,40291_CAM041831_d.JPG,major
-CAM017668,https://zenodo.org/record/3082688/files/CAM017668_d.JPG,1,test-2,5414,malleti x plesseni,5414_CAM017668_d.JPG,mimic
-CAM021035,https://zenodo.org/record/2702457/files/CAM021035_d.JPG,1,test,11504,hydara x amalfreda,11504_CAM021035_d.JPG,minor
-CAM017186,https://zenodo.org/record/3082688/files/CAM017186_d.JPG,0,test-2,4692,plesseni,4692_CAM017186_d.JPG,mimic
-F852,https://zenodo.org/record/2555086/files/F852_d.JPG,0,test,38084,demophoon,38084_F852_d.JPG,minor
-CAM041903,https://zenodo.org/record/4291095/files/CAM041903_d.JPG,0,test,40576,lativitta,40576_CAM041903_d.JPG,major
-F853,https://zenodo.org/record/2555086/files/F853_d.JPG,0,test,38088,demophoon,38088_F853_d.JPG,minor
-CAM041206,https://zenodo.org/record/2714333/files/CAM041206_d.JPG,0,test-2,14049,malleti,14049_CAM041206_d.JPG,mimic
-CAM017200,https://zenodo.org/record/3082688/files/CAM017200_d.JPG,0,test,4719,notabilis,4719_CAM017200_d.JPG,major
-CAM041186,https://zenodo.org/record/2714333/files/CAM041186_d.JPG,0,test-2,14009,malleti,14009_CAM041186_d.JPG,mimic
-CAM017312,https://zenodo.org/record/3082688/files/CAM017312_d.JPG,1,test,4910,notabilis x lativitta,4910_CAM017312_d.JPG,major
-CAM016143,https://zenodo.org/record/3082688/files/CAM016143_d.JPG,1,test-2,3194,plesseni x malleti,3194_CAM016143_d.JPG,mimic
-CAM040732,https://zenodo.org/record/2714333/files/CAM040732_d.JPG,0,test-2,13097,malleti,13097_CAM040732_d.JPG,mimic
-CAM016231,https://zenodo.org/record/4153502/files/CAM016231_D.JPG,1,test,19084,notabilis x lativitta,19084_CAM016231_D.JPG,major
-CAM016044,https://zenodo.org/record/3082688/files/CAM016044_d.JPG,1,test-2,2997,plesseni x malleti,2997_CAM016044_d.JPG,mimic
-CAM016221,https://zenodo.org/record/4153502/files/CAM016221_D.JPG,1,test,19080,notabilis x lativitta,19080_CAM016221_D.JPG,major
-CAM045179,https://zenodo.org/record/5526257/files/CAM045179_d.JPG,0,test,43281,cyrbia,43281_CAM045179_d.JPG,minor
-CS001815,https://zenodo.org/record/2553501/files/CS1815 dorsal.jpeg,0,test-2,25643,malleti,25643_CS1815 dorsal.jpeg,mimic
-CAM017243,https://zenodo.org/record/3082688/files/CAM017243_d.JPG,0,test,4803,notabilis,4803_CAM017243_d.JPG,major
-F844,https://zenodo.org/record/2555086/files/F844_d.JPG,0,test,38064,demophoon,38064_F844_d.JPG,minor
-CAM045067,https://zenodo.org/record/5526257/files/CAM045067_d.JPG,0,test,42833,cyrbia,42833_CAM045067_d.JPG,minor
-CAM017195,https://zenodo.org/record/3082688/files/CAM017195_d.JPG,0,test,4710,notabilis,4710_CAM017195_d.JPG,major
-CAM017095,https://zenodo.org/record/3082688/files/CAM017095_d.JPG,1,test-2,4531,plesseni x malleti,4531_CAM017095_d.JPG,mimic
-CAM017099,https://zenodo.org/record/3082688/files/CAM017099_d.JPG,0,test-2,4537,malleti,4537_CAM017099_d.JPG,mimic
-19N0174,https://zenodo.org/record/4288311/files/19N0174_d.JPG,0,test-2,19493,malleti,19493_19N0174_d.JPG,mimic
-CAM017212,https://zenodo.org/record/3082688/files/CAM017212_d.JPG,0,test,4741,notabilis,4741_CAM017212_d.JPG,major
-CAM009193,https://zenodo.org/record/2686762/files/CAM009193_d.JPG,0,test-2,10355,plesseni,10355_CAM009193_d.JPG,mimic
-CAM021034,https://zenodo.org/record/2702457/files/CAM021034_d.JPG,1,test,11502,hydara x amalfreda,11502_CAM021034_d.JPG,minor
-19N0948,https://zenodo.org/record/4288311/files/19N0948_d.JPG,0,test-2,20116,malleti,20116_19N0948_d.JPG,mimic
-19N0864,https://zenodo.org/record/4288311/files/19N0864_d.JPG,0,test-2,20068,malleti,20068_19N0864_d.JPG,mimic
-19N0114,https://zenodo.org/record/4288311/files/19N0114_d.JPG,0,test-2,19373,malleti,19373_19N0114_d.JPG,mimic
-CAM017056,https://zenodo.org/record/3082688/files/CAM017056_d.JPG,1,test,4461,notabilis x lativitta,4461_CAM017056_d.JPG,major
-CAM000148,https://zenodo.org/record/2677821/files/CAM000148_d.JPG,0,test,6128,chestertonii,6128_CAM000148_d.JPG,minor
-CAM041203,https://zenodo.org/record/2714333/files/CAM041203_d.JPG,0,test-2,14043,malleti,14043_CAM041203_d.JPG,mimic
-CAM017233,https://zenodo.org/record/3082688/files/CAM017233_d.JPG,1,test-2,4783,plesseni x malleti,4783_CAM017233_d.JPG,mimic
-CAM045140,https://zenodo.org/record/5526257/files/CAM045140_d.JPG,0,test,43127,cyrbia,43127_CAM045140_d.JPG,minor
-19N1194,https://zenodo.org/record/4288311/files/19N1194_d.JPG,0,test-2,20221,malleti,20221_19N1194_d.JPG,mimic
-CAM017040,https://zenodo.org/record/3082688/files/CAM017040_d.JPG,1,test-2,4433,plesseni x malleti,4433_CAM017040_d.JPG,mimic
-CAM018360,https://zenodo.org/record/2702457/files/CAM018360_d.JPG,1,test-2,11127,plesseni x malleti,11127_CAM018360_d.JPG,mimic
-CAM016769,https://zenodo.org/record/3082688/files/CAM016769_d.JPG,1,test-2,3974,plesseni x malleti,3974_CAM016769_d.JPG,mimic
-CAM016525,https://zenodo.org/record/3082688/files/CAM016525_d.JPG,1,test,3681,notabilis x lativitta,3681_CAM016525_d.JPG,major
-CAM045157,https://zenodo.org/record/5526257/files/CAM045157_d.JPG,0,test,43193,cyrbia,43193_CAM045157_d.JPG,minor
-CAM017272,https://zenodo.org/record/3082688/files/CAM017272_d.JPG,0,test-2,4856,malleti,4856_CAM017272_d.JPG,mimic
-CAM016197,https://zenodo.org/record/3082688/files/CAM016197_d.JPG,0,test-2,3302,malleti,3302_CAM016197_d.JPG,mimic
-CAM045205,https://zenodo.org/record/5526257/files/CAM045205_d.JPG,0,test,43383,cyrbia,43383_CAM045205_d.JPG,minor
-CAM002903,https://zenodo.org/record/2684906/files/CAM002903_d.JPG,1,test,8491,hydara x petiverana,8491_CAM002903_d.JPG,minor
-19N1392,https://zenodo.org/record/4288311/files/19N1392_d.JPG,0,test-2,20329,malleti,20329_19N1392_d.JPG,mimic
-CAM016406,https://zenodo.org/record/3082688/files/CAM016406_d.JPG,1,test-2,3523,plesseni x malleti,3523_CAM016406_d.JPG,mimic
-CAM016954,https://zenodo.org/record/3082688/files/CAM016954_d.JPG,0,test-2,4285,malleti,4285_CAM016954_d.JPG,mimic
-CAM021239,https://zenodo.org/record/2702457/files/CAM021239_d.JPG,0,test,11688,hydara,11688_CAM021239_d.JPG,minor
-CAM016111,https://zenodo.org/record/3082688/files/CAM016111_d.JPG,1,test-2,3130,plesseni x malleti,3130_CAM016111_d.JPG,mimic
-CAM016017,https://zenodo.org/record/3082688/files/CAM016017_d.JPG,1,test,2943,notabilis x lativitta,2943_CAM016017_d.JPG,major
-CAM009202,https://zenodo.org/record/2686762/files/CAM009202_d.JPG,0,test-2,10373,plesseni,10373_CAM009202_d.JPG,mimic
-CAM036274,https://zenodo.org/record/5561246/files/CAM036274_d.JPG,0,test,41751,phyllis,41751_CAM036274_d.JPG,minor
-CAM045159,https://zenodo.org/record/5526257/files/CAM045159_d.JPG,0,test,43201,cyrbia,43201_CAM045159_d.JPG,minor
-CAM045118,https://zenodo.org/record/5526257/files/CAM045118_d.JPG,0,test,43039,cyrbia,43039_CAM045118_d.JPG,minor
-CAM017348,https://zenodo.org/record/3082688/files/CAM017348_d.JPG,1,test,4974,notabilis x lativitta,4974_CAM017348_d.JPG,major
-19N2221,https://zenodo.org/record/4288311/files/19N2221_d.JPG,0,test-2,21811,malleti,21811_19N2221_d.JPG,mimic
-CAM018281,https://zenodo.org/record/2702457/files/CAM018281_d.JPG,1,test-2,11018,plesseni x malleti,11018_CAM018281_d.JPG,mimic
-CAM016131,https://zenodo.org/record/3082688/files/CAM016131_d.JPG,1,test-2,3170,plesseni x malleti,3170_CAM016131_d.JPG,mimic
-19N1312,https://zenodo.org/record/4288311/files/19N1312_d.JPG,0,test-2,20269,malleti,20269_19N1312_d.JPG,mimic
-19N0899,https://zenodo.org/record/4288311/files/19N0899_d.JPG,0,test-2,20094,malleti,20094_19N0899_d.JPG,mimic
-CAM041366,https://zenodo.org/record/4291095/files/CAM041366_d.JPG,0,test,38444,lativitta,38444_CAM041366_d.JPG,major
-CAM041698,https://zenodo.org/record/4291095/files/CAM041698_d.JPG,0,test,39759,lativitta,39759_CAM041698_d.JPG,major
-CAM016287,https://zenodo.org/record/3082688/files/CAM016287_d.JPG,0,test-2,3400,plesseni,3400_CAM016287_d.JPG,mimic
-19N1421,https://zenodo.org/record/4288311/files/19N1421_d.JPG,0,test-2,20351,malleti,20351_19N1421_d.JPG,mimic
-CAM008997,https://zenodo.org/record/2686762/files/CAM008997_d.JPG,0,test,10099,hydara,10099_CAM008997_d.JPG,minor
-F867,https://zenodo.org/record/2555086/files/F867_d.JPG,0,test,38116,demophoon,38116_F867_d.JPG,minor
-CAM017064,https://zenodo.org/record/3082688/files/CAM017064_d.JPG,0,test-2,4477,malleti,4477_CAM017064_d.JPG,mimic
-19N0116,https://zenodo.org/record/4288311/files/19N0116_d.JPG,0,test-2,19377,malleti,19377_19N0116_d.JPG,mimic
-CAM009205,https://zenodo.org/record/2686762/files/CAM009205_d.JPG,0,test-2,10379,plesseni,10379_CAM009205_d.JPG,mimic
-CAM045059,https://zenodo.org/record/5526257/files/CAM045059_d.JPG,0,test,42801,cyrbia,42801_CAM045059_d.JPG,minor
-CAM017754,https://zenodo.org/record/3082688/files/CAM017754_d.JPG,1,test,5514,lativitta x notabilis,5514_CAM017754_d.JPG,major
-CAM036292,https://zenodo.org/record/5561246/files/CAM036292_d.JPG,0,test,41823,phyllis,41823_CAM036292_d.JPG,minor
-CAM017447,https://zenodo.org/record/3082688/files/CAM017447_d.JPG,1,test,5128,notabilis x lativitta,5128_CAM017447_d.JPG,major
-CAM017826,https://zenodo.org/record/3082688/files/CAM017826_d.JPG,1,test,5599,lativitta x notabilis,5599_CAM017826_d.JPG,major
-CAM017338,https://zenodo.org/record/3082688/files/CAM017338_d.JPG,1,test,4954,notabilis x lativitta,4954_CAM017338_d.JPG,major
-CAM041591,https://zenodo.org/record/4291095/files/CAM041591_d.JPG,0,test,39331,lativitta,39331_CAM041591_d.JPG,major
-CAM016349,https://zenodo.org/record/3082688/files/CAM016349_d.JPG,0,test-2,3434,plesseni,3434_CAM016349_d.JPG,mimic
-CAM009200,https://zenodo.org/record/2686762/files/CAM009200_d.JPG,0,test-2,10369,plesseni,10369_CAM009200_d.JPG,mimic
-CAM016242,https://zenodo.org/record/3082688/files/CAM016242_d.JPG,1,test-2,3352,plesseni x malleti,3352_CAM016242_d.JPG,mimic
-CAM016867,https://zenodo.org/record/3082688/files/CAM016867_d.JPG,1,test-2,4153,plesseni x malleti,4153_CAM016867_d.JPG,mimic
-CAM041744,https://zenodo.org/record/4291095/files/CAM041744_d.JPG,0,test,39943,lativitta,39943_CAM041744_d.JPG,major
-CAM017142,https://zenodo.org/record/3082688/files/CAM017142_d.JPG,1,test,4609,notabilis x lativitta,4609_CAM017142_d.JPG,major
-CAM016029,https://zenodo.org/record/3082688/files/CAM016029_d.JPG,1,test,2967,notabilis x lativitta,2967_CAM016029_d.JPG,major
-CAM041867,https://zenodo.org/record/4291095/files/CAM041867_d.JPG,0,test,40432,lativitta,40432_CAM041867_d.JPG,major
-CAM016136,https://zenodo.org/record/3082688/files/CAM016136_d.JPG,1,test-2,3180,plesseni x malleti,3180_CAM016136_d.JPG,mimic
-19N0341,https://zenodo.org/record/4288311/files/19N0341_d.JPG,0,test-2,19780,malleti,19780_19N0341_d.JPG,mimic
-CAM040021,https://zenodo.org/record/2707828/files/CAM040021_d.JPG,0,test-2,11726,malleti,11726_CAM040021_d.JPG,mimic
-CAM041442,https://zenodo.org/record/4291095/files/CAM041442_d.JPG,0,test,38740,lativitta,38740_CAM041442_d.JPG,major
-CAM009199,https://zenodo.org/record/2686762/files/CAM009199_d.JPG,0,test-2,10367,plesseni,10367_CAM009199_d.JPG,mimic
-CAM041704,https://zenodo.org/record/4291095/files/CAM041704_d.JPG,0,test,39783,lativitta,39783_CAM041704_d.JPG,major
-CAM016691,https://zenodo.org/record/4153502/files/CAM016691_d.JPG,0,test-2,18926,plesseni,18926_CAM016691_d.JPG,mimic
-CAM016249,https://zenodo.org/record/3082688/files/CAM016249_d.JPG,1,test-2,3358,plesseni x malleti,3358_CAM016249_d.JPG,mimic
-CAM016079,https://zenodo.org/record/3082688/files/CAM016079_d.JPG,1,test,3066,notabilis x lativitta,3066_CAM016079_d.JPG,major
-CAM041856,https://zenodo.org/record/4291095/files/CAM041856_d.JPG,0,test,40388,lativitta,40388_CAM041856_d.JPG,major
-CS000594,https://zenodo.org/record/2553501/files/CS594 dorsal.jpeg,0,test-2,26007,malleti,26007_CS594 dorsal.jpeg,mimic
-CAM041587,https://zenodo.org/record/4291095/files/CAM041587_d.JPG,0,test-2,39315,malleti,39315_CAM041587_d.JPG,mimic
-CAM016905,https://zenodo.org/record/4153502/files/CAM016905_d.JPG,0,test-2,18974,plesseni,18974_CAM016905_d.JPG,mimic
-CAM041784,https://zenodo.org/record/4291095/files/CAM041784_d.JPG,0,test,40103,lativitta,40103_CAM041784_d.JPG,major
-CAM041013,https://zenodo.org/record/2714333/files/CAM041013_d.JPG,0,test-2,13665,malleti,13665_CAM041013_d.JPG,mimic
-CAM021053,https://zenodo.org/record/2702457/files/CAM021053_d.JPG,0,test,11538,erato,11538_CAM021053_d.JPG,minor
-CAM045227,https://zenodo.org/record/5526257/files/CAM045227_d.JPG,0,test,43471,cyrbia,43471_CAM045227_d.JPG,minor
-CAM016270,https://zenodo.org/record/3082688/files/CAM016270_d.JPG,1,test-2,3386,plesseni x malleti,3386_CAM016270_d.JPG,mimic
-CAM017246,https://zenodo.org/record/3082688/files/CAM017246_d.JPG,0,test,4809,notabilis,4809_CAM017246_d.JPG,major
-CAM017206,https://zenodo.org/record/3082688/files/CAM017206_d.JPG,1,test,4729,notabilis x lativitta,4729_CAM017206_d.JPG,major
-CAM041666,https://zenodo.org/record/4291095/files/CAM041666_d.JPG,0,test,39631,lativitta,39631_CAM041666_d.JPG,major
-CAM016009,https://zenodo.org/record/3082688/files/CAM016009_d.JPG,0,test-2,2927,plesseni,2927_CAM016009_d.JPG,mimic
-CAM017182,https://zenodo.org/record/3082688/files/CAM017182_d.JPG,0,test,4684,notabilis,4684_CAM017182_d.JPG,major
-19N1432,https://zenodo.org/record/4288311/files/19N1432_d.JPG,0,test-2,20363,malleti,20363_19N1432_d.JPG,mimic
-19N0073,https://zenodo.org/record/4288311/files/19N0073_d.JPG,0,test-2,19291,malleti,19291_19N0073_d.JPG,mimic
-19N0127,https://zenodo.org/record/4288311/files/19N0127_d.JPG,0,test-2,19399,malleti,19399_19N0127_d.JPG,mimic
-CS003541,https://zenodo.org/record/2553501/files/CS3541 dorsal.jpeg,0,test-2,25935,malleti,25935_CS3541 dorsal.jpeg,mimic
-CAM017003,https://zenodo.org/record/3082688/files/CAM017003_d.JPG,1,test,4365,notabilis x lativitta,4365_CAM017003_d.JPG,major
-19N0416,https://zenodo.org/record/4288311/files/19N0416_d.JPG,0,test-2,19811,malleti,19811_19N0416_d.JPG,mimic
-CAM040235,https://zenodo.org/record/2707828/files/CAM040235_d.JPG,0,test-2,12086,malleti,12086_CAM040235_d.JPG,mimic
-CAM009204,https://zenodo.org/record/2686762/files/CAM009204_d.JPG,0,test-2,10377,plesseni,10377_CAM009204_d.JPG,mimic
-CAM041814,https://zenodo.org/record/4291095/files/CAM041814_d.JPG,0,test,40223,lativitta,40223_CAM041814_d.JPG,major
-19N0172,https://zenodo.org/record/4288311/files/19N0172_d.JPG,0,test-2,19489,malleti,19489_19N0172_d.JPG,mimic
-CAM041456,https://zenodo.org/record/4291095/files/CAM041456_d.JPG,0,test-2,38796,malleti,38796_CAM041456_d.JPG,mimic
+CAMID,file_url,hybrid_stat,X,subspecies_ref,filename,ssp_indicator
+CAM041834,https://zenodo.org/record/4291095/files/CAM041834_d.JPG,0,40303,lativitta,40303_CAM041834_d.JPG,major
+CAM045170,https://zenodo.org/record/5526257/files/CAM045170_d.JPG,0,43245,cyrbia,43245_CAM045170_d.JPG,minor
+CAM041210,https://zenodo.org/record/2714333/files/CAM041210_d.JPG,0,14057,malleti,14057_CAM041210_d.JPG,mimic
+CAM045261,https://zenodo.org/record/5526257/files/CAM045261_d.JPG,0,43607,cyrbia,43607_CAM045261_d.JPG,minor
+CAM016653,https://zenodo.org/record/3082688/files/CAM016653_d.JPG,1,3841,notabilis x lativitta,3841_CAM016653_d.JPG,major
+CAM041645,https://zenodo.org/record/4291095/files/CAM041645_d.JPG,0,39547,lativitta,39547_CAM041645_d.JPG,major
+CAM016353,https://zenodo.org/record/4153502/files/CAM016353_D.JPG,0,19124,notabilis,19124_CAM016353_D.JPG,major
+CAM041656,https://zenodo.org/record/4291095/files/CAM041656_d.JPG,0,39591,lativitta,39591_CAM041656_d.JPG,major
+CAM009332,https://zenodo.org/record/2686762/files/CAM009332_d.JPG,0,10516,hydara,10516_CAM009332_d.JPG,minor
+CAM016066,https://zenodo.org/record/3082688/files/CAM016066_d.JPG,1,3040,plesseni x malleti,3040_CAM016066_d.JPG,mimic
+15N320,https://zenodo.org/record/4289223/files/15N320_d.JPG,0,15230,venus,15230_15N320_d.JPG,minor
+CAM045041,https://zenodo.org/record/5526257/files/CAM045041_d.JPG,0,42729,cyrbia,42729_CAM045041_d.JPG,minor
+CAM017039,https://zenodo.org/record/3082688/files/CAM017039_d.JPG,1,4431,notabilis x lativitta,4431_CAM017039_d.JPG,major
+CAM045198,https://zenodo.org/record/5526257/files/CAM045198_d.JPG,0,43357,cyrbia,43357_CAM045198_d.JPG,minor
+CAM041542,https://zenodo.org/record/4291095/files/CAM041542_d.JPG,0,39140,malleti,39140_CAM041542_d.JPG,mimic
+F895,https://zenodo.org/record/2555086/files/F895_d.JPG,0,38160,demophoon,38160_F895_d.JPG,minor
+CAM045029,https://zenodo.org/record/5526257/files/CAM045029_d.JPG,0,42681,cyrbia,42681_CAM045029_d.JPG,minor
+CAM045245,https://zenodo.org/record/5526257/files/CAM045245_d.JPG,0,43543,cyrbia,43543_CAM045245_d.JPG,minor
+CAM017280,https://zenodo.org/record/3082688/files/CAM017280_d.JPG,1,4872,notabilis x lativitta,4872_CAM017280_d.JPG,major
+CAM045057,https://zenodo.org/record/5526257/files/CAM045057_d.JPG,0,42793,cyrbia,42793_CAM045057_d.JPG,minor
+CAM016462,https://zenodo.org/record/3082688/files/CAM016462_d.JPG,1,3621,notabilis x lativitta,3621_CAM016462_d.JPG,major
+15N192,https://zenodo.org/record/4289223/files/15N192_d.JPG,0,15202,venus,15202_15N192_d.JPG,minor
+19N0336,https://zenodo.org/record/4288311/files/19N0336_d.JPG,0,19778,malleti,19778_19N0336_d.JPG,mimic
+CAM045056,https://zenodo.org/record/5526257/files/CAM045056_d.JPG,0,42789,cyrbia,42789_CAM045056_d.JPG,minor
+CAM041668,https://zenodo.org/record/4291095/files/CAM041668_d.JPG,0,39639,lativitta,39639_CAM041668_d.JPG,major
+19N1743,https://zenodo.org/record/4288311/files/19N1743_d.JPG,0,20943,malleti,20943_19N1743_d.JPG,mimic
+CAM041683,https://zenodo.org/record/4291095/files/CAM041683_d.JPG,0,39699,lativitta,39699_CAM041683_d.JPG,major
+19N2252,https://zenodo.org/record/4288311/files/19N2252_d.JPG,0,21935,malleti,21935_19N2252_d.JPG,mimic
+CAM009018,https://zenodo.org/record/2686762/files/CAM009018_d.JPG,0,10141,hydara,10141_CAM009018_d.JPG,minor
+CAM016698,https://zenodo.org/record/4153502/files/CAM016698_d.JPG,0,18940,plesseni,18940_CAM016698_d.JPG,mimic
+CAM017410,https://zenodo.org/record/3082688/files/CAM017410_d.JPG,1,5059,notabilis x lativitta,5059_CAM017410_d.JPG,major
+CAM016500,https://zenodo.org/record/3082688/files/CAM016500_d.JPG,1,3633,plesseni x malleti,3633_CAM016500_d.JPG,mimic
+19N2119,https://zenodo.org/record/4288311/files/19N2119_d.JPG,0,21627,malleti,21627_19N2119_d.JPG,mimic
+CAM041691,https://zenodo.org/record/4291095/files/CAM041691_d.JPG,0,39731,lativitta,39731_CAM041691_d.JPG,major
+CAM017604,https://zenodo.org/record/3082688/files/CAM017604_d.JPG,1,5370,notabilis x lativitta,5370_CAM017604_d.JPG,major
+19N0648,https://zenodo.org/record/4288311/files/19N0648_d.JPG,0,19942,malleti,19942_19N0648_d.JPG,mimic
+CAM017258,https://zenodo.org/record/4153502/files/CAM017258_d.JPG,0,19004,plesseni,19004_CAM017258_d.JPG,mimic
+CAM016455,https://zenodo.org/record/3082688/files/CAM016455_d.JPG,1,3611,notabilis x lativitta,3611_CAM016455_d.JPG,major
+19N2020,https://zenodo.org/record/4288311/files/19N2020_d.JPG,0,21435,malleti,21435_19N2020_d.JPG,mimic
+CAM041207,https://zenodo.org/record/2714333/files/CAM041207_d.JPG,0,14051,malleti,14051_CAM041207_d.JPG,mimic
+19N0131,https://zenodo.org/record/4288311/files/19N0131_d.JPG,0,19407,malleti,19407_19N0131_d.JPG,mimic
+19N2235,https://zenodo.org/record/4288311/files/19N2235_d.JPG,0,21867,malleti,21867_19N2235_d.JPG,mimic
+CAM017337,https://zenodo.org/record/3082688/files/CAM017337_d.JPG,1,4952,notabilis x lativitta,4952_CAM017337_d.JPG,major
+19N1260,https://zenodo.org/record/4288311/files/19N1260_d.JPG,0,20255,malleti,20255_19N1260_d.JPG,mimic
+CAM009195,https://zenodo.org/record/2686762/files/CAM009195_d.JPG,0,10359,plesseni,10359_CAM009195_d.JPG,mimic
+CAM041879,https://zenodo.org/record/4291095/files/CAM041879_d.JPG,0,40480,lativitta,40480_CAM041879_d.JPG,major
+CAM016050,https://zenodo.org/record/3082688/files/CAM016050_d.JPG,1,3009,plesseni x malleti,3009_CAM016050_d.JPG,mimic
+CAM017004,https://zenodo.org/record/3082688/files/CAM017004_d.JPG,1,4367,notabilis x lativitta,4367_CAM017004_d.JPG,major
+CAM016350,https://zenodo.org/record/3082688/files/CAM016350_d.JPG,1,3436,plesseni x malleti,3436_CAM016350_d.JPG,mimic
+CAM041354,https://zenodo.org/record/4291095/files/CAM041354_d.JPG,0,38396,lativitta,38396_CAM041354_d.JPG,major
+CAM018402,https://zenodo.org/record/2702457/files/CAM018402_d.JPG,1,11168,plesseni x malleti,11168_CAM018402_d.JPG,mimic
+19N0101,https://zenodo.org/record/4288311/files/19N0101_d.JPG,0,19347,malleti,19347_19N0101_d.JPG,mimic
+CAM016595,https://zenodo.org/record/3082688/files/CAM016595_d.JPG,0,3779,malleti,3779_CAM016595_d.JPG,mimic
+CAM041659,https://zenodo.org/record/4291095/files/CAM041659_d.JPG,0,39603,lativitta,39603_CAM041659_d.JPG,major
+CAM016148,https://zenodo.org/record/3082688/files/CAM016148_d.JPG,1,3204,notabilis x lativitta,3204_CAM016148_d.JPG,major
+CAM040038,https://zenodo.org/record/2707828/files/CAM040038_d.JPG,0,11756,dignus,11756_CAM040038_d.JPG,minor
+CAM040077,https://zenodo.org/record/2707828/files/CAM040077_d.JPG,0,11818,dignus,11818_CAM040077_d.JPG,minor
+CAM021041,https://zenodo.org/record/2702457/files/CAM021041_d.JPG,0,11514,amalfreda,11514_CAM021041_d.JPG,minor
+CAM041640,https://zenodo.org/record/4291095/files/CAM041640_d.JPG,0,39527,lativitta,39527_CAM041640_d.JPG,major
+CAM041499,https://zenodo.org/record/4291095/files/CAM041499_d.JPG,0,38968,malleti,38968_CAM041499_d.JPG,mimic
+CAM017549,https://zenodo.org/record/3082688/files/CAM017549_d.JPG,1,5288,malleti x plesseni,5288_CAM017549_d.JPG,mimic
+CAM016268,https://zenodo.org/record/3082688/files/CAM016268_d.JPG,0,3382,malleti,3382_CAM016268_d.JPG,mimic
+CAM017614,https://zenodo.org/record/3082688/files/CAM017614_d.JPG,0,5388,plesseni,5388_CAM017614_d.JPG,mimic
+CAM041200,https://zenodo.org/record/2714333/files/CAM041200_d.JPG,0,14037,malleti,14037_CAM041200_d.JPG,mimic
+CAM041731,https://zenodo.org/record/4291095/files/CAM041731_d.JPG,0,39891,lativitta,39891_CAM041731_d.JPG,major
+15N149,https://zenodo.org/record/4289223/files/15N149_d.JPG,0,14961,venus,14961_15N149_d.JPG,minor
+CAM016393,https://zenodo.org/record/3082688/files/CAM016393_d.JPG,1,3499,plesseni x malleti,3499_CAM016393_d.JPG,mimic
+19N0135,https://zenodo.org/record/4288311/files/19N0135_d.JPG,0,19415,malleti,19415_19N0135_d.JPG,mimic
+19N0630,https://zenodo.org/record/4288311/files/19N0630_d.JPG,0,19920,malleti,19920_19N0630_d.JPG,mimic
+19N0180,https://zenodo.org/record/4288311/files/19N0180_d.JPG,0,19505,malleti,19505_19N0180_d.JPG,mimic
+CAM016225,https://zenodo.org/record/3082688/files/CAM016225_d.JPG,1,3336,plesseni x malleti,3336_CAM016225_d.JPG,mimic
+CAM016026,https://zenodo.org/record/3082688/files/CAM016026_d.JPG,1,2961,notabilis x lativitta,2961_CAM016026_d.JPG,major
+CAM016424,https://zenodo.org/record/3082688/files/CAM016424_d.JPG,1,3559,plesseni x malleti,3559_CAM016424_d.JPG,mimic
+CAM041857,https://zenodo.org/record/4291095/files/CAM041857_d.JPG,0,40392,lativitta,40392_CAM041857_d.JPG,major
+CAM016656,https://zenodo.org/record/3082688/files/CAM016656_d.JPG,1,3847,plesseni x malleti,3847_CAM016656_d.JPG,mimic
+CAM041428,https://zenodo.org/record/4291095/files/CAM041428_d.JPG,0,38684,lativitta,38684_CAM041428_d.JPG,major
+CAM008864,https://zenodo.org/record/2686762/files/CAM008864_d.JPG,0,9949,hydara,9949_CAM008864_d.JPG,minor
+CAM016505,https://zenodo.org/record/3082688/files/CAM016505_d.JPG,1,3643,plesseni x malleti,3643_CAM016505_d.JPG,mimic
+CAM016588,https://zenodo.org/record/3082688/files/CAM016588_d.JPG,1,3767,notabilis x lativitta,3767_CAM016588_d.JPG,major
+CAM041647,https://zenodo.org/record/4291095/files/CAM041647_d.JPG,0,39555,lativitta,39555_CAM041647_d.JPG,major
+CAM040210,https://zenodo.org/record/2707828/files/CAM040210_d.JPG,0,12044,malleti,12044_CAM040210_d.JPG,mimic
+CAM041815,https://zenodo.org/record/4291095/files/CAM041815_d.JPG,0,40227,lativitta,40227_CAM041815_d.JPG,major
+CAM016646,https://zenodo.org/record/3082688/files/CAM016646_d.JPG,1,3827,notabilis x lativitta,3827_CAM016646_d.JPG,major
+CAM016526,https://zenodo.org/record/3082688/files/CAM016526_d.JPG,1,3683,notabilis x lativitta,3683_CAM016526_d.JPG,major
+CAM016540,https://zenodo.org/record/3082688/files/CAM016540_d.JPG,0,3691,malleti,3691_CAM016540_d.JPG,mimic
+CAM041027,https://zenodo.org/record/2714333/files/CAM041027_d.JPG,0,13693,malleti,13693_CAM041027_d.JPG,mimic
+19N1856,https://zenodo.org/record/4288311/files/19N1856_d.JPG,0,21111,malleti,21111_19N1856_d.JPG,mimic
+CAM016302,https://zenodo.org/record/4153502/files/CAM016302_d.JPG,1,18862,notabilis x lativitta,18862_CAM016302_d.JPG,major
+CAM041885,https://zenodo.org/record/4291095/files/CAM041885_d.JPG,0,40504,lativitta,40504_CAM041885_d.JPG,major
+CAM017253,https://zenodo.org/record/3082688/files/CAM017253_d.JPG,0,4823,notabilis,4823_CAM017253_d.JPG,major
+CAM041658,https://zenodo.org/record/4291095/files/CAM041658_d.JPG,0,39599,lativitta,39599_CAM041658_d.JPG,major
+CAM017351,https://zenodo.org/record/3082688/files/CAM017351_d.JPG,1,4980,plesseni x malleti,4980_CAM017351_d.JPG,mimic
+CAM045069,https://zenodo.org/record/5526257/files/CAM045069_d.JPG,0,42841,cyrbia,42841_CAM045069_d.JPG,minor
+CAM045141,https://zenodo.org/record/5526257/files/CAM045141_d.JPG,0,43131,cyrbia,43131_CAM045141_d.JPG,minor
+CAM017264,https://zenodo.org/record/3082688/files/CAM017264_d.JPG,1,4840,plesseni x malleti,4840_CAM017264_d.JPG,mimic
+CAM018257,https://zenodo.org/record/2702457/files/CAM018257_d.JPG,1,10986,plesseni x malleti,10986_CAM018257_d.JPG,mimic
+19N0674,https://zenodo.org/record/4288311/files/19N0674_d.JPG,0,19970,malleti,19970_19N0674_d.JPG,mimic
+CAM008985,https://zenodo.org/record/2686762/files/CAM008985_d.JPG,0,10075,hydara,10075_CAM008985_d.JPG,minor
+CAM041888,https://zenodo.org/record/4291095/files/CAM041888_d.JPG,0,40516,lativitta,40516_CAM041888_d.JPG,major
+CAM041747,https://zenodo.org/record/4291095/files/CAM041747_d.JPG,0,39955,lativitta,39955_CAM041747_d.JPG,major
+19N2257,https://zenodo.org/record/4288311/files/19N2257_d.JPG,0,21955,malleti,21955_19N2257_d.JPG,mimic
+CAM041843,https://zenodo.org/record/4291095/files/CAM041843_d.JPG,0,40339,lativitta,40339_CAM041843_d.JPG,major
+CAM041912,https://zenodo.org/record/4291095/files/CAM041912_d.JPG,0,40612,lativitta,40612_CAM041912_d.JPG,major
+CAM041789,https://zenodo.org/record/4291095/files/CAM041789_d.JPG,0,40123,lativitta,40123_CAM041789_d.JPG,major
+CAM017063,https://zenodo.org/record/3082688/files/CAM017063_d.JPG,1,4475,notabilis x lativitta,4475_CAM017063_d.JPG,major
+CAM045171,https://zenodo.org/record/5526257/files/CAM045171_d.JPG,0,43249,cyrbia,43249_CAM045171_d.JPG,minor
+15N195,https://zenodo.org/record/4289223/files/15N195_d.JPG,0,15208,venus,15208_15N195_d.JPG,minor
+CAM016314,https://zenodo.org/record/4153502/files/CAM016314_d.JPG,1,18868,notabilis x lativitta,18868_CAM016314_d.JPG,major
+CAM041839,https://zenodo.org/record/4291095/files/CAM041839_d.JPG,0,40323,lativitta,40323_CAM041839_d.JPG,major
+CAM041614,https://zenodo.org/record/4291095/files/CAM041614_d.JPG,0,39423,lativitta,39423_CAM041614_d.JPG,major
+CAM045213,https://zenodo.org/record/5526257/files/CAM045213_d.JPG,0,43415,cyrbia,43415_CAM045213_d.JPG,minor
+CAM016654,https://zenodo.org/record/3082688/files/CAM016654_d.JPG,1,3843,plesseni x malleti,3843_CAM016654_d.JPG,mimic
+CAM045249,https://zenodo.org/record/5526257/files/CAM045249_d.JPG,0,43559,cyrbia,43559_CAM045249_d.JPG,minor
+19N2025,https://zenodo.org/record/4288311/files/19N2025_d.JPG,0,21451,malleti,21451_19N2025_d.JPG,mimic
+CAM016031,https://zenodo.org/record/3082688/files/CAM016031_d.JPG,1,2971,notabilis x lativitta,2971_CAM016031_d.JPG,major
+CAM017134,https://zenodo.org/record/3082688/files/CAM017134_d.JPG,0,4597,malleti,4597_CAM017134_d.JPG,mimic
+CAM017619,https://zenodo.org/record/4153502/files/CAM017619_d.JPG,0,19064,plesseni,19064_CAM017619_d.JPG,mimic
+CAM017451,https://zenodo.org/record/3082688/files/CAM017451_d.JPG,1,5134,malleti x plesseni,5134_CAM017451_d.JPG,mimic
+CAM011438,https://zenodo.org/record/2550097/files/CAM011438_d.JPG,0,28244,plesseni,28244_CAM011438_d.JPG,mimic
+CAM009520,https://zenodo.org/record/2686762/files/CAM009520_d.JPG,1,10782,hydara x petiverana,10782_CAM009520_d.JPG,minor
+CAM017154,https://zenodo.org/record/3082688/files/CAM017154_d.JPG,0,4633,malleti,4633_CAM017154_d.JPG,mimic
+19N0097,https://zenodo.org/record/4288311/files/19N0097_d.JPG,0,19339,malleti,19339_19N0097_d.JPG,mimic
+CAM016028,https://zenodo.org/record/3082688/files/CAM016028_d.JPG,1,2965,notabilis x lativitta,2965_CAM016028_d.JPG,major
+CAM045183,https://zenodo.org/record/5526257/files/CAM045183_d.JPG,0,43297,cyrbia,43297_CAM045183_d.JPG,minor
+CAM016146,https://zenodo.org/record/3082688/files/CAM016146_d.JPG,1,3200,notabilis x lativitta,3200_CAM016146_d.JPG,major
+CAM045219,https://zenodo.org/record/5526257/files/CAM045219_d.JPG,0,43439,cyrbia,43439_CAM045219_d.JPG,minor
+CAM016137,https://zenodo.org/record/3082688/files/CAM016137_d.JPG,1,3182,plesseni x malleti,3182_CAM016137_d.JPG,mimic
+CAM016361,https://zenodo.org/record/4153502/files/CAM016361_D.JPG,0,19128,notabilis,19128_CAM016361_D.JPG,major
+CAM016115,https://zenodo.org/record/3082688/files/CAM016115_d.JPG,1,3138,notabilis x lativitta,3138_CAM016115_d.JPG,major
+CAM041782,https://zenodo.org/record/4291095/files/CAM041782_d.JPG,0,40095,lativitta,40095_CAM041782_d.JPG,major
+19N1179,https://zenodo.org/record/4288311/files/19N1179_d.JPG,0,20213,malleti,20213_19N1179_d.JPG,mimic
+CAM009523,https://zenodo.org/record/2686762/files/CAM009523_d.JPG,1,10788,hydara x petiverana,10788_CAM009523_d.JPG,minor
+19N2228,https://zenodo.org/record/4288311/files/19N2228_d.JPG,0,21839,malleti,21839_19N2228_d.JPG,mimic
+CAM040992,https://zenodo.org/record/2714333/files/CAM040992_d.JPG,0,13623,malleti,13623_CAM040992_d.JPG,mimic
+CAM045217,https://zenodo.org/record/5526257/files/CAM045217_d.JPG,0,43431,cyrbia,43431_CAM045217_d.JPG,minor
+CAM009006,https://zenodo.org/record/2686762/files/CAM009006_d.JPG,0,10117,hydara,10117_CAM009006_d.JPG,minor
+CAM017453,https://zenodo.org/record/1748277/files/CAM017453_d_whitestandard.JPG,0,15275,plesseni,15275_CAM017453_d_whitestandard.JPG,mimic
+CAM041625,https://zenodo.org/record/4291095/files/CAM041625_d.JPG,0,39467,lativitta,39467_CAM041625_d.JPG,major
+CAM041646,https://zenodo.org/record/4291095/files/CAM041646_d.JPG,0,39551,lativitta,39551_CAM041646_d.JPG,major
+CAM000231,https://zenodo.org/record/2677821/files/CAM000231_d.JPG,0,6288,chestertonii,6288_CAM000231_d.JPG,minor
+CAM016860,https://zenodo.org/record/3082688/files/CAM016860_d.JPG,1,4139,plesseni x malleti,4139_CAM016860_d.JPG,mimic
+19N0212,https://zenodo.org/record/4288311/files/19N0212_d.JPG,0,19569,malleti,19569_19N0212_d.JPG,mimic
+CAM045043,https://zenodo.org/record/5526257/files/CAM045043_d.JPG,0,42737,cyrbia,42737_CAM045043_d.JPG,minor
+19N0035,https://zenodo.org/record/4288311/files/19N0035_d.JPG,0,19210,malleti,19210_19N0035_d.JPG,mimic
+CAM040066,https://zenodo.org/record/2707828/files/CAM040066_d.JPG,0,11812,dignus,11812_CAM040066_d.JPG,minor
+CAM040020,https://zenodo.org/record/2707828/files/CAM040020_d.JPG,0,11724,malleti,11724_CAM040020_d.JPG,mimic
+CAM009203,https://zenodo.org/record/2686762/files/CAM009203_d.JPG,0,10375,plesseni,10375_CAM009203_d.JPG,mimic
+CAM041437,https://zenodo.org/record/4291095/files/CAM041437_d.JPG,0,38720,lativitta,38720_CAM041437_d.JPG,major
+CAM016177,https://zenodo.org/record/3082688/files/CAM016177_d.JPG,1,3262,notabilis x lativitta,3262_CAM016177_d.JPG,major
+CAM008544,https://zenodo.org/record/2684906/files/CAM008544_d.JPG,0,9440,plesseni,9440_CAM008544_d.JPG,mimic
+CAM016956,https://zenodo.org/record/3082688/files/CAM016956_d.JPG,0,4289,malleti,4289_CAM016956_d.JPG,mimic
+19N0639,https://zenodo.org/record/4288311/files/19N0639_d.JPG,0,19934,malleti,19934_19N0639_d.JPG,mimic
+CAM017309,https://zenodo.org/record/3082688/files/CAM017309_d.JPG,1,4904,notabilis x lativitta,4904_CAM017309_d.JPG,major
+CAM016652,https://zenodo.org/record/3082688/files/CAM016652_d.JPG,1,3839,notabilis x lativitta,3839_CAM016652_d.JPG,major
+CAM016828,https://zenodo.org/record/3082688/files/CAM016828_d.JPG,1,4078,plesseni x malleti,4078_CAM016828_d.JPG,mimic
+19N0089,https://zenodo.org/record/4288311/files/19N0089_d.JPG,0,19323,malleti,19323_19N0089_d.JPG,mimic
+19N1387,https://zenodo.org/record/4288311/files/19N1387_d.JPG,0,20323,malleti,20323_19N1387_d.JPG,mimic
+CAM045257,https://zenodo.org/record/5526257/files/CAM045257_d.JPG,0,43591,cyrbia,43591_CAM045257_d.JPG,minor
+CAM045192,https://zenodo.org/record/5526257/files/CAM045192_d.JPG,0,43333,cyrbia,43333_CAM045192_d.JPG,minor
+CAM017219,https://zenodo.org/record/3082688/files/CAM017219_d.JPG,0,4755,notabilis,4755_CAM017219_d.JPG,major
+CAM041036,https://zenodo.org/record/2714333/files/CAM041036_d.JPG,0,13711,malleti,13711_CAM041036_d.JPG,mimic
+19N2225,https://zenodo.org/record/4288311/files/19N2225_d.JPG,0,21827,malleti,21827_19N2225_d.JPG,mimic
+CAM016580,https://zenodo.org/record/3082688/files/CAM016580_d.JPG,1,3751,notabilis x lativitta,3751_CAM016580_d.JPG,major
+19N0177,https://zenodo.org/record/4288311/files/19N0177_d.JPG,0,19499,malleti,19499_19N0177_d.JPG,mimic
+CAM016560,https://zenodo.org/record/3082688/files/CAM016560_d.JPG,1,3725,notabilis x lativitta,3725_CAM016560_d.JPG,major
+19N0281,https://zenodo.org/record/4288311/files/19N0281_d.JPG,0,19708,malleti,19708_19N0281_d.JPG,mimic
+19N0056,https://zenodo.org/record/4288311/files/19N0056_d.JPG,0,19254,malleti,19254_19N0056_d.JPG,mimic
+CAM016703,https://zenodo.org/record/4153502/files/CAM016703_d.JPG,0,18950,notabilis,18950_CAM016703_d.JPG,major
+15N135,https://zenodo.org/record/4289223/files/15N135_d.JPG,0,15182,chestertonii,15182_15N135_d.JPG,minor
+CAM016734,https://zenodo.org/record/4153502/files/CAM016734_d.JPG,0,18962,plesseni,18962_CAM016734_d.JPG,mimic
+CAM040222,https://zenodo.org/record/2707828/files/CAM040222_d.JPG,0,12064,malleti,12064_CAM040222_d.JPG,mimic
+19N0299,https://zenodo.org/record/4288311/files/19N0299_d.JPG,0,19732,malleti,19732_19N0299_d.JPG,mimic
+CAM017658,https://zenodo.org/record/3082688/files/CAM017658_d.JPG,1,5396,malleti x plesseni,5396_CAM017658_d.JPG,mimic
+19N1467,https://zenodo.org/record/4288311/files/19N1467_d.JPG,0,20379,malleti,20379_19N1467_d.JPG,mimic
+19N0133,https://zenodo.org/record/4288311/files/19N0133_d.JPG,0,19411,malleti,19411_19N0133_d.JPG,mimic
+CAM016922,https://zenodo.org/record/3082688/files/CAM016922_d.JPG,1,4245,plesseni x malleti,4245_CAM016922_d.JPG,mimic
+CS003728,https://zenodo.org/record/2553501/files/CS3728 dorsal.jpeg,0,25967,malleti,25967_CS3728 dorsal.jpeg,mimic
+CAM041596,https://zenodo.org/record/4291095/files/CAM041596_d.JPG,0,39351,lativitta,39351_CAM041596_d.JPG,major
+CAM045105,https://zenodo.org/record/5526257/files/CAM045105_d.JPG,0,42985,cyrbia,42985_CAM045105_d.JPG,minor
+CAM040129,https://zenodo.org/record/2707828/files/CAM040129_d.JPG,0,11898,malleti,11898_CAM040129_d.JPG,mimic
+CAM041737,https://zenodo.org/record/4291095/files/CAM041737_d.JPG,0,39915,lativitta,39915_CAM041737_d.JPG,major
+19N2189,https://zenodo.org/record/4288311/files/19N2189_d.JPG,0,21723,malleti,21723_19N2189_d.JPG,mimic
+CAM045260,https://zenodo.org/record/5526257/files/CAM045260_d.JPG,0,43603,cyrbia,43603_CAM045260_d.JPG,minor
+CAM041900,https://zenodo.org/record/4291095/files/CAM041900_d.JPG,0,40564,lativitta,40564_CAM041900_d.JPG,major
+CAM041667,https://zenodo.org/record/4291095/files/CAM041667_d.JPG,0,39635,lativitta,39635_CAM041667_d.JPG,major
+CAM041436,https://zenodo.org/record/4291095/files/CAM041436_d.JPG,0,38716,lativitta,38716_CAM041436_d.JPG,major
+F849,https://zenodo.org/record/2555086/files/F849_d.JPG,0,38076,demophoon,38076_F849_d.JPG,minor
+CAM036231,https://zenodo.org/record/5561246/files/CAM036231_d.JPG,0,41635,phyllis,41635_CAM036231_d.JPG,minor
+19N0075,https://zenodo.org/record/4288311/files/19N0075_d.JPG,0,19295,malleti,19295_19N0075_d.JPG,mimic
+CAM016608,https://zenodo.org/record/3082688/files/CAM016608_d.JPG,1,3801,plesseni x malleti,3801_CAM016608_d.JPG,mimic
+CAM041771,https://zenodo.org/record/4291095/files/CAM041771_d.JPG,0,40051,lativitta,40051_CAM041771_d.JPG,major
+CAM017301,https://zenodo.org/record/3082688/files/CAM017301_d.JPG,1,4892,notabilis x lativitta,4892_CAM017301_d.JPG,major
+CAM009510,https://zenodo.org/record/2686762/files/CAM009510_d.JPG,1,10762,hydara x petiverana,10762_CAM009510_d.JPG,minor
+CAM008546,https://zenodo.org/record/2684906/files/CAM008546_d.JPG,0,9444,plesseni,9444_CAM008546_d.JPG,mimic
+CAM017574,https://zenodo.org/record/3082688/files/CAM017574_d.JPG,1,5322,malleti x plesseni,5322_CAM017574_d.JPG,mimic
+CAM041629,https://zenodo.org/record/4291095/files/CAM041629_d.JPG,0,39483,lativitta,39483_CAM041629_d.JPG,major
+CAM009442,https://zenodo.org/record/2686762/files/CAM009442_d.JPG,0,10682,plesseni,10682_CAM009442_d.JPG,mimic
+CAM018438,https://zenodo.org/record/2548678/files/CAM018438_v_whitestandard.JPG,0,18165,malleti,18165_CAM018438_v_whitestandard.JPG,mimic
+CAM016161,https://zenodo.org/record/3082688/files/CAM016161_d.JPG,1,3230,plesseni x malleti,3230_CAM016161_d.JPG,mimic
+CAM017908,https://zenodo.org/record/1748277/files/CAM017908_v_whitestandard.JPG,0,16887,malleti,16887_CAM017908_v_whitestandard.JPG,mimic
+CAM041178,https://zenodo.org/record/2714333/files/CAM041178_d.JPG,0,13993,malleti,13993_CAM041178_d.JPG,mimic
+CAM016511,https://zenodo.org/record/3082688/files/CAM016511_d.JPG,1,3655,plesseni x malleti,3655_CAM016511_d.JPG,mimic
+CAM041780,https://zenodo.org/record/4291095/files/CAM041780_d.JPG,0,40087,lativitta,40087_CAM041780_d.JPG,major
+CAM041580,https://zenodo.org/record/4291095/files/CAM041580_d.JPG,0,39288,malleti,39288_CAM041580_d.JPG,mimic
+CAM016662,https://zenodo.org/record/3082688/files/CAM016662_d.JPG,1,3859,plesseni x malleti,3859_CAM016662_d.JPG,mimic
+CAM009233,https://zenodo.org/record/2686762/files/CAM009233_d.JPG,0,10434,plesseni,10434_CAM009233_d.JPG,mimic
+19N0160,https://zenodo.org/record/4288311/files/19N0160_d.JPG,0,19465,malleti,19465_19N0160_d.JPG,mimic
+CAM016456,https://zenodo.org/record/3082688/files/CAM016456_d.JPG,1,3613,notabilis x lativitta,3613_CAM016456_d.JPG,major
+CS002276,https://zenodo.org/record/2735056/files/CS002276_d.JPG,0,40859,venus,40859_CS002276_d.JPG,minor
+CAM016648,https://zenodo.org/record/3082688/files/CAM016648_d.JPG,1,3831,notabilis x lativitta,3831_CAM016648_d.JPG,major
+CAM008865,https://zenodo.org/record/2686762/files/CAM008865_d.JPG,0,9951,hydara,9951_CAM008865_d.JPG,minor
+19N1908,https://zenodo.org/record/4288311/files/19N1908_d.JPG,0,21211,malleti,21211_19N1908_d.JPG,mimic
+CAM016362,https://zenodo.org/record/4153502/files/CAM016362_D.JPG,0,19130,notabilis,19130_CAM016362_D.JPG,major
+CAM016738,https://zenodo.org/record/4153502/files/CAM016738_d.JPG,0,18966,plesseni,18966_CAM016738_d.JPG,mimic
+19N1112,https://zenodo.org/record/4288311/files/19N1112_d.JPG,0,20190,malleti,20190_19N1112_d.JPG,mimic
+19N1426,https://zenodo.org/record/4288311/files/19N1426_d.JPG,0,20357,malleti,20357_19N1426_d.JPG,mimic
+15N101,https://zenodo.org/record/4289223/files/15N101_d.JPG,0,14953,venus,14953_15N101_d.JPG,minor
+CAM041557,https://zenodo.org/record/4291095/files/CAM041557_d.JPG,0,39196,malleti,39196_CAM041557_d.JPG,mimic
+19N1744,https://zenodo.org/record/4288311/files/19N1744_d.JPG,0,20947,malleti,20947_19N1744_d.JPG,mimic
+CAM041858,https://zenodo.org/record/4291095/files/CAM041858_d.JPG,0,40396,lativitta,40396_CAM041858_d.JPG,major
+19N0091,https://zenodo.org/record/4288311/files/19N0091_d.JPG,0,19327,malleti,19327_19N0091_d.JPG,mimic
+CAM017616,https://zenodo.org/record/4153502/files/CAM017616_d.JPG,0,19058,plesseni,19058_CAM017616_d.JPG,mimic
+CAM041661,https://zenodo.org/record/4291095/files/CAM041661_d.JPG,0,39611,lativitta,39611_CAM041661_d.JPG,major
+19N0026,https://zenodo.org/record/4288311/files/19N0026_d.JPG,0,19191,malleti,19191_19N0026_d.JPG,mimic
+CAM016527,https://zenodo.org/record/3082688/files/CAM016527_d.JPG,1,3685,notabilis x lativitta,3685_CAM016527_d.JPG,major
+CAM041819,https://zenodo.org/record/4291095/files/CAM041819_d.JPG,0,40243,lativitta,40243_CAM041819_d.JPG,major
+CAM017446,https://zenodo.org/record/3082688/files/CAM017446_d.JPG,1,5126,notabilis x lativitta,5126_CAM017446_d.JPG,major
+CAM045182,https://zenodo.org/record/5526257/files/CAM045182_d.JPG,0,43293,cyrbia,43293_CAM045182_d.JPG,minor
+CAM017349,https://zenodo.org/record/3082688/files/CAM017349_d.JPG,1,4976,notabilis x lativitta,4976_CAM017349_d.JPG,major
+CAM009313,https://zenodo.org/record/2686762/files/CAM009313_d.JPG,0,10478,hydara,10478_CAM009313_d.JPG,minor
+19N1813,https://zenodo.org/record/4288311/files/19N1813_d.JPG,0,21059,malleti,21059_19N1813_d.JPG,mimic
+CAM041062,https://zenodo.org/record/2714333/files/CAM041062_d.JPG,0,13763,malleti,13763_CAM041062_d.JPG,mimic
+CAM040192,https://zenodo.org/record/2707828/files/CAM040192_d.JPG,0,12012,malleti,12012_CAM040192_d.JPG,mimic
+19N0094,https://zenodo.org/record/4288311/files/19N0094_d.JPG,0,19333,malleti,19333_19N0094_d.JPG,mimic
+CAM041579,https://zenodo.org/record/4291095/files/CAM041579_d.JPG,0,39284,malleti,39284_CAM041579_d.JPG,mimic
+CAM016125,https://zenodo.org/record/3082688/files/CAM016125_d.JPG,1,3158,plesseni x malleti,3158_CAM016125_d.JPG,mimic
+CAM018250,https://zenodo.org/record/2702457/files/CAM018250_d.JPG,1,10974,plesseni x malleti,10974_CAM018250_d.JPG,mimic
+CAM041902,https://zenodo.org/record/4291095/files/CAM041902_d.JPG,0,40572,lativitta,40572_CAM041902_d.JPG,major
+19N0954,https://zenodo.org/record/4288311/files/19N0954_d.JPG,0,20120,malleti,20120_19N0954_d.JPG,mimic
+CAM017118,https://zenodo.org/record/3082688/files/CAM017118_d.JPG,1,4565,notabilis x lativitta,4565_CAM017118_d.JPG,major
+CAM041649,https://zenodo.org/record/4291095/files/CAM041649_d.JPG,0,39563,lativitta,39563_CAM041649_d.JPG,major
+CAM009190,https://zenodo.org/record/2686762/files/CAM009190_d.JPG,0,10349,plesseni,10349_CAM009190_d.JPG,mimic
+CAM016205,https://zenodo.org/record/3082688/files/CAM016205_d.JPG,0,3316,malleti,3316_CAM016205_d.JPG,mimic
+CAM016127,https://zenodo.org/record/3082688/files/CAM016127_d.JPG,1,3162,plesseni x malleti,3162_CAM016127_d.JPG,mimic
+CAM041882,https://zenodo.org/record/4291095/files/CAM041882_d.JPG,0,40492,lativitta,40492_CAM041882_d.JPG,major
+19N1810,https://zenodo.org/record/4288311/files/19N1810_d.JPG,0,21047,malleti,21047_19N1810_d.JPG,mimic
+CAM016176,https://zenodo.org/record/3082688/files/CAM016176_d.JPG,1,3260,notabilis x lativitta,3260_CAM016176_d.JPG,major
+CAM036255,https://zenodo.org/record/5561246/files/CAM036255_d.JPG,0,41699,phyllis,41699_CAM036255_d.JPG,minor
+CAM017068,https://zenodo.org/record/3082688/files/CAM017068_d.JPG,1,4485,plesseni x malleti,4485_CAM017068_d.JPG,mimic
+19N0866,https://zenodo.org/record/4288311/files/19N0866_d.JPG,0,20072,malleti,20072_19N0866_d.JPG,mimic
+CAM045027,https://zenodo.org/record/5526257/files/CAM045027_d.JPG,0,42673,cyrbia,42673_CAM045027_d.JPG,minor
+CAM045246,https://zenodo.org/record/5526257/files/CAM045246_d.JPG,0,43547,cyrbia,43547_CAM045246_d.JPG,minor
+CAM017327,https://zenodo.org/record/4153502/files/CAM017327_d.JPG,0,19010,plesseni,19010_CAM017327_d.JPG,mimic
+CAM017277,https://zenodo.org/record/3082688/files/CAM017277_d.JPG,1,4866,notabilis x lativitta,4866_CAM017277_d.JPG,major
+CAM041582,https://zenodo.org/record/4291095/files/CAM041582_d.JPG,0,39296,malleti,39296_CAM041582_d.JPG,mimic
+CAM041720,https://zenodo.org/record/4291095/files/CAM041720_d.JPG,0,39847,lativitta,39847_CAM041720_d.JPG,major
+CAM017067,https://zenodo.org/record/3082688/files/CAM017067_d.JPG,1,4483,plesseni x malleti,4483_CAM017067_d.JPG,mimic
+CAM041576,https://zenodo.org/record/4291095/files/CAM041576_d.JPG,0,39272,malleti,39272_CAM041576_d.JPG,mimic
+CAM036165,https://zenodo.org/record/5561246/files/CAM036165_d.JPG,0,41431,phyllis,41431_CAM036165_d.JPG,minor
+19N0242,https://zenodo.org/record/4288311/files/19N0242_d.JPG,0,19629,malleti,19629_19N0242_d.JPG,mimic
+CAM000243,https://zenodo.org/record/2677821/files/CAM000243_d.JPG,0,6312,chestertonii,6312_CAM000243_d.JPG,minor
+CAM017450,https://zenodo.org/record/3082688/files/CAM017450_d.JPG,1,5132,malleti x plesseni,5132_CAM017450_d.JPG,mimic
+CAM017187,https://zenodo.org/record/3082688/files/CAM017187_d.JPG,0,4694,plesseni,4694_CAM017187_d.JPG,mimic
+CAM016178,https://zenodo.org/record/3082688/files/CAM016178_d.JPG,1,3264,notabilis x lativitta,3264_CAM016178_d.JPG,major
+CAM017355,https://zenodo.org/record/4153502/files/CAM017355_d.JPG,0,19016,plesseni,19016_CAM017355_d.JPG,mimic
+19N1020,https://zenodo.org/record/4288311/files/19N1020_d.JPG,0,20155,malleti,20155_19N1020_d.JPG,mimic
+CAM017227,https://zenodo.org/record/3082688/files/CAM017227_d.JPG,0,4771,notabilis,4771_CAM017227_d.JPG,major
+CAM045172,https://zenodo.org/record/5526257/files/CAM045172_d.JPG,0,43253,cyrbia,43253_CAM045172_d.JPG,minor
+19N0304,https://zenodo.org/record/4288311/files/19N0304_d.JPG,0,19740,malleti,19740_19N0304_d.JPG,mimic
+19N1316,https://zenodo.org/record/4288311/files/19N1316_d.JPG,0,20271,malleti,20271_19N1316_d.JPG,mimic
+CAM040171,https://zenodo.org/record/2707828/files/CAM040171_d.JPG,0,11972,malleti,11972_CAM040171_d.JPG,mimic
+CAM041804,https://zenodo.org/record/4291095/files/CAM041804_d.JPG,0,40183,lativitta,40183_CAM041804_d.JPG,major
+CAM016035,https://zenodo.org/record/3082688/files/CAM016035_d.JPG,1,2979,notabilis x lativitta,2979_CAM016035_d.JPG,major
+CAM017607,https://zenodo.org/record/3082688/files/CAM017607_d.JPG,1,5376,notabilis x lativitta,5376_CAM017607_d.JPG,major
+CAM016308,https://zenodo.org/record/4153502/files/CAM016308_D.JPG,1,19110,notabilis x lativitta,19110_CAM016308_D.JPG,major
+CAM016407,https://zenodo.org/record/3082688/files/CAM016407_d.JPG,1,3525,plesseni x malleti,3525_CAM016407_d.JPG,mimic
+CAM045168,https://zenodo.org/record/5526257/files/CAM045168_d.JPG,0,43237,cyrbia,43237_CAM045168_d.JPG,minor
+19N0175,https://zenodo.org/record/4288311/files/19N0175_d.JPG,0,19495,malleti,19495_19N0175_d.JPG,mimic
+CAM041368,https://zenodo.org/record/4291095/files/CAM041368_d.JPG,0,38452,malleti,38452_CAM041368_d.JPG,mimic
+CAM016712,https://zenodo.org/record/4153502/files/CAM016712_d.JPG,0,18960,notabilis,18960_CAM016712_d.JPG,major
+CAM016693,https://zenodo.org/record/4153502/files/CAM016693_d.JPG,0,18930,plesseni,18930_CAM016693_d.JPG,mimic
+CAM041432,https://zenodo.org/record/4291095/files/CAM041432_d.JPG,0,38700,lativitta,38700_CAM041432_d.JPG,major
+CAM040284,https://zenodo.org/record/2707828/files/CAM040284_d.JPG,0,12184,malleti,12184_CAM040284_d.JPG,mimic
+CAM021060,https://zenodo.org/record/2702457/files/CAM021060_d.JPG,0,11549,erato,11549_CAM021060_d.JPG,minor
+CAM009194,https://zenodo.org/record/2686762/files/CAM009194_d.JPG,0,10357,plesseni,10357_CAM009194_d.JPG,mimic
+CAM009534,https://zenodo.org/record/2686762/files/CAM009534_d.JPG,0,10810,petiverana,10810_CAM009534_d.JPG,minor
+F794,https://zenodo.org/record/2555086/files/F794_d.JPG,0,38040,demophoon,38040_F794_d.JPG,minor
+19N0955,https://zenodo.org/record/4288311/files/19N0955_d.JPG,0,20122,malleti,20122_19N0955_d.JPG,mimic
+CAM045174,https://zenodo.org/record/5526257/files/CAM045174_d.JPG,0,43261,cyrbia,43261_CAM045174_d.JPG,minor
+CAM017261,https://zenodo.org/record/3082688/files/CAM017261_d.JPG,0,4834,notabilis,4834_CAM017261_d.JPG,major
+19N1195,https://zenodo.org/record/4288311/files/19N1195_d.JPG,0,20223,malleti,20223_19N1195_d.JPG,mimic
+CAM041385,https://zenodo.org/record/4291095/files/CAM041385_d.JPG,0,38520,lativitta,38520_CAM041385_d.JPG,major
+CAM041844,https://zenodo.org/record/4291095/files/CAM041844_d.JPG,0,40343,lativitta,40343_CAM041844_d.JPG,major
+CAM017083,https://zenodo.org/record/3082688/files/CAM017083_d.JPG,0,4507,malleti,4507_CAM017083_d.JPG,mimic
+CAM016690,https://zenodo.org/record/4153502/files/CAM016690_d.JPG,0,18924,plesseni,18924_CAM016690_d.JPG,mimic
+19N1446,https://zenodo.org/record/4288311/files/19N1446_d.JPG,0,20371,malleti,20371_19N1446_d.JPG,mimic
+CAM041807,https://zenodo.org/record/4291095/files/CAM041807_d.JPG,0,40195,lativitta,40195_CAM041807_d.JPG,major
+19N0660,https://zenodo.org/record/4288311/files/19N0660_d.JPG,0,19950,malleti,19950_19N0660_d.JPG,mimic
+CAM017376,https://zenodo.org/record/4153502/files/CAM017376_d.JPG,0,19038,plesseni,19038_CAM017376_d.JPG,mimic
+CAM045104,https://zenodo.org/record/5526257/files/CAM045104_d.JPG,0,42981,cyrbia,42981_CAM045104_d.JPG,minor
+CAM041728,https://zenodo.org/record/4291095/files/CAM041728_d.JPG,0,39879,lativitta,39879_CAM041728_d.JPG,major
+CAM036230,https://zenodo.org/record/5561246/files/CAM036230_d.JPG,0,41631,phyllis,41631_CAM036230_d.JPG,minor
+CAM017437,https://zenodo.org/record/3082688/files/CAM017437_d.JPG,1,5109,plesseni x malleti,5109_CAM017437_d.JPG,mimic
+CAM017347,https://zenodo.org/record/3082688/files/CAM017347_d.JPG,1,4972,notabilis x lativitta,4972_CAM017347_d.JPG,major
+19N0255,https://zenodo.org/record/4288311/files/19N0255_d.JPG,0,19655,malleti,19655_19N0255_d.JPG,mimic
+CS003660,https://zenodo.org/record/2735056/files/CS003660_d.JPG,0,41075,venus,41075_CS003660_d.JPG,minor
+CAM016168,https://zenodo.org/record/3082688/files/CAM016168_d.JPG,1,3244,notabilis x lativitta,3244_CAM016168_d.JPG,major
+CAM040267,https://zenodo.org/record/2707828/files/CAM040267_d.JPG,0,12150,malleti,12150_CAM040267_d.JPG,mimic
+CAM017276,https://zenodo.org/record/3082688/files/CAM017276_d.JPG,1,4864,notabilis x lativitta,4864_CAM017276_d.JPG,major
+CAM045068,https://zenodo.org/record/5526257/files/CAM045068_d.JPG,0,42837,cyrbia,42837_CAM045068_d.JPG,minor
+CAM018520,https://zenodo.org/record/2702457/files/CAM018520_d.JPG,1,11375,malleti x plesseni,11375_CAM018520_d.JPG,mimic
+19N2078,https://zenodo.org/record/4288311/files/19N2078_d.JPG,0,21567,malleti,21567_19N2078_d.JPG,mimic
+19N1398,https://zenodo.org/record/4288311/files/19N1398_d.JPG,0,20339,malleti,20339_19N1398_d.JPG,mimic
+19N2027,https://zenodo.org/record/4288311/files/19N2027_d.JPG,0,21459,malleti,21459_19N2027_d.JPG,mimic
+CAM040197,https://zenodo.org/record/2707828/files/CAM040197_d.JPG,0,12020,malleti,12020_CAM040197_d.JPG,mimic
+19N0646,https://zenodo.org/record/4288311/files/19N0646_d.JPG,0,19938,malleti,19938_19N0646_d.JPG,mimic
+CAM017267,https://zenodo.org/record/3082688/files/CAM017267_d.JPG,1,4846,plesseni x malleti,4846_CAM017267_d.JPG,mimic
+19N0332,https://zenodo.org/record/4288311/files/19N0332_d.JPG,0,19774,erato,19774_19N0332_d.JPG,minor
+CAM017069,https://zenodo.org/record/3082688/files/CAM017069_d.JPG,0,4487,malleti,4487_CAM017069_d.JPG,mimic
+CAM016149,https://zenodo.org/record/3082688/files/CAM016149_d.JPG,1,3206,notabilis x lativitta,3206_CAM016149_d.JPG,major
+CAM016195,https://zenodo.org/record/3082688/files/CAM016195_d.JPG,1,3298,plesseni x malleti,3298_CAM016195_d.JPG,mimic
+CAM018294,https://zenodo.org/record/2702457/files/CAM018294_d.JPG,1,11030,plesseni x malleti,11030_CAM018294_d.JPG,mimic
+CAM011449,https://zenodo.org/record/2550097/files/CAM011449_d.JPG,0,28288,plesseni,28288_CAM011449_d.JPG,mimic
+CAM000169,https://zenodo.org/record/2677821/files/CAM000169_d.JPG,0,6170,chestertonii,6170_CAM000169_d.JPG,minor
+CAM016792,https://zenodo.org/record/3082688/files/CAM016792_d.JPG,1,4006,plesseni x malleti,4006_CAM016792_d.JPG,mimic
+19N0106,https://zenodo.org/record/4288311/files/19N0106_d.JPG,0,19357,malleti,19357_19N0106_d.JPG,mimic
+CAM016032,https://zenodo.org/record/3082688/files/CAM016032_d.JPG,1,2973,notabilis x lativitta,2973_CAM016032_d.JPG,major
+CAM045055,https://zenodo.org/record/5526257/files/CAM045055_d.JPG,0,42785,cyrbia,42785_CAM045055_d.JPG,minor
+CS003544,https://zenodo.org/record/2553501/files/CS3544 dorsal.jpeg,0,25941,malleti,25941_CS3544 dorsal.jpeg,mimic
+CAM045135,https://zenodo.org/record/5526257/files/CAM045135_d.JPG,0,43107,cyrbia,43107_CAM045135_d.JPG,minor
+CAM017213,https://zenodo.org/record/3082688/files/CAM017213_d.JPG,0,4743,notabilis,4743_CAM017213_d.JPG,major
+CAM017144,https://zenodo.org/record/3082688/files/CAM017144_d.JPG,1,4613,notabilis x lativitta,4613_CAM017144_d.JPG,major
+CAM016686,https://zenodo.org/record/4153502/files/CAM016686_d.JPG,0,18916,plesseni,18916_CAM016686_d.JPG,mimic
+CAM040294,https://zenodo.org/record/2707828/files/CAM040294_d.JPG,0,12204,malleti,12204_CAM040294_d.JPG,mimic
+CAM017103,https://zenodo.org/record/3082688/files/CAM017103_d.JPG,0,4543,malleti,4543_CAM017103_d.JPG,mimic
+19N0759,https://zenodo.org/record/4288311/files/19N0759_d.JPG,0,20024,malleti,20024_19N0759_d.JPG,mimic
+CAM016542,https://zenodo.org/record/3082688/files/CAM016542_d.JPG,0,3695,malleti,3695_CAM016542_d.JPG,mimic
+19N2279,https://zenodo.org/record/4288311/files/19N2279_d.JPG,0,22043,malleti,22043_19N2279_d.JPG,mimic
+CS003830,https://zenodo.org/record/2553501/files/CS3830 dorsal.jpeg,0,25987,malleti,25987_CS3830 dorsal.jpeg,mimic
+CAM041606,https://zenodo.org/record/4291095/files/CAM041606_d.JPG,0,39391,lativitta,39391_CAM041606_d.JPG,major
+CAM045158,https://zenodo.org/record/5526257/files/CAM045158_d.JPG,0,43197,cyrbia,43197_CAM045158_d.JPG,minor
+CAM016753,https://zenodo.org/record/3082688/files/CAM016753_d.JPG,1,3942,plesseni x malleti,3942_CAM016753_d.JPG,mimic
+CAM041384,https://zenodo.org/record/4291095/files/CAM041384_d.JPG,0,38516,lativitta,38516_CAM041384_d.JPG,major
+CAM017263,https://zenodo.org/record/3082688/files/CAM017263_d.JPG,0,4838,notabilis,4838_CAM017263_d.JPG,major
+19N1912,https://zenodo.org/record/4288311/files/19N1912_d.JPG,0,21219,malleti,21219_19N1912_d.JPG,mimic
+CAM045150,https://zenodo.org/record/5526257/files/CAM045150_d.JPG,0,43167,cyrbia,43167_CAM045150_d.JPG,minor
+CAM045061,https://zenodo.org/record/5526257/files/CAM045061_d.JPG,0,42809,cyrbia,42809_CAM045061_d.JPG,minor
+19N2250,https://zenodo.org/record/4288311/files/19N2250_d.JPG,0,21927,malleti,21927_19N2250_d.JPG,mimic
+CAM045035,https://zenodo.org/record/5526257/files/CAM045035_d.JPG,0,42705,cyrbia,42705_CAM045035_d.JPG,minor
+CAM045039,https://zenodo.org/record/5526257/files/CAM045039_d.JPG,0,42721,cyrbia,42721_CAM045039_d.JPG,minor
+15N136,https://zenodo.org/record/4289223/files/15N136_d.JPG,0,15184,chestertonii,15184_15N136_d.JPG,minor
+CAM017314,https://zenodo.org/record/3082688/files/CAM017314_d.JPG,1,4912,notabilis x lativitta,4912_CAM017314_d.JPG,major
+CAM041355,https://zenodo.org/record/4291095/files/CAM041355_d.JPG,0,38400,lativitta,38400_CAM041355_d.JPG,major
+CAM045255,https://zenodo.org/record/5526257/files/CAM045255_d.JPG,0,43583,cyrbia,43583_CAM045255_d.JPG,minor
+CAM041875,https://zenodo.org/record/4291095/files/CAM041875_d.JPG,0,40464,lativitta,40464_CAM041875_d.JPG,major
+CAM016154,https://zenodo.org/record/3082688/files/CAM016154_d.JPG,1,3216,notabilis x lativitta,3216_CAM016154_d.JPG,major
+CS001002,https://zenodo.org/record/2553501/files/CS1002 dorsal.jpeg,0,25591,malleti,25591_CS1002 dorsal.jpeg,mimic
+19N0323,https://zenodo.org/record/4288311/files/19N0323_d.JPG,0,19762,malleti,19762_19N0323_d.JPG,mimic
+19N0102,https://zenodo.org/record/4288311/files/19N0102_d.JPG,0,19349,malleti,19349_19N0102_d.JPG,mimic
+CAM000057,https://zenodo.org/record/2677821/files/CAM000057_d.JPG,1,5949,chestertonii x venus,5949_CAM000057_d.JPG,minor
+19N2011,https://zenodo.org/record/4288311/files/19N2011_d.JPG,0,21415,malleti,21415_19N2011_d.JPG,mimic
+CAM017265,https://zenodo.org/record/3082688/files/CAM017265_d.JPG,1,4842,notabilis x lativitta,4842_CAM017265_d.JPG,major
+19N2270,https://zenodo.org/record/4288311/files/19N2270_d.JPG,0,22007,malleti,22007_19N2270_d.JPG,mimic
+CAM017266,https://zenodo.org/record/3082688/files/CAM017266_d.JPG,1,4844,notabilis x lativitta,4844_CAM017266_d.JPG,major
+CAM017303,https://zenodo.org/record/3082688/files/CAM017303_d.JPG,1,4896,notabilis x lativitta,4896_CAM017303_d.JPG,major
+CAM017054,https://zenodo.org/record/3082688/files/CAM017054_d.JPG,1,4457,notabilis x lativitta,4457_CAM017054_d.JPG,major
+CAM018285,https://zenodo.org/record/2702457/files/CAM018285_d.JPG,1,11022,plesseni x malleti,11022_CAM018285_d.JPG,mimic
+19N1909,https://zenodo.org/record/4288311/files/19N1909_d.JPG,0,21215,malleti,21215_19N1909_d.JPG,mimic
+CAM016924,https://zenodo.org/record/3082688/files/CAM016924_d.JPG,1,4249,notabilis x lativitta,4249_CAM016924_d.JPG,major
+CAM016004,https://zenodo.org/record/4153502/files/CAM016004_d.JPG,0,18849,plesseni,18849_CAM016004_d.JPG,mimic
+CAM040018,https://zenodo.org/record/2707828/files/CAM040018_d.JPG,0,11720,dignus,11720_CAM040018_d.JPG,minor
+15N193,https://zenodo.org/record/4289223/files/15N193_d.JPG,0,15204,venus,15204_15N193_d.JPG,minor
+CAM016598,https://zenodo.org/record/3082688/files/CAM016598_d.JPG,0,3783,malleti,3783_CAM016598_d.JPG,mimic
+CAM040039,https://zenodo.org/record/2707828/files/CAM040039_d.JPG,0,11758,dignus,11758_CAM040039_d.JPG,minor
+19N1945,https://zenodo.org/record/4288311/files/19N1945_d.JPG,0,21275,malleti,21275_19N1945_d.JPG,mimic
+CAM016102,https://zenodo.org/record/3082688/files/CAM016102_d.JPG,1,3112,notabilis x lativitta,3112_CAM016102_d.JPG,major
+CAM016610,https://zenodo.org/record/3082688/files/CAM016610_d.JPG,0,3805,malleti,3805_CAM016610_d.JPG,mimic
+CAM017372,https://zenodo.org/record/4153502/files/CAM017372_d.JPG,0,19034,plesseni,19034_CAM017372_d.JPG,mimic
+CAM045223,https://zenodo.org/record/5526257/files/CAM045223_d.JPG,0,43455,cyrbia,43455_CAM045223_d.JPG,minor
+CAM016998,https://zenodo.org/record/3082688/files/CAM016998_d.JPG,1,4355,notabilis x lativitta,4355_CAM016998_d.JPG,major
+CAM040281,https://zenodo.org/record/2707828/files/CAM040281_d.JPG,0,12178,malleti,12178_CAM040281_d.JPG,mimic
+19N0278,https://zenodo.org/record/4288311/files/19N0278_d.JPG,0,19702,malleti,19702_19N0278_d.JPG,mimic
+CAM017330,https://zenodo.org/record/3082688/files/CAM017330_d.JPG,1,4938,notabilis x lativitta,4938_CAM017330_d.JPG,major
+CAM018353,https://zenodo.org/record/2548678/files/CAM018353_v_whitestandard.JPG,0,17829,malleti,17829_CAM018353_v_whitestandard.JPG,mimic
+CAM017037,https://zenodo.org/record/3082688/files/CAM017037_d.JPG,1,4427,notabilis x lativitta,4427_CAM017037_d.JPG,major
+CAM016448,https://zenodo.org/record/3082688/files/CAM016448_d.JPG,1,3601,notabilis x lativitta,3601_CAM016448_d.JPG,major
+CAM017192,https://zenodo.org/record/3082688/files/CAM017192_d.JPG,1,4704,notabilis x lativitta,4704_CAM017192_d.JPG,major
+15N309,https://zenodo.org/record/4289223/files/15N309_d.JPG,0,15228,venus,15228_15N309_d.JPG,minor
+CAM045060,https://zenodo.org/record/5526257/files/CAM045060_d.JPG,0,42805,cyrbia,42805_CAM045060_d.JPG,minor
+CAM040282,https://zenodo.org/record/2707828/files/CAM040282_d.JPG,0,12180,malleti,12180_CAM040282_d.JPG,mimic
+CAM041828,https://zenodo.org/record/4291095/files/CAM041828_d.JPG,0,40279,lativitta,40279_CAM041828_d.JPG,major
+CAM016043,https://zenodo.org/record/3082688/files/CAM016043_d.JPG,1,2995,plesseni x malleti,2995_CAM016043_d.JPG,mimic
+19N0288,https://zenodo.org/record/4288311/files/19N0288_d.JPG,0,19720,malleti,19720_19N0288_d.JPG,mimic
+19N1348,https://zenodo.org/record/4288311/files/19N1348_d.JPG,0,20287,malleti,20287_19N1348_d.JPG,mimic
+CAM016863,https://zenodo.org/record/3082688/files/CAM016863_d.JPG,1,4145,plesseni x malleti,4145_CAM016863_d.JPG,mimic
+19N0107,https://zenodo.org/record/4288311/files/19N0107_d.JPG,0,19359,malleti,19359_19N0107_d.JPG,mimic
+CAM017074,https://zenodo.org/record/3082688/files/CAM017074_d.JPG,1,4497,notabilis x lativitta,4497_CAM017074_d.JPG,major
+CAM016036,https://zenodo.org/record/3082688/files/CAM016036_d.JPG,1,2981,plesseni x malleti,2981_CAM016036_d.JPG,mimic
+CAM009407,https://zenodo.org/record/2686762/files/CAM009407_d.JPG,0,10612,malleti,10612_CAM009407_d.JPG,mimic
+CAM016861,https://zenodo.org/record/3082688/files/CAM016861_d.JPG,1,4141,plesseni x malleti,4141_CAM016861_d.JPG,mimic
+CAM017141,https://zenodo.org/record/3082688/files/CAM017141_d.JPG,1,4607,notabilis x lativitta,4607_CAM017141_d.JPG,major
+CAM045155,https://zenodo.org/record/5526257/files/CAM045155_d.JPG,0,43187,cyrbia,43187_CAM045155_d.JPG,minor
+CAM017185,https://zenodo.org/record/3082688/files/CAM017185_d.JPG,0,4690,plesseni,4690_CAM017185_d.JPG,mimic
+CAM041718,https://zenodo.org/record/4291095/files/CAM041718_d.JPG,0,39839,lativitta,39839_CAM041718_d.JPG,major
+CAM016184,https://zenodo.org/record/3082688/files/CAM016184_d.JPG,1,3276,notabilis x lativitta,3276_CAM016184_d.JPG,major
+CAM041174,https://zenodo.org/record/2714333/files/CAM041174_d.JPG,0,13985,malleti,13985_CAM041174_d.JPG,mimic
+CAM045036,https://zenodo.org/record/5526257/files/CAM045036_d.JPG,0,42709,cyrbia,42709_CAM045036_d.JPG,minor
+CAM017070,https://zenodo.org/record/3082688/files/CAM017070_d.JPG,0,4489,malleti,4489_CAM017070_d.JPG,mimic
+F907,https://zenodo.org/record/2555086/files/F907_d.JPG,0,38184,demophoon,38184_F907_d.JPG,minor
+CAM041657,https://zenodo.org/record/4291095/files/CAM041657_d.JPG,0,39595,lativitta,39595_CAM041657_d.JPG,major
+CAM017228,https://zenodo.org/record/3082688/files/CAM017228_d.JPG,0,4773,notabilis,4773_CAM017228_d.JPG,major
+CAM016001,https://zenodo.org/record/4153502/files/CAM016001_d.JPG,0,18843,plesseni,18843_CAM016001_d.JPG,mimic
+CAM018365,https://zenodo.org/record/2702457/files/CAM018365_d.JPG,1,11130,malleti x plesseni,11130_CAM018365_d.JPG,mimic
+CAM041741,https://zenodo.org/record/4291095/files/CAM041741_d.JPG,0,39931,lativitta,39931_CAM041741_d.JPG,major
+CAM017145,https://zenodo.org/record/3082688/files/CAM017145_d.JPG,1,4615,notabilis x lativitta,4615_CAM017145_d.JPG,major
+CAM016315,https://zenodo.org/record/4153502/files/CAM016315_D.JPG,0,19116,notabilis,19116_CAM016315_D.JPG,major
+CAM041525,https://zenodo.org/record/4291095/files/CAM041525_d.JPG,0,39072,malleti,39072_CAM041525_d.JPG,mimic
+CAM040258,https://zenodo.org/record/2707828/files/CAM040258_d.JPG,0,12132,malleti,12132_CAM040258_d.JPG,mimic
+CAM041547,https://zenodo.org/record/4291095/files/CAM041547_d.JPG,0,39160,malleti,39160_CAM041547_d.JPG,mimic
+CAM016293,https://zenodo.org/record/2553977/files/16293_H_melpomene_plesseni_D.JPG.jpg,0,26047,plesseni,26047_16293_H_melpomene_plesseni_D.JPG.jpg,mimic
+F809,https://zenodo.org/record/2555086/files/F809_d.JPG,0,38048,demophoon,38048_F809_d.JPG,minor
+CAM016170,https://zenodo.org/record/3082688/files/CAM016170_d.JPG,1,3248,notabilis x lativitta,3248_CAM016170_d.JPG,major
+19N1333,https://zenodo.org/record/4288311/files/19N1333_d.JPG,0,20281,malleti,20281_19N1333_d.JPG,mimic
+19N0528,https://zenodo.org/record/4288311/files/19N0528_d.JPG,0,19882,malleti,19882_19N0528_d.JPG,mimic
+15N115,https://zenodo.org/record/4289223/files/15N115_d.JPG,0,14955,venus,14955_15N115_d.JPG,minor
+CAM016644,https://zenodo.org/record/3082688/files/CAM016644_d.JPG,1,3823,notabilis x lativitta,3823_CAM016644_d.JPG,major
+CAM041713,https://zenodo.org/record/4291095/files/CAM041713_d.JPG,0,39819,lativitta,39819_CAM041713_d.JPG,major
+CAM041052,https://zenodo.org/record/2714333/files/CAM041052_d.JPG,0,13743,malleti,13743_CAM041052_d.JPG,mimic
+CAM016826,https://zenodo.org/record/3082688/files/CAM016826_d.JPG,1,4074,plesseni x malleti,4074_CAM016826_d.JPG,mimic
+19N2118,https://zenodo.org/record/4288311/files/19N2118_d.JPG,0,21623,malleti,21623_19N2118_d.JPG,mimic
+CAM009309,https://zenodo.org/record/2686762/files/CAM009309_d.JPG,0,10470,hydara,10470_CAM009309_d.JPG,minor
+CAM017236,https://zenodo.org/record/3082688/files/CAM017236_d.JPG,0,4789,notabilis,4789_CAM017236_d.JPG,major
+19N2144,https://zenodo.org/record/4288311/files/19N2144_d.JPG,0,21679,malleti,21679_19N2144_d.JPG,mimic
+CAM045254,https://zenodo.org/record/5526257/files/CAM045254_d.JPG,0,43579,cyrbia,43579_CAM045254_d.JPG,minor
+CAM009188,https://zenodo.org/record/2686762/files/CAM009188_d.JPG,0,10345,plesseni,10345_CAM009188_d.JPG,mimic
+F864,https://zenodo.org/record/2555086/files/F864_d.JPG,0,38104,demophoon,38104_F864_d.JPG,minor
+CAM016521,https://zenodo.org/record/3082688/files/CAM016521_d.JPG,1,3673,notabilis x lativitta,3673_CAM016521_d.JPG,major
+CAM016913,https://zenodo.org/record/4153502/files/CAM016913_d.JPG,0,18988,plesseni,18988_CAM016913_d.JPG,mimic
+CAM040149,https://zenodo.org/record/2707828/files/CAM040149_d.JPG,0,11934,malleti,11934_CAM040149_d.JPG,mimic
+19N0280,https://zenodo.org/record/4288311/files/19N0280_d.JPG,0,19706,malleti,19706_19N0280_d.JPG,mimic
+CS002277,https://zenodo.org/record/2735056/files/CS002277_d.JPG,0,40863,venus,40863_CS002277_d.JPG,minor
+19N0372,https://zenodo.org/record/4288311/files/19N0372_d.JPG,0,19786,malleti,19786_19N0372_d.JPG,mimic
+CAM045175,https://zenodo.org/record/5526257/files/CAM045175_d.JPG,0,43265,cyrbia,43265_CAM045175_d.JPG,minor
+CAM041390,https://zenodo.org/record/4291095/files/CAM041390_d.JPG,0,38540,lativitta,38540_CAM041390_d.JPG,major
+19N0983,https://zenodo.org/record/4288311/files/19N0983_d.JPG,0,20139,malleti,20139_19N0983_d.JPG,mimic
+CAM045045,https://zenodo.org/record/5526257/files/CAM045045_d.JPG,0,42745,cyrbia,42745_CAM045045_d.JPG,minor
+CAM016100,https://zenodo.org/record/3082688/files/CAM016100_d.JPG,1,3108,plesseni x malleti,3108_CAM016100_d.JPG,mimic
+19N0150,https://zenodo.org/record/4288311/files/19N0150_d.JPG,0,19445,malleti,19445_19N0150_d.JPG,mimic
+CAM041706,https://zenodo.org/record/4291095/files/CAM041706_d.JPG,0,39791,lativitta,39791_CAM041706_d.JPG,major
+CAM017199,https://zenodo.org/record/3082688/files/CAM017199_d.JPG,0,4717,notabilis,4717_CAM017199_d.JPG,major
+CAM045022,https://zenodo.org/record/5526257/files/CAM045022_d.JPG,0,42653,cyrbia,42653_CAM045022_d.JPG,minor
+CAM041693,https://zenodo.org/record/4291095/files/CAM041693_d.JPG,0,39739,lativitta,39739_CAM041693_d.JPG,major
+CAM017250,https://zenodo.org/record/3082688/files/CAM017250_d.JPG,0,4817,notabilis,4817_CAM017250_d.JPG,major
+CAM036290,https://zenodo.org/record/5561246/files/CAM036290_d.JPG,0,41815,phyllis,41815_CAM036290_d.JPG,minor
+19N1212,https://zenodo.org/record/4288311/files/19N1212_d.JPG,0,20231,malleti,20231_19N1212_d.JPG,mimic
+CAM036214,https://zenodo.org/record/5561246/files/CAM036214_d.JPG,0,41571,phyllis,41571_CAM036214_d.JPG,minor
+CAM017084,https://zenodo.org/record/3082688/files/CAM017084_d.JPG,1,4509,plesseni x malleti,4509_CAM017084_d.JPG,mimic
+CAM045003,https://zenodo.org/record/5526257/files/CAM045003_d.JPG,0,42571,cyrbia,42571_CAM045003_d.JPG,minor
+CAM041380,https://zenodo.org/record/4291095/files/CAM041380_d.JPG,0,38500,lativitta,38500_CAM041380_d.JPG,major
+CAM016305,https://zenodo.org/record/4153502/files/CAM016305_d.JPG,0,18864,notabilis,18864_CAM016305_d.JPG,major
+19N1377,https://zenodo.org/record/4288311/files/19N1377_d.JPG,0,20309,malleti,20309_19N1377_d.JPG,mimic
+F866,https://zenodo.org/record/2555086/files/F866_d.JPG,0,38112,demophoon,38112_F866_d.JPG,minor
+CAM040253,https://zenodo.org/record/2707828/files/CAM040253_d.JPG,0,12122,malleti,12122_CAM040253_d.JPG,mimic
+CAM016317,https://zenodo.org/record/4153502/files/CAM016317_D.JPG,1,19120,notabilis x lativitta,19120_CAM016317_D.JPG,major
+CAM045264,https://zenodo.org/record/5526257/files/CAM045264_d.JPG,0,43619,cyrbia,43619_CAM045264_d.JPG,minor
+CAM016458,https://zenodo.org/record/3082688/files/CAM016458_d.JPG,1,3615,notabilis x lativitta,3615_CAM016458_d.JPG,major
+CAM016073,https://zenodo.org/record/3082688/files/CAM016073_d.JPG,0,3054,plesseni,3054_CAM016073_d.JPG,mimic
+CAM016541,https://zenodo.org/record/3082688/files/CAM016541_d.JPG,0,3693,malleti,3693_CAM016541_d.JPG,mimic
+19N1389,https://zenodo.org/record/4288311/files/19N1389_d.JPG,0,20327,malleti,20327_19N1389_d.JPG,mimic
+CAM017776,https://zenodo.org/record/3082688/files/CAM017776_d.JPG,1,5540,malleti x plesseni,5540_CAM017776_d.JPG,mimic
+CAM016506,https://zenodo.org/record/3082688/files/CAM016506_d.JPG,0,3645,malleti,3645_CAM016506_d.JPG,mimic
+19N0061,https://zenodo.org/record/4288311/files/19N0061_d.JPG,0,19267,malleti,19267_19N0061_d.JPG,mimic
+CAM016042,https://zenodo.org/record/3082688/files/CAM016042_d.JPG,1,2993,plesseni x malleti,2993_CAM016042_d.JPG,mimic
+CAM017178,https://zenodo.org/record/3082688/files/CAM017178_d.JPG,0,4676,notabilis,4676_CAM017178_d.JPG,major
+CAM045136,https://zenodo.org/record/5526257/files/CAM045136_d.JPG,0,43111,cyrbia,43111_CAM045136_d.JPG,minor
+F8621,https://zenodo.org/record/2555086/files/F8621_d.JPG,0,38392,demophoon,38392_F8621_d.JPG,minor
+CS000586,https://zenodo.org/record/2553501/files/CS586 dorsal.jpeg,0,26005,malleti,26005_CS586 dorsal.jpeg,mimic
+CAM016251,https://zenodo.org/record/3082688/files/CAM016251_d.JPG,1,3362,plesseni x malleti,3362_CAM016251_d.JPG,mimic
+CAM017296,https://zenodo.org/record/3082688/files/CAM017296_d.JPG,1,4884,notabilis x lativitta,4884_CAM017296_d.JPG,major
+19N0015,https://zenodo.org/record/4288311/files/19N0015_d.JPG,0,19169,malleti,19169_19N0015_d.JPG,mimic
+CAM045226,https://zenodo.org/record/5526257/files/CAM045226_d.JPG,0,43467,cyrbia,43467_CAM045226_d.JPG,minor
+CAM017215,https://zenodo.org/record/3082688/files/CAM017215_d.JPG,1,4747,notabilis x lativitta,4747_CAM017215_d.JPG,major
+CAM016098,https://zenodo.org/record/3082688/files/CAM016098_d.JPG,1,3104,plesseni x malleti,3104_CAM016098_d.JPG,mimic
+CAM041611,https://zenodo.org/record/4291095/files/CAM041611_d.JPG,0,39411,lativitta,39411_CAM041611_d.JPG,major
+CAM009553,https://zenodo.org/record/2686762/files/CAM009553_d.JPG,1,10848,hydara x petiverana,10848_CAM009553_d.JPG,minor
+CAM041884,https://zenodo.org/record/4291095/files/CAM041884_d.JPG,0,40500,lativitta,40500_CAM041884_d.JPG,major
+CAM041429,https://zenodo.org/record/4291095/files/CAM041429_d.JPG,0,38688,lativitta,38688_CAM041429_d.JPG,major
+CAM009310,https://zenodo.org/record/2686762/files/CAM009310_d.JPG,0,10472,hydara,10472_CAM009310_d.JPG,minor
+CAM017867,https://zenodo.org/record/3082688/files/CAM017867_d.JPG,1,5661,malleti x plesseni,5661_CAM017867_d.JPG,mimic
+CAM017282,https://zenodo.org/record/3082688/files/CAM017282_d.JPG,1,4876,plesseni x malleti,4876_CAM017282_d.JPG,mimic
+CAM041654,https://zenodo.org/record/4291095/files/CAM041654_d.JPG,0,39583,lativitta,39583_CAM041654_d.JPG,major
+CAM045167,https://zenodo.org/record/5526257/files/CAM045167_d.JPG,0,43233,cyrbia,43233_CAM045167_d.JPG,minor
+CAM036188,https://zenodo.org/record/5561246/files/CAM036188_d.JPG,0,41483,phyllis,41483_CAM036188_d.JPG,minor
+CAM041595,https://zenodo.org/record/4291095/files/CAM041595_d.JPG,0,39347,lativitta,39347_CAM041595_d.JPG,major
+CAM017019,https://zenodo.org/record/3082688/files/CAM017019_d.JPG,0,4393,malleti,4393_CAM017019_d.JPG,mimic
+CAM000239,https://zenodo.org/record/2677821/files/CAM000239_d.JPG,0,6304,chestertonii,6304_CAM000239_d.JPG,minor
+CAM016005,https://zenodo.org/record/4153502/files/CAM016005_d.JPG,0,18851,plesseni,18851_CAM016005_d.JPG,mimic
+CAM041736,https://zenodo.org/record/4291095/files/CAM041736_d.JPG,0,39911,lativitta,39911_CAM041736_d.JPG,major
+CAM016139,https://zenodo.org/record/3082688/files/CAM016139_d.JPG,1,3186,notabilis x lativitta,3186_CAM016139_d.JPG,major
+CAM017356,https://zenodo.org/record/4153502/files/CAM017356_d.JPG,0,19018,plesseni,19018_CAM017356_d.JPG,mimic
+CAM041841,https://zenodo.org/record/4291095/files/CAM041841_d.JPG,0,40331,lativitta,40331_CAM041841_d.JPG,major
+CAM016809,https://zenodo.org/record/3082688/files/CAM016809_d.JPG,1,4040,plesseni x malleti,4040_CAM016809_d.JPG,mimic
+CAM016452,https://zenodo.org/record/3082688/files/CAM016452_d.JPG,1,3607,notabilis x lativitta,3607_CAM016452_d.JPG,major
+CAM011411,https://zenodo.org/record/2550097/files/CAM011411_d.JPG,0,28144,plesseni,28144_CAM011411_d.JPG,mimic
+19N1110,https://zenodo.org/record/4288311/files/19N1110_d.JPG,0,20186,malleti,20186_19N1110_d.JPG,mimic
+19N0746,https://zenodo.org/record/4288311/files/19N0746_d.JPG,0,20022,malleti,20022_19N0746_d.JPG,mimic
+CAM009161,https://zenodo.org/record/2686762/files/CAM009161_d.JPG,0,10291,plesseni,10291_CAM009161_d.JPG,mimic
+CAM045262,https://zenodo.org/record/5526257/files/CAM045262_d.JPG,0,43611,cyrbia,43611_CAM045262_d.JPG,minor
+CAM017454,https://zenodo.org/record/3082688/files/CAM017454_d.JPG,1,5138,plesseni x malleti,5138_CAM017454_d.JPG,mimic
+CAM016164,https://zenodo.org/record/3082688/files/CAM016164_d.JPG,1,3236,notabilis x lativitta,3236_CAM016164_d.JPG,major
+CAM016990,https://zenodo.org/record/3082688/files/CAM016990_d.JPG,0,4342,malleti,4342_CAM016990_d.JPG,mimic
+19N0095,https://zenodo.org/record/4288311/files/19N0095_d.JPG,0,19335,malleti,19335_19N0095_d.JPG,mimic
+CAM017773,https://zenodo.org/record/3082688/files/CAM017773_d.JPG,1,5534,lativitta x notabilis,5534_CAM017773_d.JPG,major
+CAM041873,https://zenodo.org/record/4291095/files/CAM041873_d.JPG,0,40456,lativitta,40456_CAM041873_d.JPG,major
+19N0115,https://zenodo.org/record/4288311/files/19N0115_d.JPG,0,19375,malleti,19375_19N0115_d.JPG,mimic
+19N1763,https://zenodo.org/record/4288311/files/19N1763_d.JPG,0,20979,malleti,20979_19N1763_d.JPG,mimic
+CAM041431,https://zenodo.org/record/4291095/files/CAM041431_d.JPG,0,38696,lativitta,38696_CAM041431_d.JPG,major
+CAM016323,https://zenodo.org/record/3082688/files/CAM016323_d.JPG,0,3420,plesseni,3420_CAM016323_d.JPG,mimic
+CAM017620,https://zenodo.org/record/4153502/files/CAM017620_d.JPG,0,19066,plesseni,19066_CAM017620_d.JPG,mimic
+CAM041768,https://zenodo.org/record/4291095/files/CAM041768_d.JPG,0,40039,lativitta,40039_CAM041768_d.JPG,major
+CAM040023,https://zenodo.org/record/2707828/files/CAM040023_d.JPG,0,11730,malleti,11730_CAM040023_d.JPG,mimic
+CAM041655,https://zenodo.org/record/4291095/files/CAM041655_d.JPG,0,39587,lativitta,39587_CAM041655_d.JPG,major
+19N1063,https://zenodo.org/record/4288311/files/19N1063_d.JPG,0,20170,malleti,20170_19N1063_d.JPG,mimic
+CAM017704,https://zenodo.org/record/1748277/files/CAM017704_d_whitestandard.JPG,0,16079,plesseni,16079_CAM017704_d_whitestandard.JPG,mimic
+CAM041773,https://zenodo.org/record/4291095/files/CAM041773_d.JPG,0,40059,lativitta,40059_CAM041773_d.JPG,major
+CAM045019,https://zenodo.org/record/5526257/files/CAM045019_d.JPG,0,42641,cyrbia,42641_CAM045019_d.JPG,minor
+CAM041886,https://zenodo.org/record/4291095/files/CAM041886_d.JPG,0,40508,lativitta,40508_CAM041886_d.JPG,major
+CAM016356,https://zenodo.org/record/4153502/files/CAM016356_D.JPG,0,19126,notabilis,19126_CAM016356_D.JPG,major
+CAM016034,https://zenodo.org/record/3082688/files/CAM016034_d.JPG,1,2977,notabilis x lativitta,2977_CAM016034_d.JPG,major
+CAM016234,https://zenodo.org/record/3082688/files/CAM016234_d.JPG,0,3344,malleti,3344_CAM016234_d.JPG,mimic
+19N1850,https://zenodo.org/record/4288311/files/19N1850_d.JPG,0,21103,malleti,21103_19N1850_d.JPG,mimic
+CAM017692,https://zenodo.org/record/3082688/files/CAM017692_d.JPG,1,5448,malleti x plesseni,5448_CAM017692_d.JPG,mimic
+CAM016145,https://zenodo.org/record/3082688/files/CAM016145_d.JPG,1,3198,notabilis x lativitta,3198_CAM016145_d.JPG,major
+CAM017238,https://zenodo.org/record/3082688/files/CAM017238_d.JPG,0,4793,notabilis,4793_CAM017238_d.JPG,major
+19N0715,https://zenodo.org/record/4288311/files/19N0715_d.JPG,0,20008,malleti,20008_19N0715_d.JPG,mimic
+CAM016122,https://zenodo.org/record/3082688/files/CAM016122_d.JPG,1,3152,plesseni x malleti,3152_CAM016122_d.JPG,mimic
+CAM016023,https://zenodo.org/record/3082688/files/CAM016023_d.JPG,1,2955,notabilis x lativitta,2955_CAM016023_d.JPG,major
+CAM045177,https://zenodo.org/record/5526257/files/CAM045177_d.JPG,0,43273,cyrbia,43273_CAM045177_d.JPG,minor
+CAM041715,https://zenodo.org/record/4291095/files/CAM041715_d.JPG,0,39827,lativitta,39827_CAM041715_d.JPG,major
+15N113,https://zenodo.org/record/4289223/files/15N113_d.JPG,0,15173,venus,15173_15N113_d.JPG,minor
+CAM016906,https://zenodo.org/record/4153502/files/CAM016906_d.JPG,0,18976,plesseni,18976_CAM016906_d.JPG,mimic
+CAM016295,https://zenodo.org/record/3082688/files/CAM016295_d.JPG,0,3406,plesseni,3406_CAM016295_d.JPG,mimic
+CS003109,https://zenodo.org/record/2553501/files/CS3109 dorsal.jpeg,0,25847,malleti,25847_CS3109 dorsal.jpeg,mimic
+CAM017127,https://zenodo.org/record/3082688/files/CAM017127_d.JPG,1,4583,notabilis x lativitta,4583_CAM017127_d.JPG,major
+CAM016021,https://zenodo.org/record/3082688/files/CAM016021_d.JPG,1,2951,notabilis x lativitta,2951_CAM016021_d.JPG,major
+CAM017087,https://zenodo.org/record/3082688/files/CAM017087_d.JPG,1,4515,notabilis x lativitta,4515_CAM017087_d.JPG,major
+CAM021054,https://zenodo.org/record/2702457/files/CAM021054_d.JPG,1,11540,hydara x erato,11540_CAM021054_d.JPG,minor
+CAM041219,https://zenodo.org/record/2714333/files/CAM041219_d.JPG,0,14075,malleti,14075_CAM041219_d.JPG,mimic
+CAM017287,https://zenodo.org/record/3082688/files/CAM017287_d.JPG,1,4882,notabilis x lativitta,4882_CAM017287_d.JPG,major
+CAM016174,https://zenodo.org/record/3082688/files/CAM016174_d.JPG,1,3256,notabilis x lativitta,3256_CAM016174_d.JPG,major
+CAM016567,https://zenodo.org/record/3082688/files/CAM016567_d.JPG,0,3739,malleti,3739_CAM016567_d.JPG,mimic
+CAM041618,https://zenodo.org/record/4291095/files/CAM041618_d.JPG,0,39439,lativitta,39439_CAM041618_d.JPG,major
+CAM017163,https://zenodo.org/record/3082688/files/CAM017163_d.JPG,1,4649,notabilis x lativitta,4649_CAM017163_d.JPG,major
+CAM016696,https://zenodo.org/record/4153502/files/CAM016696_d.JPG,0,18936,plesseni,18936_CAM016696_d.JPG,mimic
+CAM041438,https://zenodo.org/record/4291095/files/CAM041438_d.JPG,0,38724,lativitta,38724_CAM041438_d.JPG,major
+CAM016969,https://zenodo.org/record/3082688/files/CAM016969_d.JPG,1,4308,notabilis x lativitta,4308_CAM016969_d.JPG,major
+CAM041363,https://zenodo.org/record/4291095/files/CAM041363_d.JPG,0,38432,lativitta,38432_CAM041363_d.JPG,major
+CAM017615,https://zenodo.org/record/4153502/files/CAM017615_d.JPG,0,19056,plesseni,19056_CAM017615_d.JPG,mimic
+CAM041276,https://zenodo.org/record/2714333/files/CAM041276_d.JPG,0,14188,malleti,14188_CAM041276_d.JPG,mimic
+CAM009306,https://zenodo.org/record/2686762/files/CAM009306_d.JPG,0,10464,hydara,10464_CAM009306_d.JPG,minor
+CAM016151,https://zenodo.org/record/3082688/files/CAM016151_d.JPG,1,3210,notabilis x lativitta,3210_CAM016151_d.JPG,major
+CAM017053,https://zenodo.org/record/3082688/files/CAM017053_d.JPG,1,4455,plesseni x malleti,4455_CAM017053_d.JPG,mimic
+CAM017747,https://zenodo.org/record/3082688/files/CAM017747_d.JPG,1,5504,malleti x plesseni,5504_CAM017747_d.JPG,mimic
+19N0667,https://zenodo.org/record/4288311/files/19N0667_d.JPG,0,19958,malleti,19958_19N0667_d.JPG,mimic
+CAM041604,https://zenodo.org/record/4291095/files/CAM041604_d.JPG,0,39383,lativitta,39383_CAM041604_d.JPG,major
+CAM045173,https://zenodo.org/record/5526257/files/CAM045173_d.JPG,0,43257,cyrbia,43257_CAM045173_d.JPG,minor
+CAM016544,https://zenodo.org/record/3082688/files/CAM016544_d.JPG,0,3697,malleti,3697_CAM016544_d.JPG,mimic
+CAM041613,https://zenodo.org/record/4291095/files/CAM041613_d.JPG,0,39419,lativitta,39419_CAM041613_d.JPG,major
+19N2260,https://zenodo.org/record/4288311/files/19N2260_d.JPG,0,21967,malleti,21967_19N2260_d.JPG,mimic
+CAM017033,https://zenodo.org/record/3082688/files/CAM017033_d.JPG,1,4421,notabilis x lativitta,4421_CAM017033_d.JPG,major
+CAM017089,https://zenodo.org/record/3082688/files/CAM017089_d.JPG,0,4519,malleti,4519_CAM017089_d.JPG,mimic
+19N2082,https://zenodo.org/record/4288311/files/19N2082_d.JPG,0,21579,malleti,21579_19N2082_d.JPG,mimic
+CAM016428,https://zenodo.org/record/3082688/files/CAM016428_d.JPG,1,3567,plesseni x malleti,3567_CAM016428_d.JPG,mimic
+CAM017315,https://zenodo.org/record/3082688/files/CAM017315_d.JPG,1,4914,notabilis x lativitta,4914_CAM017315_d.JPG,major
+CAM017179,https://zenodo.org/record/3082688/files/CAM017179_d.JPG,0,4678,notabilis,4678_CAM017179_d.JPG,major
+CAM009228,https://zenodo.org/record/2686762/files/CAM009228_d.JPG,0,10424,plesseni,10424_CAM009228_d.JPG,mimic
+19N0946,https://zenodo.org/record/4288311/files/19N0946_d.JPG,0,20112,malleti,20112_19N0946_d.JPG,mimic
+CAM016702,https://zenodo.org/record/4153502/files/CAM016702_d.JPG,0,18948,notabilis,18948_CAM016702_d.JPG,major
+19N0673,https://zenodo.org/record/4288311/files/19N0673_d.JPG,0,19968,malleti,19968_19N0673_d.JPG,mimic
+CAM017398,https://zenodo.org/record/3082688/files/CAM017398_d.JPG,1,5039,notabilis x lativitta,5039_CAM017398_d.JPG,major
+CAM016117,https://zenodo.org/record/3082688/files/CAM016117_d.JPG,1,3142,plesseni x malleti,3142_CAM016117_d.JPG,mimic
+F858,https://zenodo.org/record/2555086/files/F858_d.JPG,0,38096,demophoon,38096_F858_d.JPG,minor
+19N0809,https://zenodo.org/record/4288311/files/19N0809_d.JPG,0,20034,malleti,20034_19N0809_d.JPG,mimic
+CAM045218,https://zenodo.org/record/5526257/files/CAM045218_d.JPG,0,43435,cyrbia,43435_CAM045218_d.JPG,minor
+CAM016024,https://zenodo.org/record/3082688/files/CAM016024_d.JPG,1,2957,notabilis x lativitta,2957_CAM016024_d.JPG,major
+CAM017703,https://zenodo.org/record/3082688/files/CAM017703_d.JPG,1,5458,lativitta x notabilis,5458_CAM017703_d.JPG,major
+CS000583,https://zenodo.org/record/2553501/files/CS583 dorsal.jpeg,0,26003,malleti,26003_CS583 dorsal.jpeg,mimic
+CAM017123,https://zenodo.org/record/3082688/files/CAM017123_d.JPG,1,4575,plesseni x malleti,4575_CAM017123_d.JPG,mimic
+CAM017000,https://zenodo.org/record/3082688/files/CAM017000_d.JPG,1,4359,notabilis x lativitta,4359_CAM017000_d.JPG,major
+19N1997,https://zenodo.org/record/4288311/files/19N1997_d.JPG,0,21387,malleti,21387_19N1997_d.JPG,mimic
+CAM016313,https://zenodo.org/record/3082688/files/CAM016313_d.JPG,1,3418,plesseni x malleti,3418_CAM016313_d.JPG,mimic
+CAM041697,https://zenodo.org/record/4291095/files/CAM041697_d.JPG,0,39755,lativitta,39755_CAM041697_d.JPG,major
+CAM041216,https://zenodo.org/record/2714333/files/CAM041216_d.JPG,0,14069,malleti,14069_CAM041216_d.JPG,mimic
+CAM016765,https://zenodo.org/record/3082688/files/CAM016765_d.JPG,1,3966,plesseni x malleti,3966_CAM016765_d.JPG,mimic
+19N0647,https://zenodo.org/record/4288311/files/19N0647_d.JPG,0,19940,malleti,19940_19N0647_d.JPG,mimic
+19N0033,https://zenodo.org/record/4288311/files/19N0033_d.JPG,0,19206,malleti,19206_19N0033_d.JPG,mimic
+CAM017085,https://zenodo.org/record/3082688/files/CAM017085_d.JPG,1,4511,notabilis x lativitta,4511_CAM017085_d.JPG,major
+CAM045186,https://zenodo.org/record/5526257/files/CAM045186_d.JPG,0,43309,cyrbia,43309_CAM045186_d.JPG,minor
+19N0012,https://zenodo.org/record/4288311/files/19N0012_d.JPG,0,19163,malleti,19163_19N0012_d.JPG,mimic
+CAM041435,https://zenodo.org/record/4291095/files/CAM041435_d.JPG,0,38712,lativitta,38712_CAM041435_d.JPG,major
+CAM041765,https://zenodo.org/record/4291095/files/CAM041765_d.JPG,0,40027,lativitta,40027_CAM041765_d.JPG,major
+19N0666,https://zenodo.org/record/4288311/files/19N0666_d.JPG,0,19956,malleti,19956_19N0666_d.JPG,mimic
+CAM041051,https://zenodo.org/record/2714333/files/CAM041051_d.JPG,0,13741,malleti,13741_CAM041051_d.JPG,mimic
+CAM021031,https://zenodo.org/record/2702457/files/CAM021031_d.JPG,1,11496,hydara x amalfreda,11496_CAM021031_d.JPG,minor
+CAM009438,https://zenodo.org/record/2686762/files/CAM009438_d.JPG,0,10674,plesseni,10674_CAM009438_d.JPG,mimic
+CAM017408,https://zenodo.org/record/3082688/files/CAM017408_d.JPG,1,5057,notabilis x lativitta,5057_CAM017408_d.JPG,major
+CAM045066,https://zenodo.org/record/5526257/files/CAM045066_d.JPG,0,42829,cyrbia,42829_CAM045066_d.JPG,minor
+CAM009321,https://zenodo.org/record/2686762/files/CAM009321_d.JPG,0,10494,hydara,10494_CAM009321_d.JPG,minor
+CAM016659,https://zenodo.org/record/3082688/files/CAM016659_d.JPG,1,3853,plesseni x malleti,3853_CAM016659_d.JPG,mimic
+CAM041727,https://zenodo.org/record/4291095/files/CAM041727_d.JPG,0,39875,lativitta,39875_CAM041727_d.JPG,major
+CAM041608,https://zenodo.org/record/4291095/files/CAM041608_d.JPG,0,39399,lativitta,39399_CAM041608_d.JPG,major
+CAM009206,https://zenodo.org/record/2686762/files/CAM009206_d.JPG,0,10381,plesseni,10381_CAM009206_d.JPG,mimic
+19N2253,https://zenodo.org/record/4288311/files/19N2253_d.JPG,0,21939,malleti,21939_19N2253_d.JPG,mimic
+CAM041892,https://zenodo.org/record/4291095/files/CAM041892_d.JPG,0,40532,lativitta,40532_CAM041892_d.JPG,major
+CAM017217,https://zenodo.org/record/3082688/files/CAM017217_d.JPG,0,4751,notabilis,4751_CAM017217_d.JPG,major
+19N0437,https://zenodo.org/record/4288311/files/19N0437_d.JPG,0,19820,malleti,19820_19N0437_d.JPG,mimic
+CAM041627,https://zenodo.org/record/4291095/files/CAM041627_d.JPG,0,39475,lativitta,39475_CAM041627_d.JPG,major
+CAM016408,https://zenodo.org/record/3082688/files/CAM016408_d.JPG,1,3527,plesseni x malleti,3527_CAM016408_d.JPG,mimic
+CAM045015,https://zenodo.org/record/5526257/files/CAM045015_d.JPG,0,42625,cyrbia,42625_CAM045015_d.JPG,minor
+CAM041209,https://zenodo.org/record/2714333/files/CAM041209_d.JPG,0,14055,malleti,14055_CAM041209_d.JPG,mimic
+CAM041822,https://zenodo.org/record/4291095/files/CAM041822_d.JPG,0,40255,lativitta,40255_CAM041822_d.JPG,major
+CAM041883,https://zenodo.org/record/4291095/files/CAM041883_d.JPG,0,40496,lativitta,40496_CAM041883_d.JPG,major
+F846,https://zenodo.org/record/2555086/files/F846_d.JPG,0,38068,demophoon,38068_F846_d.JPG,minor
+CAM017324,https://zenodo.org/record/3082688/files/CAM017324_d.JPG,0,4932,notabilis,4932_CAM017324_d.JPG,major
+CAM041838,https://zenodo.org/record/4291095/files/CAM041838_d.JPG,0,40319,lativitta,40319_CAM041838_d.JPG,major
+CAM041897,https://zenodo.org/record/4291095/files/CAM041897_d.JPG,0,40552,lativitta,40552_CAM041897_d.JPG,major
+CAM017302,https://zenodo.org/record/3082688/files/CAM017302_d.JPG,1,4894,notabilis x lativitta,4894_CAM017302_d.JPG,major
+CAM017136,https://zenodo.org/record/3082688/files/CAM017136_d.JPG,0,4601,malleti,4601_CAM017136_d.JPG,mimic
+CAM017427,https://zenodo.org/record/3082688/files/CAM017427_d.JPG,1,5091,notabilis x lativitta,5091_CAM017427_d.JPG,major
+19N1932,https://zenodo.org/record/4288311/files/19N1932_d.JPG,0,21251,malleti,21251_19N1932_d.JPG,mimic
+CAM041906,https://zenodo.org/record/4291095/files/CAM041906_d.JPG,0,40588,lativitta,40588_CAM041906_d.JPG,major
+CAM016232,https://zenodo.org/record/4153502/files/CAM016232_D.JPG,1,19086,notabilis x lativitta,19086_CAM016232_D.JPG,major
+CAM016699,https://zenodo.org/record/4153502/files/CAM016699_d.JPG,0,18942,plesseni,18942_CAM016699_d.JPG,mimic
+CAM041801,https://zenodo.org/record/4291095/files/CAM041801_d.JPG,0,40171,lativitta,40171_CAM041801_d.JPG,major
+CAM045058,https://zenodo.org/record/5526257/files/CAM045058_d.JPG,0,42797,cyrbia,42797_CAM045058_d.JPG,minor
+CAM120448,https://zenodo.org/record/2813153/files/CAM120448_d.JPG,0,14885,malleti,14885_CAM120448_d.JPG,mimic
+F837,https://zenodo.org/record/2555086/files/F837_d.JPG,0,38060,demophoon,38060_F837_d.JPG,minor
+CAM016907,https://zenodo.org/record/4153502/files/CAM016907_d.JPG,0,18978,plesseni,18978_CAM016907_d.JPG,mimic
+CAM016404,https://zenodo.org/record/3082688/files/CAM016404_d.JPG,0,3519,plesseni,3519_CAM016404_d.JPG,mimic
+CAM017344,https://zenodo.org/record/3082688/files/CAM017344_d.JPG,1,4966,notabilis x lativitta,4966_CAM017344_d.JPG,major
+CAM011443,https://zenodo.org/record/2550097/files/CAM011443_d.JPG,0,28264,plesseni,28264_CAM011443_d.JPG,mimic
+CAM016640,https://zenodo.org/record/4153502/files/CAM016640_d.JPG,1,18906,notabilis x lativitta,18906_CAM016640_d.JPG,major
+19N2079,https://zenodo.org/record/4288311/files/19N2079_d.JPG,0,21571,malleti,21571_19N2079_d.JPG,mimic
+CAM041753,https://zenodo.org/record/4291095/files/CAM041753_d.JPG,0,39979,lativitta,39979_CAM041753_d.JPG,major
+CAM016955,https://zenodo.org/record/3082688/files/CAM016955_d.JPG,0,4287,malleti,4287_CAM016955_d.JPG,mimic
+19N0279,https://zenodo.org/record/4288311/files/19N0279_d.JPG,0,19704,malleti,19704_19N0279_d.JPG,mimic
+CAM016642,https://zenodo.org/record/4153502/files/CAM016642_d.JPG,1,18908,notabilis x lativitta,18908_CAM016642_d.JPG,major
+CAM009191,https://zenodo.org/record/2686762/files/CAM009191_d.JPG,0,10351,plesseni,10351_CAM009191_d.JPG,mimic
+CAM045064,https://zenodo.org/record/5526257/files/CAM045064_d.JPG,0,42821,cyrbia,42821_CAM045064_d.JPG,minor
+CAM016094,https://zenodo.org/record/3082688/files/CAM016094_d.JPG,1,3096,notabilis x lativitta,3096_CAM016094_d.JPG,major
+CAM017022,https://zenodo.org/record/3082688/files/CAM017022_d.JPG,1,4399,notabilis x lativitta,4399_CAM017022_d.JPG,major
+CAM017030,https://zenodo.org/record/3082688/files/CAM017030_d.JPG,0,4415,malleti,4415_CAM017030_d.JPG,mimic
+CAM008867,https://zenodo.org/record/2686762/files/CAM008867_d.JPG,0,9955,hydara,9955_CAM008867_d.JPG,minor
+CAM041217,https://zenodo.org/record/2714333/files/CAM041217_d.JPG,0,14071,malleti,14071_CAM041217_d.JPG,mimic
+CAM041896,https://zenodo.org/record/4291095/files/CAM041896_d.JPG,0,40548,lativitta,40548_CAM041896_d.JPG,major
+CAM008161,https://zenodo.org/record/2684906/files/CAM008161_d.JPG,0,8768,malleti,8768_CAM008161_d.JPG,mimic
+CAM045134,https://zenodo.org/record/5526257/files/CAM045134_d.JPG,0,43103,cyrbia,43103_CAM045134_d.JPG,minor
+19N0658,https://zenodo.org/record/4288311/files/19N0658_d.JPG,0,19946,malleti,19946_19N0658_d.JPG,mimic
+CAM017034,https://zenodo.org/record/3082688/files/CAM017034_d.JPG,1,4423,notabilis x lativitta,4423_CAM017034_d.JPG,major
+CAM041851,https://zenodo.org/record/4291095/files/CAM041851_d.JPG,0,40371,lativitta,40371_CAM041851_d.JPG,major
+CAM016457,https://zenodo.org/record/4153502/files/CAM016457_d.JPG,1,18882,notabilis x lativitta,18882_CAM016457_d.JPG,major
+CAM017237,https://zenodo.org/record/3082688/files/CAM017237_d.JPG,0,4791,notabilis,4791_CAM017237_d.JPG,major
+CAM016547,https://zenodo.org/record/3082688/files/CAM016547_d.JPG,0,3703,malleti,3703_CAM016547_d.JPG,mimic
+CAM017363,https://zenodo.org/record/4153502/files/CAM017363_d.JPG,0,19022,plesseni,19022_CAM017363_d.JPG,mimic
+CAM040078,https://zenodo.org/record/2707828/files/CAM040078_d.JPG,0,11820,dignus,11820_CAM040078_d.JPG,minor
+CAM016086,https://zenodo.org/record/3082688/files/CAM016086_d.JPG,1,3080,plesseni x malleti,3080_CAM016086_d.JPG,mimic
+19N1762,https://zenodo.org/record/4288311/files/19N1762_d.JPG,0,20975,malleti,20975_19N1762_d.JPG,mimic
+CAM009320,https://zenodo.org/record/2686762/files/CAM009320_d.JPG,0,10492,hydara,10492_CAM009320_d.JPG,minor
+CAM017420,https://zenodo.org/record/3082688/files/CAM017420_d.JPG,1,5077,notabilis x lativitta,5077_CAM017420_d.JPG,major
+CAM017421,https://zenodo.org/record/3082688/files/CAM017421_d.JPG,1,5079,notabilis x lativitta,5079_CAM017421_d.JPG,major
+CAM041746,https://zenodo.org/record/4291095/files/CAM041746_d.JPG,0,39951,lativitta,39951_CAM041746_d.JPG,major
+CAM016512,https://zenodo.org/record/3082688/files/CAM016512_d.JPG,1,3657,notabilis x lativitta,3657_CAM016512_d.JPG,major
+CAM017441,https://zenodo.org/record/3082688/files/CAM017441_d.JPG,1,5117,notabilis x lativitta,5117_CAM017441_d.JPG,major
+CAM045040,https://zenodo.org/record/5526257/files/CAM045040_d.JPG,0,42725,cyrbia,42725_CAM045040_d.JPG,minor
+CAM041598,https://zenodo.org/record/4291095/files/CAM041598_d.JPG,0,39359,lativitta,39359_CAM041598_d.JPG,major
+19N2283,https://zenodo.org/record/4288311/files/19N2283_d.JPG,0,22059,malleti,22059_19N2283_d.JPG,mimic
+CAM045139,https://zenodo.org/record/5526257/files/CAM045139_d.JPG,0,43123,cyrbia,43123_CAM045139_d.JPG,minor
+CAM016196,https://zenodo.org/record/3082688/files/CAM016196_d.JPG,1,3300,plesseni x malleti,3300_CAM016196_d.JPG,mimic
+CAM041633,https://zenodo.org/record/4291095/files/CAM041633_d.JPG,0,39499,lativitta,39499_CAM041633_d.JPG,major
+CAM017223,https://zenodo.org/record/3082688/files/CAM017223_d.JPG,0,4763,notabilis,4763_CAM017223_d.JPG,major
+CAM016163,https://zenodo.org/record/3082688/files/CAM016163_d.JPG,1,3234,notabilis x lativitta,3234_CAM016163_d.JPG,major
+CS002311,https://zenodo.org/record/2553501/files/CS2311 dorsal.jpeg,0,25701,malleti,25701_CS2311 dorsal.jpeg,mimic
+CAM045138,https://zenodo.org/record/5526257/files/CAM045138_d.JPG,0,43119,cyrbia,43119_CAM045138_d.JPG,minor
+19N2115,https://zenodo.org/record/4288311/files/19N2115_d.JPG,0,21611,malleti,21611_19N2115_d.JPG,mimic
+19N1158,https://zenodo.org/record/4288311/files/19N1158_d.JPG,0,20204,malleti,20204_19N1158_d.JPG,mimic
+CAM041223,https://zenodo.org/record/2714333/files/CAM041223_d.JPG,0,14083,malleti,14083_CAM041223_d.JPG,mimic
+CAM041177,https://zenodo.org/record/2714333/files/CAM041177_d.JPG,0,13991,malleti,13991_CAM041177_d.JPG,mimic
+CAM016707,https://zenodo.org/record/4153502/files/CAM016707_d.JPG,0,18956,notabilis,18956_CAM016707_d.JPG,major
+CAM045210,https://zenodo.org/record/5526257/files/CAM045210_d.JPG,0,43403,cyrbia,43403_CAM045210_d.JPG,minor
+CAM016280,https://zenodo.org/record/3082688/files/CAM016280_d.JPG,0,3394,plesseni,3394_CAM016280_d.JPG,mimic
+CAM017456,https://zenodo.org/record/3082688/files/CAM017456_d.JPG,1,5140,malleti x plesseni,5140_CAM017456_d.JPG,mimic
+CAM016192,https://zenodo.org/record/3082688/files/CAM016192_d.JPG,1,3292,notabilis x lativitta,3292_CAM016192_d.JPG,major
+19N2068,https://zenodo.org/record/4288311/files/19N2068_d.JPG,0,21547,malleti,21547_19N2068_d.JPG,mimic
+19N0700,https://zenodo.org/record/4288311/files/19N0700_d.JPG,0,19996,malleti,19996_19N0700_d.JPG,mimic
+CAM045263,https://zenodo.org/record/5526257/files/CAM045263_d.JPG,0,43615,cyrbia,43615_CAM045263_d.JPG,minor
+CAM016546,https://zenodo.org/record/3082688/files/CAM016546_d.JPG,0,3701,malleti,3701_CAM016546_d.JPG,mimic
+CAM016132,https://zenodo.org/record/3082688/files/CAM016132_d.JPG,1,3172,plesseni x malleti,3172_CAM016132_d.JPG,mimic
+19N1771,https://zenodo.org/record/4288311/files/19N1771_d.JPG,0,20999,malleti,20999_19N1771_d.JPG,mimic
+CAM016410,https://zenodo.org/record/3082688/files/CAM016410_d.JPG,1,3531,notabilis x lativitta,3531_CAM016410_d.JPG,major
+CAM018447,https://zenodo.org/record/2548678/files/CAM018447_v_whitestandard.JPG,0,18201,plesseni,18201_CAM018447_v_whitestandard.JPG,mimic
+CAM016859,https://zenodo.org/record/3082688/files/CAM016859_d.JPG,1,4137,plesseni x malleti,4137_CAM016859_d.JPG,mimic
+CAM016157,https://zenodo.org/record/3082688/files/CAM016157_d.JPG,1,3222,notabilis x lativitta,3222_CAM016157_d.JPG,major
+CAM041672,https://zenodo.org/record/4291095/files/CAM041672_d.JPG,0,39655,lativitta,39655_CAM041672_d.JPG,major
+CAM018528,https://zenodo.org/record/2548678/files/CAM018528_v_whitestandard.JPG,0,18525,malleti,18525_CAM018528_v_whitestandard.JPG,mimic
+19N0162,https://zenodo.org/record/4288311/files/19N0162_d.JPG,0,19469,malleti,19469_19N0162_d.JPG,mimic
+CAM041740,https://zenodo.org/record/4291095/files/CAM041740_d.JPG,0,39927,lativitta,39927_CAM041740_d.JPG,major
+CAM041864,https://zenodo.org/record/4291095/files/CAM041864_d.JPG,0,40420,lativitta,40420_CAM041864_d.JPG,major
+CAM016099,https://zenodo.org/record/3082688/files/CAM016099_d.JPG,1,3106,notabilis x lativitta,3106_CAM016099_d.JPG,major
+19N0261,https://zenodo.org/record/4288311/files/19N0261_d.JPG,0,19667,malleti,19667_19N0261_d.JPG,mimic
+CAM016460,https://zenodo.org/record/4153502/files/CAM016460_d.JPG,1,18884,notabilis x lativitta,18884_CAM016460_d.JPG,major
+CAM008163,https://zenodo.org/record/2684906/files/CAM008163_d.JPG,0,8772,malleti,8772_CAM008163_d.JPG,mimic
+CAM009551,https://zenodo.org/record/2686762/files/CAM009551_d.JPG,1,10844,hydara x petiverana,10844_CAM009551_d.JPG,minor
+CAM016105,https://zenodo.org/record/3082688/files/CAM016105_d.JPG,1,3118,notabilis x lativitta,3118_CAM016105_d.JPG,major
+CAM040245,https://zenodo.org/record/2707828/files/CAM040245_d.JPG,0,12106,malleti,12106_CAM040245_d.JPG,mimic
+CAM016522,https://zenodo.org/record/3082688/files/CAM016522_d.JPG,1,3675,notabilis x lativitta,3675_CAM016522_d.JPG,major
+CAM016551,https://zenodo.org/record/3082688/files/CAM016551_d.JPG,0,3711,malleti,3711_CAM016551_d.JPG,mimic
+CAM040172,https://zenodo.org/record/2707828/files/CAM040172_d.JPG,0,11974,malleti,11974_CAM040172_d.JPG,mimic
+CAM017133,https://zenodo.org/record/3082688/files/CAM017133_d.JPG,1,4595,notabilis x lativitta,4595_CAM017133_d.JPG,major
+CAM017835,https://zenodo.org/record/3082688/files/CAM017835_d.JPG,1,5615,plesseni x malleti,5615_CAM017835_d.JPG,mimic
+15N120,https://zenodo.org/record/4289223/files/15N120_d.JPG,0,15174,venus,15174_15N120_d.JPG,minor
+CAM016113,https://zenodo.org/record/3082688/files/CAM016113_d.JPG,0,3134,plesseni,3134_CAM016113_d.JPG,mimic
+CAM041695,https://zenodo.org/record/4291095/files/CAM041695_d.JPG,0,39747,lativitta,39747_CAM041695_d.JPG,major
+CAM045145,https://zenodo.org/record/5526257/files/CAM045145_d.JPG,0,43147,cyrbia,43147_CAM045145_d.JPG,minor
+CAM017339,https://zenodo.org/record/3082688/files/CAM017339_d.JPG,1,4956,notabilis x lativitta,4956_CAM017339_d.JPG,major
+CAM041035,https://zenodo.org/record/2714333/files/CAM041035_d.JPG,0,13709,malleti,13709_CAM041035_d.JPG,mimic
+CAM018466,https://zenodo.org/record/2702457/files/CAM018466_d.JPG,1,11274,plesseni x malleti,11274_CAM018466_d.JPG,mimic
+19N0137,https://zenodo.org/record/4288311/files/19N0137_d.JPG,0,19419,malleti,19419_19N0137_d.JPG,mimic
+CAM041221,https://zenodo.org/record/2714333/files/CAM041221_d.JPG,0,14079,malleti,14079_CAM041221_d.JPG,mimic
+19N0712,https://zenodo.org/record/4288311/files/19N0712_d.JPG,0,20002,malleti,20002_19N0712_d.JPG,mimic
+CAM041621,https://zenodo.org/record/4291095/files/CAM041621_d.JPG,0,39451,lativitta,39451_CAM041621_d.JPG,major
+CAM036229,https://zenodo.org/record/5561246/files/CAM036229_d.JPG,0,41627,phyllis,41627_CAM036229_d.JPG,minor
+CAM017244,https://zenodo.org/record/3082688/files/CAM017244_d.JPG,0,4805,notabilis,4805_CAM017244_d.JPG,major
+CAM016121,https://zenodo.org/record/3082688/files/CAM016121_d.JPG,1,3150,notabilis x lativitta,3150_CAM016121_d.JPG,major
+CAM041911,https://zenodo.org/record/4291095/files/CAM041911_d.JPG,0,40608,lativitta,40608_CAM041911_d.JPG,major
+19N0897,https://zenodo.org/record/4288311/files/19N0897_d.JPG,0,20090,malleti,20090_19N0897_d.JPG,mimic
+CAM017602,https://zenodo.org/record/3082688/files/CAM017602_d.JPG,1,5366,notabilis x lativitta,5366_CAM017602_d.JPG,major
+CAM016187,https://zenodo.org/record/3082688/files/CAM016187_d.JPG,1,3282,notabilis x lativitta,3282_CAM016187_d.JPG,major
+CAM041763,https://zenodo.org/record/4291095/files/CAM041763_d.JPG,0,40019,lativitta,40019_CAM041763_d.JPG,major
+CAM016374,https://zenodo.org/record/3082688/files/CAM016374_d.JPG,0,3462,plesseni,3462_CAM016374_d.JPG,mimic
+CAM041774,https://zenodo.org/record/4291095/files/CAM041774_d.JPG,0,40063,lativitta,40063_CAM041774_d.JPG,major
+CAM041823,https://zenodo.org/record/4291095/files/CAM041823_d.JPG,0,40259,lativitta,40259_CAM041823_d.JPG,major
+CAM017442,https://zenodo.org/record/3082688/files/CAM017442_d.JPG,1,5119,notabilis x lativitta,5119_CAM017442_d.JPG,major
+CAM041739,https://zenodo.org/record/4291095/files/CAM041739_d.JPG,0,39923,lativitta,39923_CAM041739_d.JPG,major
+CAM041053,https://zenodo.org/record/2714333/files/CAM041053_d.JPG,0,13745,malleti,13745_CAM041053_d.JPG,mimic
+CAM045161,https://zenodo.org/record/5526257/files/CAM045161_d.JPG,0,43209,cyrbia,43209_CAM045161_d.JPG,minor
+CAM016126,https://zenodo.org/record/3082688/files/CAM016126_d.JPG,1,3160,plesseni x malleti,3160_CAM016126_d.JPG,mimic
+CAM041690,https://zenodo.org/record/4291095/files/CAM041690_d.JPG,0,39727,lativitta,39727_CAM041690_d.JPG,major
+CAM016324,https://zenodo.org/record/3082688/files/CAM016324_d.JPG,0,3422,plesseni,3422_CAM016324_d.JPG,mimic
+CAM041650,https://zenodo.org/record/4291095/files/CAM041650_d.JPG,0,39567,lativitta,39567_CAM041650_d.JPG,major
+CAM017232,https://zenodo.org/record/3082688/files/CAM017232_d.JPG,1,4781,plesseni x malleti,4781_CAM017232_d.JPG,mimic
+CAM017259,https://zenodo.org/record/3082688/files/CAM017259_d.JPG,0,4830,notabilis,4830_CAM017259_d.JPG,major
+CAM045250,https://zenodo.org/record/5526257/files/CAM045250_d.JPG,0,43563,cyrbia,43563_CAM045250_d.JPG,minor
+19N0956,https://zenodo.org/record/4288311/files/19N0956_d.JPG,0,20124,malleti,20124_19N0956_d.JPG,mimic
+CAM016557,https://zenodo.org/record/3082688/files/CAM016557_d.JPG,1,3719,notabilis x lativitta,3719_CAM016557_d.JPG,major
+CAM017156,https://zenodo.org/record/3082688/files/CAM017156_d.JPG,0,4637,malleti,4637_CAM017156_d.JPG,mimic
+CAM016236,https://zenodo.org/record/4153502/files/CAM016236_D.JPG,1,19090,notabilis x lativitta,19090_CAM016236_D.JPG,major
+CAM041060,https://zenodo.org/record/2714333/files/CAM041060_d.JPG,0,13759,malleti,13759_CAM041060_d.JPG,mimic
+CAM041871,https://zenodo.org/record/4291095/files/CAM041871_d.JPG,0,40448,lativitta,40448_CAM041871_d.JPG,major
+CAM041872,https://zenodo.org/record/4291095/files/CAM041872_d.JPG,0,40452,lativitta,40452_CAM041872_d.JPG,major
+CAM041620,https://zenodo.org/record/4291095/files/CAM041620_d.JPG,0,39447,lativitta,39447_CAM041620_d.JPG,major
+CAM041863,https://zenodo.org/record/4291095/files/CAM041863_d.JPG,0,40416,lativitta,40416_CAM041863_d.JPG,major
+CAM016087,https://zenodo.org/record/3082688/files/CAM016087_d.JPG,1,3082,plesseni x malleti,3082_CAM016087_d.JPG,mimic
+CAM016322,https://zenodo.org/record/4153502/files/CAM016322_d.JPG,0,18870,notabilis,18870_CAM016322_d.JPG,major
+CAM016378,https://zenodo.org/record/3082688/files/CAM016378_d.JPG,0,3470,plesseni,3470_CAM016378_d.JPG,mimic
+CAM017239,https://zenodo.org/record/3082688/files/CAM017239_d.JPG,0,4795,notabilis,4795_CAM017239_d.JPG,major
+CAM016978,https://zenodo.org/record/3082688/files/CAM016978_d.JPG,1,4326,notabilis x lativitta,4326_CAM016978_d.JPG,major
+CAM041772,https://zenodo.org/record/4291095/files/CAM041772_d.JPG,0,40055,lativitta,40055_CAM041772_d.JPG,major
+CAM017057,https://zenodo.org/record/3082688/files/CAM017057_d.JPG,1,4463,notabilis x lativitta,4463_CAM017057_d.JPG,major
+CAM041891,https://zenodo.org/record/4291095/files/CAM041891_d.JPG,0,40528,lativitta,40528_CAM041891_d.JPG,major
+CAM016507,https://zenodo.org/record/3082688/files/CAM016507_d.JPG,1,3647,notabilis x lativitta,3647_CAM016507_d.JPG,major
+CAM045211,https://zenodo.org/record/5526257/files/CAM045211_d.JPG,0,43407,cyrbia,43407_CAM045211_d.JPG,minor
+CAM017222,https://zenodo.org/record/3082688/files/CAM017222_d.JPG,1,4761,notabilis x lativitta,4761_CAM017222_d.JPG,major
+CAM045200,https://zenodo.org/record/5526257/files/CAM045200_d.JPG,0,43365,cyrbia,43365_CAM045200_d.JPG,minor
+CAM009546,https://zenodo.org/record/2686762/files/CAM009546_d.JPG,1,10834,hydara x petiverana,10834_CAM009546_d.JPG,minor
+CAM045137,https://zenodo.org/record/5526257/files/CAM045137_d.JPG,0,43115,cyrbia,43115_CAM045137_d.JPG,minor
+CAM041479,https://zenodo.org/record/4291095/files/CAM041479_d.JPG,0,38888,lativitta,38888_CAM041479_d.JPG,major
+CAM041599,https://zenodo.org/record/4291095/files/CAM041599_d.JPG,0,39363,lativitta,39363_CAM041599_d.JPG,major
+CAM017412,https://zenodo.org/record/3082688/files/CAM017412_d.JPG,0,5061,malleti,5061_CAM017412_d.JPG,mimic
+CAM041809,https://zenodo.org/record/4291095/files/CAM041809_d.JPG,0,40203,lativitta,40203_CAM041809_d.JPG,major
+CAM041825,https://zenodo.org/record/4291095/files/CAM041825_d.JPG,0,40267,lativitta,40267_CAM041825_d.JPG,major
+CAM017023,https://zenodo.org/record/3082688/files/CAM017023_d.JPG,1,4401,notabilis x lativitta,4401_CAM017023_d.JPG,major
+CAM041777,https://zenodo.org/record/4291095/files/CAM041777_d.JPG,0,40075,lativitta,40075_CAM041777_d.JPG,major
+19N2141,https://zenodo.org/record/4288311/files/19N2141_d.JPG,0,21667,malleti,21667_19N2141_d.JPG,mimic
+CAM041369,https://zenodo.org/record/4291095/files/CAM041369_d.JPG,0,38456,malleti,38456_CAM041369_d.JPG,mimic
+CAM021029,https://zenodo.org/record/2702457/files/CAM021029_d.JPG,1,11492,hydara x amalfreda,11492_CAM021029_d.JPG,minor
+CAM041894,https://zenodo.org/record/4291095/files/CAM041894_d.JPG,0,40540,lativitta,40540_CAM041894_d.JPG,major
+CAM040298,https://zenodo.org/record/2707828/files/CAM040298_d.JPG,0,12212,malleti,12212_CAM040298_d.JPG,mimic
+CAM016247,https://zenodo.org/record/3082688/files/CAM016247_d.JPG,0,3356,plesseni,3356_CAM016247_d.JPG,mimic
+CAM016118,https://zenodo.org/record/3082688/files/CAM016118_d.JPG,1,3144,plesseni x malleti,3144_CAM016118_d.JPG,mimic
+CAM040180,https://zenodo.org/record/2707828/files/CAM040180_d.JPG,0,11990,malleti,11990_CAM040180_d.JPG,mimic
+CAM016092,https://zenodo.org/record/3082688/files/CAM016092_d.JPG,1,3092,plesseni x malleti,3092_CAM016092_d.JPG,mimic
+19N2230,https://zenodo.org/record/4288311/files/19N2230_d.JPG,0,21847,malleti,21847_19N2230_d.JPG,mimic
+CAM041767,https://zenodo.org/record/4291095/files/CAM041767_d.JPG,0,40035,lativitta,40035_CAM041767_d.JPG,major
+CAM017214,https://zenodo.org/record/3082688/files/CAM017214_d.JPG,0,4745,notabilis,4745_CAM017214_d.JPG,major
+CAM009003,https://zenodo.org/record/2686762/files/CAM009003_d.JPG,0,10111,hydara,10111_CAM009003_d.JPG,minor
+CAM041813,https://zenodo.org/record/4291095/files/CAM041813_d.JPG,0,40219,lativitta,40219_CAM041813_d.JPG,major
+CS003709,https://zenodo.org/record/2553501/files/CS3709 dorsal.jpeg,0,25965,malleti,25965_CS3709 dorsal.jpeg,mimic
+CAM045146,https://zenodo.org/record/5526257/files/CAM045146_d.JPG,0,43151,cyrbia,43151_CAM045146_d.JPG,minor
+CAM017384,https://zenodo.org/record/3082688/files/CAM017384_d.JPG,1,5018,plesseni x malleti,5018_CAM017384_d.JPG,mimic
+19N0246,https://zenodo.org/record/4288311/files/19N0246_d.JPG,0,19637,malleti,19637_19N0246_d.JPG,mimic
+CAM017333,https://zenodo.org/record/3082688/files/CAM017333_d.JPG,1,4944,notabilis x lativitta,4944_CAM017333_d.JPG,major
+19N1236,https://zenodo.org/record/4288311/files/19N1236_d.JPG,0,20245,malleti,20245_19N1236_d.JPG,mimic
+19N0034,https://zenodo.org/record/4288311/files/19N0034_d.JPG,0,19208,malleti,19208_19N0034_d.JPG,mimic
+CAM017055,https://zenodo.org/record/3082688/files/CAM017055_d.JPG,1,4459,notabilis x lativitta,4459_CAM017055_d.JPG,major
+CAM045248,https://zenodo.org/record/5526257/files/CAM045248_d.JPG,0,43555,cyrbia,43555_CAM045248_d.JPG,minor
+CAM016040,https://zenodo.org/record/3082688/files/CAM016040_d.JPG,1,2989,notabilis x lativitta,2989_CAM016040_d.JPG,major
+CAM017350,https://zenodo.org/record/3082688/files/CAM017350_d.JPG,1,4978,notabilis x lativitta,4978_CAM017350_d.JPG,major
+CAM017226,https://zenodo.org/record/3082688/files/CAM017226_d.JPG,1,4769,notabilis x lativitta,4769_CAM017226_d.JPG,major
+CS003542,https://zenodo.org/record/2553501/files/CS3542 dorsal.jpeg,0,25937,malleti,25937_CS3542 dorsal.jpeg,mimic
+19N1238,https://zenodo.org/record/4288311/files/19N1238_d.JPG,0,20249,erato,20249_19N1238_d.JPG,minor
+CAM016582,https://zenodo.org/record/3082688/files/CAM016582_d.JPG,1,3755,notabilis x lativitta,3755_CAM016582_d.JPG,major
+CAM009524,https://zenodo.org/record/2686762/files/CAM009524_d.JPG,0,10790,petiverana,10790_CAM009524_d.JPG,minor
+CAM017153,https://zenodo.org/record/3082688/files/CAM017153_d.JPG,1,4631,plesseni x malleti,4631_CAM017153_d.JPG,mimic
+CAM018309,https://zenodo.org/record/2702457/files/CAM018309_d.JPG,1,11052,plesseni x malleti,11052_CAM018309_d.JPG,mimic
+CAM016156,https://zenodo.org/record/3082688/files/CAM016156_d.JPG,1,3220,notabilis x lativitta,3220_CAM016156_d.JPG,major
+CAM017247,https://zenodo.org/record/3082688/files/CAM017247_d.JPG,0,4811,notabilis,4811_CAM017247_d.JPG,major
+CAM016846,https://zenodo.org/record/3082688/files/CAM016846_d.JPG,1,4111,plesseni x malleti,4111_CAM016846_d.JPG,mimic
+19N0867,https://zenodo.org/record/4288311/files/19N0867_d.JPG,0,20074,malleti,20074_19N0867_d.JPG,mimic
+CAM017328,https://zenodo.org/record/3082688/files/CAM017328_d.JPG,1,4934,notabilis x lativitta,4934_CAM017328_d.JPG,major
+19N1983,https://zenodo.org/record/4288311/files/19N1983_d.JPG,0,21347,malleti,21347_19N1983_d.JPG,mimic
+CAM041637,https://zenodo.org/record/4291095/files/CAM041637_d.JPG,0,39515,lativitta,39515_CAM041637_d.JPG,major
+CAM016689,https://zenodo.org/record/4153502/files/CAM016689_d.JPG,0,18922,plesseni,18922_CAM016689_d.JPG,mimic
+19N1381,https://zenodo.org/record/4288311/files/19N1381_d.JPG,0,20317,malleti,20317_19N1381_d.JPG,mimic
+CAM009156,https://zenodo.org/record/2686762/files/CAM009156_d.JPG,0,10281,plesseni,10281_CAM009156_d.JPG,mimic
+CAM009424,https://zenodo.org/record/2686762/files/CAM009424_d.JPG,0,10646,plesseni,10646_CAM009424_d.JPG,mimic
+19N0205,https://zenodo.org/record/4288311/files/19N0205_d.JPG,0,19555,malleti,19555_19N0205_d.JPG,mimic
+CAM017313,https://zenodo.org/record/4153502/files/CAM017313_d.JPG,1,19006,plesseni x malleti,19006_CAM017313_d.JPG,mimic
+CAM009126,https://zenodo.org/record/2686762/files/CAM009126_d.JPG,0,10221,etylus,10221_CAM009126_d.JPG,minor
+CAM041730,https://zenodo.org/record/4291095/files/CAM041730_d.JPG,0,39887,lativitta,39887_CAM041730_d.JPG,major
+19N2166,https://zenodo.org/record/4288311/files/19N2166_d.JPG,0,21699,malleti,21699_19N2166_d.JPG,mimic
+CAM045190,https://zenodo.org/record/5526257/files/CAM045190_d.JPG,0,43325,cyrbia,43325_CAM045190_d.JPG,minor
+CAM041643,https://zenodo.org/record/4291095/files/CAM041643_d.JPG,0,39539,lativitta,39539_CAM041643_d.JPG,major
+CAM017001,https://zenodo.org/record/3082688/files/CAM017001_d.JPG,1,4361,notabilis x lativitta,4361_CAM017001_d.JPG,major
+CAM041678,https://zenodo.org/record/4291095/files/CAM041678_d.JPG,0,39679,lativitta,39679_CAM041678_d.JPG,major
+CAM041811,https://zenodo.org/record/4291095/files/CAM041811_d.JPG,0,40211,lativitta,40211_CAM041811_d.JPG,major
+19N0187,https://zenodo.org/record/4288311/files/19N0187_d.JPG,0,19519,malleti,19519_19N0187_d.JPG,mimic
+CAM041833,https://zenodo.org/record/4291095/files/CAM041833_d.JPG,0,40299,lativitta,40299_CAM041833_d.JPG,major
+CAM016027,https://zenodo.org/record/3082688/files/CAM016027_d.JPG,1,2963,notabilis x lativitta,2963_CAM016027_d.JPG,major
+CAM017455,https://zenodo.org/record/1748277/files/CAM017455_d_whitestandard.JPG,0,15283,malleti,15283_CAM017455_d_whitestandard.JPG,mimic
+CAM017129,https://zenodo.org/record/3082688/files/CAM017129_d.JPG,1,4587,notabilis x lativitta,4587_CAM017129_d.JPG,major
+CAM041660,https://zenodo.org/record/4291095/files/CAM041660_d.JPG,0,39607,lativitta,39607_CAM041660_d.JPG,major
+CAM010089,https://zenodo.org/record/2549524/files/CAM010089_d.JPG,0,26347,malleti,26347_CAM010089_d.JPG,mimic
+CAM008866,https://zenodo.org/record/2686762/files/CAM008866_d.JPG,0,9953,hydara,9953_CAM008866_d.JPG,minor
+CAM041275,https://zenodo.org/record/2714333/files/CAM041275_d.JPG,0,14186,malleti,14186_CAM041275_d.JPG,mimic
+CAM017002,https://zenodo.org/record/3082688/files/CAM017002_d.JPG,1,4363,notabilis x lativitta,4363_CAM017002_d.JPG,major
+CAM016055,https://zenodo.org/record/3082688/files/CAM016055_d.JPG,1,3019,plesseni x malleti,3019_CAM016055_d.JPG,mimic
+CAM017426,https://zenodo.org/record/3082688/files/CAM017426_d.JPG,1,5089,notabilis x lativitta,5089_CAM017426_d.JPG,major
+CAM041458,https://zenodo.org/record/4291095/files/CAM041458_d.JPG,0,38804,malleti,38804_CAM041458_d.JPG,mimic
+CAM016517,https://zenodo.org/record/3082688/files/CAM016517_d.JPG,1,3667,notabilis x lativitta,3667_CAM016517_d.JPG,major
+CAM009544,https://zenodo.org/record/2686762/files/CAM009544_d.JPG,1,10830,hydara x petiverana,10830_CAM009544_d.JPG,minor
+CAM017148,https://zenodo.org/record/3082688/files/CAM017148_d.JPG,1,4621,notabilis x lativitta,4621_CAM017148_d.JPG,major
+CAM041147,https://zenodo.org/record/2714333/files/CAM041147_d.JPG,0,13931,malleti,13931_CAM041147_d.JPG,mimic
+CAM009417,https://zenodo.org/record/2686762/files/CAM009417_d.JPG,0,10632,plesseni,10632_CAM009417_d.JPG,mimic
+CAM017252,https://zenodo.org/record/3082688/files/CAM017252_d.JPG,0,4821,notabilis,4821_CAM017252_d.JPG,major
+CAM009237,https://zenodo.org/record/2686762/files/CAM009237_d.JPG,0,10442,plesseni,10442_CAM009237_d.JPG,mimic
+19N1861,https://zenodo.org/record/4288311/files/19N1861_d.JPG,0,21123,malleti,21123_19N1861_d.JPG,mimic
+CAM017618,https://zenodo.org/record/4153502/files/CAM017618_d.JPG,0,19062,plesseni,19062_CAM017618_d.JPG,mimic
+CAM041588,https://zenodo.org/record/4291095/files/CAM041588_d.JPG,0,39319,malleti,39319_CAM041588_d.JPG,mimic
+CAM017032,https://zenodo.org/record/3082688/files/CAM017032_d.JPG,1,4419,notabilis x lativitta,4419_CAM017032_d.JPG,major
+CAM040297,https://zenodo.org/record/2707828/files/CAM040297_d.JPG,0,12210,malleti,12210_CAM040297_d.JPG,mimic
+CAM036168,https://zenodo.org/record/5561246/files/CAM036168_d.JPG,0,41443,phyllis,41443_CAM036168_d.JPG,minor
+CAM041439,https://zenodo.org/record/4291095/files/CAM041439_d.JPG,0,38728,lativitta,38728_CAM041439_d.JPG,major
+CAM017311,https://zenodo.org/record/3082688/files/CAM017311_d.JPG,1,4908,notabilis x lativitta,4908_CAM017311_d.JPG,major
+19N1769,https://zenodo.org/record/4288311/files/19N1769_d.JPG,0,20991,malleti,20991_19N1769_d.JPG,mimic
+CAM045166,https://zenodo.org/record/5526257/files/CAM045166_d.JPG,0,43229,cyrbia,43229_CAM045166_d.JPG,minor
+19N0691,https://zenodo.org/record/4288311/files/19N0691_d.JPG,0,19984,malleti,19984_19N0691_d.JPG,mimic
+CAM000230,https://zenodo.org/record/2677821/files/CAM000230_d.JPG,0,6286,chestertonii,6286_CAM000230_d.JPG,minor
+CAM041497,https://zenodo.org/record/4291095/files/CAM041497_d.JPG,0,38960,malleti,38960_CAM041497_d.JPG,mimic
+CAM009230,https://zenodo.org/record/2686762/files/CAM009230_d.JPG,0,10428,plesseni,10428_CAM009230_d.JPG,mimic
+CAM041712,https://zenodo.org/record/4291095/files/CAM041712_d.JPG,0,39815,lativitta,39815_CAM041712_d.JPG,major
+19N2237,https://zenodo.org/record/4288311/files/19N2237_d.JPG,0,21875,malleti,21875_19N2237_d.JPG,mimic
+CAM009158,https://zenodo.org/record/2686762/files/CAM009158_d.JPG,0,10285,plesseni,10285_CAM009158_d.JPG,mimic
+CAM017159,https://zenodo.org/record/3082688/files/CAM017159_d.JPG,1,4643,notabilis x lativitta,4643_CAM017159_d.JPG,major
+19N2127,https://zenodo.org/record/4288311/files/19N2127_d.JPG,0,21647,malleti,21647_19N2127_d.JPG,mimic
+CAM016509,https://zenodo.org/record/3082688/files/CAM016509_d.JPG,1,3651,plesseni x malleti,3651_CAM016509_d.JPG,mimic
+CAM016084,https://zenodo.org/record/3082688/files/CAM016084_d.JPG,1,3076,plesseni x malleti,3076_CAM016084_d.JPG,mimic
+CAM016065,https://zenodo.org/record/3082688/files/CAM016065_d.JPG,1,3038,plesseni x malleti,3038_CAM016065_d.JPG,mimic
+CAM045195,https://zenodo.org/record/5526257/files/CAM045195_d.JPG,0,43345,cyrbia,43345_CAM045195_d.JPG,minor
+CAM016566,https://zenodo.org/record/3082688/files/CAM016566_d.JPG,1,3737,notabilis x lativitta,3737_CAM016566_d.JPG,major
+19N0123,https://zenodo.org/record/4288311/files/19N0123_d.JPG,0,19391,malleti,19391_19N0123_d.JPG,mimic
+CAM017125,https://zenodo.org/record/3082688/files/CAM017125_d.JPG,1,4579,plesseni x malleti,4579_CAM017125_d.JPG,mimic
+19N0169,https://zenodo.org/record/4288311/files/19N0169_d.JPG,0,19483,malleti,19483_19N0169_d.JPG,mimic
+CAM045021,https://zenodo.org/record/5526257/files/CAM045021_d.JPG,0,42649,cyrbia,42649_CAM045021_d.JPG,minor
+CAM041743,https://zenodo.org/record/4291095/files/CAM041743_d.JPG,0,39939,lativitta,39939_CAM041743_d.JPG,major
+CAM017092,https://zenodo.org/record/3082688/files/CAM017092_d.JPG,0,4525,malleti,4525_CAM017092_d.JPG,mimic
+15N111,https://zenodo.org/record/4289223/files/15N111_d.JPG,0,15169,venus,15169_15N111_d.JPG,minor
+CAM041517,https://zenodo.org/record/4291095/files/CAM041517_d.JPG,0,39040,malleti,39040_CAM041517_d.JPG,mimic
+19N0863,https://zenodo.org/record/4288311/files/19N0863_d.JPG,0,20066,malleti,20066_19N0863_d.JPG,mimic
+CAM017605,https://zenodo.org/record/3082688/files/CAM017605_d.JPG,1,5372,plesseni x malleti,5372_CAM017605_d.JPG,mimic
+CAM045020,https://zenodo.org/record/5526257/files/CAM045020_d.JPG,0,42645,cyrbia,42645_CAM045020_d.JPG,minor
+CAM016821,https://zenodo.org/record/3082688/files/CAM016821_d.JPG,1,4064,plesseni x malleti,4064_CAM016821_d.JPG,mimic
+CAM016190,https://zenodo.org/record/3082688/files/CAM016190_d.JPG,0,3288,malleti,3288_CAM016190_d.JPG,mimic
+CAM009234,https://zenodo.org/record/2686762/files/CAM009234_d.JPG,0,10436,plesseni,10436_CAM009234_d.JPG,mimic
+CAM016167,https://zenodo.org/record/3082688/files/CAM016167_d.JPG,1,3242,notabilis x lativitta,3242_CAM016167_d.JPG,major
+CAM009307,https://zenodo.org/record/2686762/files/CAM009307_d.JPG,0,10466,hydara,10466_CAM009307_d.JPG,minor
+CAM017174,https://zenodo.org/record/3082688/files/CAM017174_d.JPG,0,4669,notabilis,4669_CAM017174_d.JPG,major
+CAM045231,https://zenodo.org/record/5526257/files/CAM045231_d.JPG,0,43487,cyrbia,43487_CAM045231_d.JPG,minor
+CAM041862,https://zenodo.org/record/4291095/files/CAM041862_d.JPG,0,40412,lativitta,40412_CAM041862_d.JPG,major
+CAM041204,https://zenodo.org/record/2714333/files/CAM041204_d.JPG,0,14045,malleti,14045_CAM041204_d.JPG,mimic
+CAM041806,https://zenodo.org/record/4291095/files/CAM041806_d.JPG,0,40191,lativitta,40191_CAM041806_d.JPG,major
+CAM041371,https://zenodo.org/record/4291095/files/CAM041371_d.JPG,0,38464,malleti,38464_CAM041371_d.JPG,mimic
+CAM045209,https://zenodo.org/record/5526257/files/CAM045209_d.JPG,0,43399,cyrbia,43399_CAM045209_d.JPG,minor
+CAM120557,https://zenodo.org/record/2813153/files/CAM120557_d.JPG,0,14891,malleti,14891_CAM120557_d.JPG,mimic
+CAM016181,https://zenodo.org/record/3082688/files/CAM016181_d.JPG,1,3270,notabilis x lativitta,3270_CAM016181_d.JPG,major
+CS001321,https://zenodo.org/record/2553501/files/CS1321 dorsal.jpeg,0,25627,malleti,25627_CS1321 dorsal.jpeg,mimic
+CAM045148,https://zenodo.org/record/5526257/files/CAM045148_d.JPG,0,43159,cyrbia,43159_CAM045148_d.JPG,minor
+CAM000170,https://zenodo.org/record/2677821/files/CAM000170_d.JPG,0,6172,chestertonii,6172_CAM000170_d.JPG,minor
+CAM017180,https://zenodo.org/record/3082688/files/CAM017180_d.JPG,0,4680,notabilis,4680_CAM017180_d.JPG,major
+CAM010077,https://zenodo.org/record/2549524/files/CAM010077_d.JPG,0,26327,malleti,26327_CAM010077_d.JPG,mimic
+CAM017621,https://zenodo.org/record/4153502/files/CAM017621_d.JPG,0,19068,plesseni,19068_CAM017621_d.JPG,mimic
+CAM045270,https://zenodo.org/record/5526257/files/CAM045270_d.JPG,0,43643,cyrbia,43643_CAM045270_d.JPG,minor
+CAM017158,https://zenodo.org/record/3082688/files/CAM017158_d.JPG,1,4641,notabilis x lativitta,4641_CAM017158_d.JPG,major
+CAM017257,https://zenodo.org/record/3082688/files/CAM017257_d.JPG,1,4828,plesseni x malleti,4828_CAM017257_d.JPG,mimic
+19N1761,https://zenodo.org/record/4288311/files/19N1761_d.JPG,0,20971,malleti,20971_19N1761_d.JPG,mimic
+CAM017612,https://zenodo.org/record/3082688/files/CAM017612_d.JPG,1,5386,plesseni x malleti,5386_CAM017612_d.JPG,mimic
+19N2224,https://zenodo.org/record/4288311/files/19N2224_d.JPG,0,21823,malleti,21823_19N2224_d.JPG,mimic
+19N1888,https://zenodo.org/record/4288311/files/19N1888_d.JPG,0,21171,malleti,21171_19N1888_d.JPG,mimic
+CAM009526,https://zenodo.org/record/2686762/files/CAM009526_d.JPG,1,10794,hydara x petiverana,10794_CAM009526_d.JPG,minor
+CAM041605,https://zenodo.org/record/4291095/files/CAM041605_d.JPG,0,39387,lativitta,39387_CAM041605_d.JPG,major
+CAM016649,https://zenodo.org/record/3082688/files/CAM016649_d.JPG,1,3833,notabilis x lativitta,3833_CAM016649_d.JPG,major
+CAM045229,https://zenodo.org/record/5526257/files/CAM045229_d.JPG,0,43479,cyrbia,43479_CAM045229_d.JPG,minor
+CAM016228,https://zenodo.org/record/3082688/files/CAM016228_d.JPG,1,3340,plesseni x malleti,3340_CAM016228_d.JPG,mimic
+CAM016033,https://zenodo.org/record/3082688/files/CAM016033_d.JPG,1,2975,notabilis x lativitta,2975_CAM016033_d.JPG,major
+CS002274,https://zenodo.org/record/2735056/files/CS002274_d.JPG,0,40851,venus,40851_CS002274_d.JPG,minor
+CAM041601,https://zenodo.org/record/4291095/files/CAM041601_d.JPG,0,39371,lativitta,39371_CAM041601_d.JPG,major
+CAM018315,https://zenodo.org/record/2702457/files/CAM018315_d.JPG,1,11060,plesseni x malleti,11060_CAM018315_d.JPG,mimic
+CAM040295,https://zenodo.org/record/2707828/files/CAM040295_d.JPG,0,12206,malleti,12206_CAM040295_d.JPG,mimic
+CAM017188,https://zenodo.org/record/3082688/files/CAM017188_d.JPG,0,4696,notabilis,4696_CAM017188_d.JPG,major
+CAM036232,https://zenodo.org/record/5561246/files/CAM036232_d.JPG,0,41639,phyllis,41639_CAM036232_d.JPG,minor
+CAM017325,https://zenodo.org/record/4153502/files/CAM017325_d.JPG,0,19008,plesseni,19008_CAM017325_d.JPG,mimic
+19N2158,https://zenodo.org/record/4288311/files/19N2158_d.JPG,0,21687,malleti,21687_19N2158_d.JPG,mimic
+CAM017240,https://zenodo.org/record/3082688/files/CAM017240_d.JPG,0,4797,notabilis,4797_CAM017240_d.JPG,major
+CAM040266,https://zenodo.org/record/2707828/files/CAM040266_d.JPG,0,12148,malleti,12148_CAM040266_d.JPG,mimic
+CAM018529,https://zenodo.org/record/2702457/files/CAM018529_d.JPG,1,11389,malleti x plesseni,11389_CAM018529_d.JPG,mimic
+CAM045154,https://zenodo.org/record/5526257/files/CAM045154_d.JPG,0,43183,cyrbia,43183_CAM045154_d.JPG,minor
+CAM041855,https://zenodo.org/record/4291095/files/CAM041855_d.JPG,0,40384,lativitta,40384_CAM041855_d.JPG,major
+F868,https://zenodo.org/record/2555086/files/F868_d.JPG,0,38120,demophoon,38120_F868_d.JPG,minor
+CAM009189,https://zenodo.org/record/2686762/files/CAM009189_d.JPG,0,10347,plesseni,10347_CAM009189_d.JPG,mimic
+19N2249,https://zenodo.org/record/4288311/files/19N2249_d.JPG,0,21923,malleti,21923_19N2249_d.JPG,mimic
+CAM041817,https://zenodo.org/record/4291095/files/CAM041817_d.JPG,0,40235,lativitta,40235_CAM041817_d.JPG,major
+CAM045007,https://zenodo.org/record/5526257/files/CAM045007_d.JPG,0,42591,cyrbia,42591_CAM045007_d.JPG,minor
+CAM011428,https://zenodo.org/record/2550097/files/CAM011428_d.JPG,0,28212,malleti,28212_CAM011428_d.JPG,mimic
+CAM040731,https://zenodo.org/record/2714333/files/CAM040731_d.JPG,0,13093,malleti,13093_CAM040731_d.JPG,mimic
+CAM041711,https://zenodo.org/record/4291095/files/CAM041711_d.JPG,0,39811,lativitta,39811_CAM041711_d.JPG,major
+CAM017274,https://zenodo.org/record/3082688/files/CAM017274_d.JPG,1,4860,notabilis x lativitta,4860_CAM017274_d.JPG,major
+CAM017114,https://zenodo.org/record/3082688/files/CAM017114_d.JPG,1,4557,notabilis x lativitta,4557_CAM017114_d.JPG,major
+CAM017109,https://zenodo.org/record/3082688/files/CAM017109_d.JPG,1,4547,notabilis x lativitta,4547_CAM017109_d.JPG,major
+CAM016423,https://zenodo.org/record/3082688/files/CAM016423_d.JPG,1,3557,notabilis x lativitta,3557_CAM016423_d.JPG,major
+CAM016683,https://zenodo.org/record/4153502/files/CAM016683_d.JPG,0,18910,plesseni,18910_CAM016683_d.JPG,mimic
+CAM000233,https://zenodo.org/record/2677821/files/CAM000233_d.JPG,0,6292,chestertonii,6292_CAM000233_d.JPG,minor
+CAM045160,https://zenodo.org/record/5526257/files/CAM045160_d.JPG,0,43205,cyrbia,43205_CAM045160_d.JPG,minor
+CAM018295,https://zenodo.org/record/2702457/files/CAM018295_d.JPG,1,11032,plesseni x malleti,11032_CAM018295_d.JPG,mimic
+CAM017331,https://zenodo.org/record/3082688/files/CAM017331_d.JPG,1,4940,notabilis x lativitta,4940_CAM017331_d.JPG,major
+CAM016316,https://zenodo.org/record/4153502/files/CAM016316_D.JPG,1,19118,notabilis x lativitta,19118_CAM016316_D.JPG,major
+CAM045032,https://zenodo.org/record/5526257/files/CAM045032_d.JPG,0,42693,cyrbia,42693_CAM045032_d.JPG,minor
+CAM017041,https://zenodo.org/record/3082688/files/CAM017041_d.JPG,0,4435,malleti,4435_CAM017041_d.JPG,mimic
+CAM017608,https://zenodo.org/record/3082688/files/CAM017608_d.JPG,1,5378,notabilis x lativitta,5378_CAM017608_d.JPG,major
+CAM041360,https://zenodo.org/record/4291095/files/CAM041360_d.JPG,0,38420,lativitta,38420_CAM041360_d.JPG,major
+CAM041719,https://zenodo.org/record/4291095/files/CAM041719_d.JPG,0,39843,lativitta,39843_CAM041719_d.JPG,major
+19N2273,https://zenodo.org/record/4288311/files/19N2273_d.JPG,0,22019,malleti,22019_19N2273_d.JPG,mimic
+CAM045201,https://zenodo.org/record/5526257/files/CAM045201_d.JPG,0,43367,cyrbia,43367_CAM045201_d.JPG,minor
+CAM017091,https://zenodo.org/record/3082688/files/CAM017091_d.JPG,0,4523,malleti,4523_CAM017091_d.JPG,mimic
+CAM041367,https://zenodo.org/record/4291095/files/CAM041367_d.JPG,0,38448,malleti,38448_CAM041367_d.JPG,mimic
+CAM016545,https://zenodo.org/record/3082688/files/CAM016545_d.JPG,0,3699,malleti,3699_CAM016545_d.JPG,mimic
+CAM040198,https://zenodo.org/record/2707828/files/CAM040198_d.JPG,0,12022,malleti,12022_CAM040198_d.JPG,mimic
+CAM036172,https://zenodo.org/record/5561246/files/CAM036172_d.JPG,0,41459,phyllis,41459_CAM036172_d.JPG,minor
+CAM017365,https://zenodo.org/record/4153502/files/CAM017365_d.JPG,0,19026,plesseni,19026_CAM017365_d.JPG,mimic
+CAM017316,https://zenodo.org/record/3082688/files/CAM017316_d.JPG,1,4916,notabilis x lativitta,4916_CAM017316_d.JPG,major
+CAM045054,https://zenodo.org/record/5526257/files/CAM045054_d.JPG,0,42781,cyrbia,42781_CAM045054_d.JPG,minor
+CAM045244,https://zenodo.org/record/5526257/files/CAM045244_d.JPG,0,43539,cyrbia,43539_CAM045244_d.JPG,minor
+CAM000236,https://zenodo.org/record/2677821/files/CAM000236_d.JPG,0,6298,chestertonii,6298_CAM000236_d.JPG,minor
+CAM017319,https://zenodo.org/record/3082688/files/CAM017319_d.JPG,1,4922,notabilis x lativitta,4922_CAM017319_d.JPG,major
+CAM045033,https://zenodo.org/record/5526257/files/CAM045033_d.JPG,0,42697,cyrbia,42697_CAM045033_d.JPG,minor
+CAM017308,https://zenodo.org/record/3082688/files/CAM017308_d.JPG,1,4902,notabilis x lativitta,4902_CAM017308_d.JPG,major
+CAM041850,https://zenodo.org/record/4291095/files/CAM041850_d.JPG,0,40367,lativitta,40367_CAM041850_d.JPG,major
+CAM045011,https://zenodo.org/record/5526257/files/CAM045011_d.JPG,0,42609,cyrbia,42609_CAM045011_d.JPG,minor
+CAM045243,https://zenodo.org/record/5526257/files/CAM045243_d.JPG,0,43535,cyrbia,43535_CAM045243_d.JPG,minor
+CAM016020,https://zenodo.org/record/3082688/files/CAM016020_d.JPG,1,2949,notabilis x lativitta,2949_CAM016020_d.JPG,major
+F824,https://zenodo.org/record/2555086/files/F824_d.JPG,0,38052,demophoon,38052_F824_d.JPG,minor
+CAM016655,https://zenodo.org/record/3082688/files/CAM016655_d.JPG,1,3845,plesseni x malleti,3845_CAM016655_d.JPG,mimic
+CAM016171,https://zenodo.org/record/3082688/files/CAM016171_d.JPG,1,3250,notabilis x lativitta,3250_CAM016171_d.JPG,major
+CAM016022,https://zenodo.org/record/3082688/files/CAM016022_d.JPG,1,2953,notabilis x lativitta,2953_CAM016022_d.JPG,major
+CAM041702,https://zenodo.org/record/4291095/files/CAM041702_d.JPG,0,39775,lativitta,39775_CAM041702_d.JPG,major
+CAM016645,https://zenodo.org/record/3082688/files/CAM016645_d.JPG,1,3825,notabilis x lativitta,3825_CAM016645_d.JPG,major
+CAM016309,https://zenodo.org/record/3082688/files/CAM016309_d.JPG,1,3414,plesseni x malleti,3414_CAM016309_d.JPG,mimic
+CAM018482,https://zenodo.org/record/2702457/files/CAM018482_d.JPG,1,11305,plesseni x malleti,11305_CAM018482_d.JPG,mimic
+CAM041781,https://zenodo.org/record/4291095/files/CAM041781_d.JPG,0,40091,lativitta,40091_CAM041781_d.JPG,major
+CAM017748,https://zenodo.org/record/3082688/files/CAM017748_d.JPG,1,5506,lativitta x notabilis,5506_CAM017748_d.JPG,major
+CAM041787,https://zenodo.org/record/4291095/files/CAM041787_d.JPG,0,40115,lativitta,40115_CAM041787_d.JPG,major
+15N146,https://zenodo.org/record/4289223/files/15N146_d.JPG,0,14959,venus,14959_15N146_d.JPG,minor
+CAM021028,https://zenodo.org/record/2702457/files/CAM021028_d.JPG,1,11490,hydara x amalfreda,11490_CAM021028_d.JPG,minor
+CAM041890,https://zenodo.org/record/4291095/files/CAM041890_d.JPG,0,40524,lativitta,40524_CAM041890_d.JPG,major
+CAM041904,https://zenodo.org/record/4291095/files/CAM041904_d.JPG,0,40580,lativitta,40580_CAM041904_d.JPG,major
+CAM041639,https://zenodo.org/record/4291095/files/CAM041639_d.JPG,0,39523,lativitta,39523_CAM041639_d.JPG,major
+CAM016096,https://zenodo.org/record/3082688/files/CAM016096_d.JPG,1,3100,notabilis x lativitta,3100_CAM016096_d.JPG,major
+CAM017603,https://zenodo.org/record/3082688/files/CAM017603_d.JPG,1,5368,notabilis x lativitta,5368_CAM017603_d.JPG,major
+CAM016183,https://zenodo.org/record/3082688/files/CAM016183_d.JPG,1,3274,notabilis x lativitta,3274_CAM016183_d.JPG,major
+CAM045008,https://zenodo.org/record/5526257/files/CAM045008_d.JPG,0,42595,cyrbia,42595_CAM045008_d.JPG,minor
+19N1393,https://zenodo.org/record/4288311/files/19N1393_d.JPG,0,20331,malleti,20331_19N1393_d.JPG,mimic
+CAM016282,https://zenodo.org/record/3082688/files/CAM016282_d.JPG,0,3396,plesseni,3396_CAM016282_d.JPG,mimic
+CAM008539,https://zenodo.org/record/2684906/files/CAM008539_d.JPG,0,9432,plesseni,9432_CAM008539_d.JPG,mimic
+CAM016785,https://zenodo.org/record/3082688/files/CAM016785_d.JPG,1,3992,plesseni x malleti,3992_CAM016785_d.JPG,mimic
+19N2259,https://zenodo.org/record/4288311/files/19N2259_d.JPG,0,21963,malleti,21963_19N2259_d.JPG,mimic
+CAM045001,https://zenodo.org/record/5526257/files/CAM045001_d.JPG,0,42563,cyrbia,42563_CAM045001_d.JPG,minor
+CAM017713,https://zenodo.org/record/3082688/files/CAM017713_d.JPG,1,5466,lativitta x notabilis,5466_CAM017713_d.JPG,major
+CAM040263,https://zenodo.org/record/2707828/files/CAM040263_d.JPG,0,12142,malleti,12142_CAM040263_d.JPG,mimic
+F875,https://zenodo.org/record/2555086/files/F875_d.JPG,0,38136,demophoon,38136_F875_d.JPG,minor
+CAM041357,https://zenodo.org/record/4291095/files/CAM041357_d.JPG,0,38408,lativitta,38408_CAM041357_d.JPG,major
+CAM016849,https://zenodo.org/record/3082688/files/CAM016849_d.JPG,1,4117,plesseni x malleti,4117_CAM016849_d.JPG,mimic
+CAM016130,https://zenodo.org/record/3082688/files/CAM016130_d.JPG,1,3168,plesseni x malleti,3168_CAM016130_d.JPG,mimic
+CAM017104,https://zenodo.org/record/3082688/files/CAM017104_d.JPG,0,4545,malleti,4545_CAM017104_d.JPG,mimic
+CAM016672,https://zenodo.org/record/3082688/files/CAM016672_d.JPG,1,3878,plesseni x malleti,3878_CAM016672_d.JPG,mimic
+CAM041769,https://zenodo.org/record/4291095/files/CAM041769_d.JPG,0,40043,lativitta,40043_CAM041769_d.JPG,major
+CAM016602,https://zenodo.org/record/3082688/files/CAM016602_d.JPG,1,3791,plesseni x malleti,3791_CAM016602_d.JPG,mimic
+19N1864,https://zenodo.org/record/4288311/files/19N1864_d.JPG,0,21131,malleti,21131_19N1864_d.JPG,mimic
+CAM041064,https://zenodo.org/record/2714333/files/CAM041064_d.JPG,0,13767,malleti,13767_CAM041064_d.JPG,mimic
+CAM041212,https://zenodo.org/record/2714333/files/CAM041212_d.JPG,0,14061,malleti,14061_CAM041212_d.JPG,mimic
+19N1646,https://zenodo.org/record/4288311/files/19N1646_d.JPG,0,20835,malleti,20835_19N1646_d.JPG,mimic
+19N2229,https://zenodo.org/record/4288311/files/19N2229_d.JPG,0,21843,malleti,21843_19N2229_d.JPG,mimic
+CAM045024,https://zenodo.org/record/5526257/files/CAM045024_d.JPG,0,42661,cyrbia,42661_CAM045024_d.JPG,minor
+CAM017248,https://zenodo.org/record/3082688/files/CAM017248_d.JPG,0,4813,notabilis,4813_CAM017248_d.JPG,major
+CAM045050,https://zenodo.org/record/5526257/files/CAM045050_d.JPG,0,42765,cyrbia,42765_CAM045050_d.JPG,minor
+CAM009568,https://zenodo.org/record/2686762/files/CAM009568_d.JPG,1,10878,hydara x petiverana,10878_CAM009568_d.JPG,minor
+CAM008226,https://zenodo.org/record/2684906/files/CAM008226_d.JPG,0,8895,malleti,8895_CAM008226_d.JPG,mimic
+CAM017190,https://zenodo.org/record/3082688/files/CAM017190_d.JPG,0,4700,notabilis,4700_CAM017190_d.JPG,major
+CAM040259,https://zenodo.org/record/2707828/files/CAM040259_d.JPG,0,12134,malleti,12134_CAM040259_d.JPG,mimic
+CAM016819,https://zenodo.org/record/3082688/files/CAM016819_d.JPG,1,4060,plesseni x malleti,4060_CAM016819_d.JPG,mimic
+CAM009300,https://zenodo.org/record/2686762/files/CAM009300_d.JPG,0,10452,hydara,10452_CAM009300_d.JPG,minor
+CAM009429,https://zenodo.org/record/2686762/files/CAM009429_d.JPG,0,10656,plesseni,10656_CAM009429_d.JPG,mimic
+CAM017235,https://zenodo.org/record/3082688/files/CAM017235_d.JPG,1,4787,notabilis x lativitta,4787_CAM017235_d.JPG,major
+CAM016186,https://zenodo.org/record/3082688/files/CAM016186_d.JPG,1,3280,notabilis x lativitta,3280_CAM016186_d.JPG,major
+CAM041682,https://zenodo.org/record/4291095/files/CAM041682_d.JPG,0,39695,lativitta,39695_CAM041682_d.JPG,major
+CAM016141,https://zenodo.org/record/3082688/files/CAM016141_d.JPG,1,3190,plesseni x malleti,3190_CAM016141_d.JPG,mimic
+19N1471,https://zenodo.org/record/4288311/files/19N1471_d.JPG,0,20381,malleti,20381_19N1471_d.JPG,mimic
+CAM041000,https://zenodo.org/record/2714333/files/CAM041000_d.JPG,0,13639,malleti,13639_CAM041000_d.JPG,mimic
+CAM041818,https://zenodo.org/record/4291095/files/CAM041818_d.JPG,0,40239,lativitta,40239_CAM041818_d.JPG,major
+CAM009304,https://zenodo.org/record/2686762/files/CAM009304_d.JPG,0,10460,hydara,10460_CAM009304_d.JPG,minor
+CAM041434,https://zenodo.org/record/4291095/files/CAM041434_d.JPG,0,38708,lativitta,38708_CAM041434_d.JPG,major
+CAM021073,https://zenodo.org/record/2702457/files/CAM021073_d.JPG,0,11575,erato,11575_CAM021073_d.JPG,minor
+19N1349,https://zenodo.org/record/4288311/files/19N1349_d.JPG,0,20289,malleti,20289_19N1349_d.JPG,mimic
+19N1907,https://zenodo.org/record/4288311/files/19N1907_d.JPG,0,21207,malleti,21207_19N1907_d.JPG,mimic
+CAM041732,https://zenodo.org/record/4291095/files/CAM041732_d.JPG,0,39895,lativitta,39895_CAM041732_d.JPG,major
+19N0068,https://zenodo.org/record/4288311/files/19N0068_d.JPG,0,19281,malleti,19281_19N0068_d.JPG,mimic
+CAM017051,https://zenodo.org/record/3082688/files/CAM017051_d.JPG,1,4451,notabilis x lativitta,4451_CAM017051_d.JPG,major
+CAM041359,https://zenodo.org/record/4291095/files/CAM041359_d.JPG,0,38416,lativitta,38416_CAM041359_d.JPG,major
+19N0076,https://zenodo.org/record/4288311/files/19N0076_d.JPG,0,19297,malleti,19297_19N0076_d.JPG,mimic
+19N0153,https://zenodo.org/record/4288311/files/19N0153_d.JPG,0,19451,malleti,19451_19N0153_d.JPG,mimic
+19N0981,https://zenodo.org/record/4288311/files/19N0981_d.JPG,0,20135,malleti,20135_19N0981_d.JPG,mimic
+CAM041093,https://zenodo.org/record/2714333/files/CAM041093_d.JPG,0,13824,malleti,13824_CAM041093_d.JPG,mimic
+CAM040269,https://zenodo.org/record/2707828/files/CAM040269_d.JPG,0,12154,malleti,12154_CAM040269_d.JPG,mimic
+CAM041880,https://zenodo.org/record/4291095/files/CAM041880_d.JPG,0,40484,lativitta,40484_CAM041880_d.JPG,major
+CAM000238,https://zenodo.org/record/2677821/files/CAM000238_d.JPG,0,6302,chestertonii,6302_CAM000238_d.JPG,minor
+CAM018268,https://zenodo.org/record/2548678/files/CAM018268_v_whitestandard.JPG,0,17501,plesseni,17501_CAM018268_v_whitestandard.JPG,mimic
+CAM016466,https://zenodo.org/record/3082688/files/CAM016466_d.JPG,1,3629,notabilis x lativitta,3629_CAM016466_d.JPG,major
+19N0613,https://zenodo.org/record/4288311/files/19N0613_d.JPG,0,19910,malleti,19910_19N0613_d.JPG,mimic
+CAM041831,https://zenodo.org/record/4291095/files/CAM041831_d.JPG,0,40291,lativitta,40291_CAM041831_d.JPG,major
+CAM017668,https://zenodo.org/record/3082688/files/CAM017668_d.JPG,1,5414,malleti x plesseni,5414_CAM017668_d.JPG,mimic
+CAM021035,https://zenodo.org/record/2702457/files/CAM021035_d.JPG,1,11504,hydara x amalfreda,11504_CAM021035_d.JPG,minor
+CAM017186,https://zenodo.org/record/3082688/files/CAM017186_d.JPG,0,4692,plesseni,4692_CAM017186_d.JPG,mimic
+F852,https://zenodo.org/record/2555086/files/F852_d.JPG,0,38084,demophoon,38084_F852_d.JPG,minor
+CAM041903,https://zenodo.org/record/4291095/files/CAM041903_d.JPG,0,40576,lativitta,40576_CAM041903_d.JPG,major
+F853,https://zenodo.org/record/2555086/files/F853_d.JPG,0,38088,demophoon,38088_F853_d.JPG,minor
+CAM041206,https://zenodo.org/record/2714333/files/CAM041206_d.JPG,0,14049,malleti,14049_CAM041206_d.JPG,mimic
+CAM017200,https://zenodo.org/record/3082688/files/CAM017200_d.JPG,0,4719,notabilis,4719_CAM017200_d.JPG,major
+CAM041186,https://zenodo.org/record/2714333/files/CAM041186_d.JPG,0,14009,malleti,14009_CAM041186_d.JPG,mimic
+CAM017312,https://zenodo.org/record/3082688/files/CAM017312_d.JPG,1,4910,notabilis x lativitta,4910_CAM017312_d.JPG,major
+CAM016143,https://zenodo.org/record/3082688/files/CAM016143_d.JPG,1,3194,plesseni x malleti,3194_CAM016143_d.JPG,mimic
+CAM040732,https://zenodo.org/record/2714333/files/CAM040732_d.JPG,0,13097,malleti,13097_CAM040732_d.JPG,mimic
+CAM016231,https://zenodo.org/record/4153502/files/CAM016231_D.JPG,1,19084,notabilis x lativitta,19084_CAM016231_D.JPG,major
+CAM016044,https://zenodo.org/record/3082688/files/CAM016044_d.JPG,1,2997,plesseni x malleti,2997_CAM016044_d.JPG,mimic
+CAM016221,https://zenodo.org/record/4153502/files/CAM016221_D.JPG,1,19080,notabilis x lativitta,19080_CAM016221_D.JPG,major
+CAM045179,https://zenodo.org/record/5526257/files/CAM045179_d.JPG,0,43281,cyrbia,43281_CAM045179_d.JPG,minor
+CS001815,https://zenodo.org/record/2553501/files/CS1815 dorsal.jpeg,0,25643,malleti,25643_CS1815 dorsal.jpeg,mimic
+CAM017243,https://zenodo.org/record/3082688/files/CAM017243_d.JPG,0,4803,notabilis,4803_CAM017243_d.JPG,major
+F844,https://zenodo.org/record/2555086/files/F844_d.JPG,0,38064,demophoon,38064_F844_d.JPG,minor
+CAM045067,https://zenodo.org/record/5526257/files/CAM045067_d.JPG,0,42833,cyrbia,42833_CAM045067_d.JPG,minor
+CAM017195,https://zenodo.org/record/3082688/files/CAM017195_d.JPG,0,4710,notabilis,4710_CAM017195_d.JPG,major
+CAM017095,https://zenodo.org/record/3082688/files/CAM017095_d.JPG,1,4531,plesseni x malleti,4531_CAM017095_d.JPG,mimic
+CAM017099,https://zenodo.org/record/3082688/files/CAM017099_d.JPG,0,4537,malleti,4537_CAM017099_d.JPG,mimic
+19N0174,https://zenodo.org/record/4288311/files/19N0174_d.JPG,0,19493,malleti,19493_19N0174_d.JPG,mimic
+CAM017212,https://zenodo.org/record/3082688/files/CAM017212_d.JPG,0,4741,notabilis,4741_CAM017212_d.JPG,major
+CAM009193,https://zenodo.org/record/2686762/files/CAM009193_d.JPG,0,10355,plesseni,10355_CAM009193_d.JPG,mimic
+CAM021034,https://zenodo.org/record/2702457/files/CAM021034_d.JPG,1,11502,hydara x amalfreda,11502_CAM021034_d.JPG,minor
+19N0948,https://zenodo.org/record/4288311/files/19N0948_d.JPG,0,20116,malleti,20116_19N0948_d.JPG,mimic
+19N0864,https://zenodo.org/record/4288311/files/19N0864_d.JPG,0,20068,malleti,20068_19N0864_d.JPG,mimic
+19N0114,https://zenodo.org/record/4288311/files/19N0114_d.JPG,0,19373,malleti,19373_19N0114_d.JPG,mimic
+CAM017056,https://zenodo.org/record/3082688/files/CAM017056_d.JPG,1,4461,notabilis x lativitta,4461_CAM017056_d.JPG,major
+CAM000148,https://zenodo.org/record/2677821/files/CAM000148_d.JPG,0,6128,chestertonii,6128_CAM000148_d.JPG,minor
+CAM041203,https://zenodo.org/record/2714333/files/CAM041203_d.JPG,0,14043,malleti,14043_CAM041203_d.JPG,mimic
+CAM017233,https://zenodo.org/record/3082688/files/CAM017233_d.JPG,1,4783,plesseni x malleti,4783_CAM017233_d.JPG,mimic
+CAM045140,https://zenodo.org/record/5526257/files/CAM045140_d.JPG,0,43127,cyrbia,43127_CAM045140_d.JPG,minor
+19N1194,https://zenodo.org/record/4288311/files/19N1194_d.JPG,0,20221,malleti,20221_19N1194_d.JPG,mimic
+CAM017040,https://zenodo.org/record/3082688/files/CAM017040_d.JPG,1,4433,plesseni x malleti,4433_CAM017040_d.JPG,mimic
+CAM018360,https://zenodo.org/record/2702457/files/CAM018360_d.JPG,1,11127,plesseni x malleti,11127_CAM018360_d.JPG,mimic
+CAM016769,https://zenodo.org/record/3082688/files/CAM016769_d.JPG,1,3974,plesseni x malleti,3974_CAM016769_d.JPG,mimic
+CAM016525,https://zenodo.org/record/3082688/files/CAM016525_d.JPG,1,3681,notabilis x lativitta,3681_CAM016525_d.JPG,major
+CAM045157,https://zenodo.org/record/5526257/files/CAM045157_d.JPG,0,43193,cyrbia,43193_CAM045157_d.JPG,minor
+CAM017272,https://zenodo.org/record/3082688/files/CAM017272_d.JPG,0,4856,malleti,4856_CAM017272_d.JPG,mimic
+CAM016197,https://zenodo.org/record/3082688/files/CAM016197_d.JPG,0,3302,malleti,3302_CAM016197_d.JPG,mimic
+CAM045205,https://zenodo.org/record/5526257/files/CAM045205_d.JPG,0,43383,cyrbia,43383_CAM045205_d.JPG,minor
+CAM002903,https://zenodo.org/record/2684906/files/CAM002903_d.JPG,1,8491,hydara x petiverana,8491_CAM002903_d.JPG,minor
+19N1392,https://zenodo.org/record/4288311/files/19N1392_d.JPG,0,20329,malleti,20329_19N1392_d.JPG,mimic
+CAM016406,https://zenodo.org/record/3082688/files/CAM016406_d.JPG,1,3523,plesseni x malleti,3523_CAM016406_d.JPG,mimic
+CAM016954,https://zenodo.org/record/3082688/files/CAM016954_d.JPG,0,4285,malleti,4285_CAM016954_d.JPG,mimic
+CAM021239,https://zenodo.org/record/2702457/files/CAM021239_d.JPG,0,11688,hydara,11688_CAM021239_d.JPG,minor
+CAM016111,https://zenodo.org/record/3082688/files/CAM016111_d.JPG,1,3130,plesseni x malleti,3130_CAM016111_d.JPG,mimic
+CAM016017,https://zenodo.org/record/3082688/files/CAM016017_d.JPG,1,2943,notabilis x lativitta,2943_CAM016017_d.JPG,major
+CAM009202,https://zenodo.org/record/2686762/files/CAM009202_d.JPG,0,10373,plesseni,10373_CAM009202_d.JPG,mimic
+CAM036274,https://zenodo.org/record/5561246/files/CAM036274_d.JPG,0,41751,phyllis,41751_CAM036274_d.JPG,minor
+CAM045159,https://zenodo.org/record/5526257/files/CAM045159_d.JPG,0,43201,cyrbia,43201_CAM045159_d.JPG,minor
+CAM045118,https://zenodo.org/record/5526257/files/CAM045118_d.JPG,0,43039,cyrbia,43039_CAM045118_d.JPG,minor
+CAM017348,https://zenodo.org/record/3082688/files/CAM017348_d.JPG,1,4974,notabilis x lativitta,4974_CAM017348_d.JPG,major
+19N2221,https://zenodo.org/record/4288311/files/19N2221_d.JPG,0,21811,malleti,21811_19N2221_d.JPG,mimic
+CAM018281,https://zenodo.org/record/2702457/files/CAM018281_d.JPG,1,11018,plesseni x malleti,11018_CAM018281_d.JPG,mimic
+CAM016131,https://zenodo.org/record/3082688/files/CAM016131_d.JPG,1,3170,plesseni x malleti,3170_CAM016131_d.JPG,mimic
+19N1312,https://zenodo.org/record/4288311/files/19N1312_d.JPG,0,20269,malleti,20269_19N1312_d.JPG,mimic
+19N0899,https://zenodo.org/record/4288311/files/19N0899_d.JPG,0,20094,malleti,20094_19N0899_d.JPG,mimic
+CAM041366,https://zenodo.org/record/4291095/files/CAM041366_d.JPG,0,38444,lativitta,38444_CAM041366_d.JPG,major
+CAM041698,https://zenodo.org/record/4291095/files/CAM041698_d.JPG,0,39759,lativitta,39759_CAM041698_d.JPG,major
+CAM016287,https://zenodo.org/record/3082688/files/CAM016287_d.JPG,0,3400,plesseni,3400_CAM016287_d.JPG,mimic
+19N1421,https://zenodo.org/record/4288311/files/19N1421_d.JPG,0,20351,malleti,20351_19N1421_d.JPG,mimic
+CAM008997,https://zenodo.org/record/2686762/files/CAM008997_d.JPG,0,10099,hydara,10099_CAM008997_d.JPG,minor
+F867,https://zenodo.org/record/2555086/files/F867_d.JPG,0,38116,demophoon,38116_F867_d.JPG,minor
+CAM017064,https://zenodo.org/record/3082688/files/CAM017064_d.JPG,0,4477,malleti,4477_CAM017064_d.JPG,mimic
+19N0116,https://zenodo.org/record/4288311/files/19N0116_d.JPG,0,19377,malleti,19377_19N0116_d.JPG,mimic
+CAM009205,https://zenodo.org/record/2686762/files/CAM009205_d.JPG,0,10379,plesseni,10379_CAM009205_d.JPG,mimic
+CAM045059,https://zenodo.org/record/5526257/files/CAM045059_d.JPG,0,42801,cyrbia,42801_CAM045059_d.JPG,minor
+CAM017754,https://zenodo.org/record/3082688/files/CAM017754_d.JPG,1,5514,lativitta x notabilis,5514_CAM017754_d.JPG,major
+CAM036292,https://zenodo.org/record/5561246/files/CAM036292_d.JPG,0,41823,phyllis,41823_CAM036292_d.JPG,minor
+CAM017447,https://zenodo.org/record/3082688/files/CAM017447_d.JPG,1,5128,notabilis x lativitta,5128_CAM017447_d.JPG,major
+CAM017826,https://zenodo.org/record/3082688/files/CAM017826_d.JPG,1,5599,lativitta x notabilis,5599_CAM017826_d.JPG,major
+CAM017338,https://zenodo.org/record/3082688/files/CAM017338_d.JPG,1,4954,notabilis x lativitta,4954_CAM017338_d.JPG,major
+CAM041591,https://zenodo.org/record/4291095/files/CAM041591_d.JPG,0,39331,lativitta,39331_CAM041591_d.JPG,major
+CAM016349,https://zenodo.org/record/3082688/files/CAM016349_d.JPG,0,3434,plesseni,3434_CAM016349_d.JPG,mimic
+CAM009200,https://zenodo.org/record/2686762/files/CAM009200_d.JPG,0,10369,plesseni,10369_CAM009200_d.JPG,mimic
+CAM016242,https://zenodo.org/record/3082688/files/CAM016242_d.JPG,1,3352,plesseni x malleti,3352_CAM016242_d.JPG,mimic
+CAM016867,https://zenodo.org/record/3082688/files/CAM016867_d.JPG,1,4153,plesseni x malleti,4153_CAM016867_d.JPG,mimic
+CAM041744,https://zenodo.org/record/4291095/files/CAM041744_d.JPG,0,39943,lativitta,39943_CAM041744_d.JPG,major
+CAM017142,https://zenodo.org/record/3082688/files/CAM017142_d.JPG,1,4609,notabilis x lativitta,4609_CAM017142_d.JPG,major
+CAM016029,https://zenodo.org/record/3082688/files/CAM016029_d.JPG,1,2967,notabilis x lativitta,2967_CAM016029_d.JPG,major
+CAM041867,https://zenodo.org/record/4291095/files/CAM041867_d.JPG,0,40432,lativitta,40432_CAM041867_d.JPG,major
+CAM016136,https://zenodo.org/record/3082688/files/CAM016136_d.JPG,1,3180,plesseni x malleti,3180_CAM016136_d.JPG,mimic
+19N0341,https://zenodo.org/record/4288311/files/19N0341_d.JPG,0,19780,malleti,19780_19N0341_d.JPG,mimic
+CAM040021,https://zenodo.org/record/2707828/files/CAM040021_d.JPG,0,11726,malleti,11726_CAM040021_d.JPG,mimic
+CAM041442,https://zenodo.org/record/4291095/files/CAM041442_d.JPG,0,38740,lativitta,38740_CAM041442_d.JPG,major
+CAM009199,https://zenodo.org/record/2686762/files/CAM009199_d.JPG,0,10367,plesseni,10367_CAM009199_d.JPG,mimic
+CAM041704,https://zenodo.org/record/4291095/files/CAM041704_d.JPG,0,39783,lativitta,39783_CAM041704_d.JPG,major
+CAM016691,https://zenodo.org/record/4153502/files/CAM016691_d.JPG,0,18926,plesseni,18926_CAM016691_d.JPG,mimic
+CAM016249,https://zenodo.org/record/3082688/files/CAM016249_d.JPG,1,3358,plesseni x malleti,3358_CAM016249_d.JPG,mimic
+CAM016079,https://zenodo.org/record/3082688/files/CAM016079_d.JPG,1,3066,notabilis x lativitta,3066_CAM016079_d.JPG,major
+CAM041856,https://zenodo.org/record/4291095/files/CAM041856_d.JPG,0,40388,lativitta,40388_CAM041856_d.JPG,major
+CS000594,https://zenodo.org/record/2553501/files/CS594 dorsal.jpeg,0,26007,malleti,26007_CS594 dorsal.jpeg,mimic
+CAM041587,https://zenodo.org/record/4291095/files/CAM041587_d.JPG,0,39315,malleti,39315_CAM041587_d.JPG,mimic
+CAM016905,https://zenodo.org/record/4153502/files/CAM016905_d.JPG,0,18974,plesseni,18974_CAM016905_d.JPG,mimic
+CAM041784,https://zenodo.org/record/4291095/files/CAM041784_d.JPG,0,40103,lativitta,40103_CAM041784_d.JPG,major
+CAM041013,https://zenodo.org/record/2714333/files/CAM041013_d.JPG,0,13665,malleti,13665_CAM041013_d.JPG,mimic
+CAM021053,https://zenodo.org/record/2702457/files/CAM021053_d.JPG,0,11538,erato,11538_CAM021053_d.JPG,minor
+CAM045227,https://zenodo.org/record/5526257/files/CAM045227_d.JPG,0,43471,cyrbia,43471_CAM045227_d.JPG,minor
+CAM016270,https://zenodo.org/record/3082688/files/CAM016270_d.JPG,1,3386,plesseni x malleti,3386_CAM016270_d.JPG,mimic
+CAM017246,https://zenodo.org/record/3082688/files/CAM017246_d.JPG,0,4809,notabilis,4809_CAM017246_d.JPG,major
+CAM017206,https://zenodo.org/record/3082688/files/CAM017206_d.JPG,1,4729,notabilis x lativitta,4729_CAM017206_d.JPG,major
+CAM041666,https://zenodo.org/record/4291095/files/CAM041666_d.JPG,0,39631,lativitta,39631_CAM041666_d.JPG,major
+CAM016009,https://zenodo.org/record/3082688/files/CAM016009_d.JPG,0,2927,plesseni,2927_CAM016009_d.JPG,mimic
+CAM017182,https://zenodo.org/record/3082688/files/CAM017182_d.JPG,0,4684,notabilis,4684_CAM017182_d.JPG,major
+19N1432,https://zenodo.org/record/4288311/files/19N1432_d.JPG,0,20363,malleti,20363_19N1432_d.JPG,mimic
+19N0073,https://zenodo.org/record/4288311/files/19N0073_d.JPG,0,19291,malleti,19291_19N0073_d.JPG,mimic
+19N0127,https://zenodo.org/record/4288311/files/19N0127_d.JPG,0,19399,malleti,19399_19N0127_d.JPG,mimic
+CS003541,https://zenodo.org/record/2553501/files/CS3541 dorsal.jpeg,0,25935,malleti,25935_CS3541 dorsal.jpeg,mimic
+CAM017003,https://zenodo.org/record/3082688/files/CAM017003_d.JPG,1,4365,notabilis x lativitta,4365_CAM017003_d.JPG,major
+19N0416,https://zenodo.org/record/4288311/files/19N0416_d.JPG,0,19811,malleti,19811_19N0416_d.JPG,mimic
+CAM040235,https://zenodo.org/record/2707828/files/CAM040235_d.JPG,0,12086,malleti,12086_CAM040235_d.JPG,mimic
+CAM009204,https://zenodo.org/record/2686762/files/CAM009204_d.JPG,0,10377,plesseni,10377_CAM009204_d.JPG,mimic
+CAM041814,https://zenodo.org/record/4291095/files/CAM041814_d.JPG,0,40223,lativitta,40223_CAM041814_d.JPG,major
+19N0172,https://zenodo.org/record/4288311/files/19N0172_d.JPG,0,19489,malleti,19489_19N0172_d.JPG,mimic
+CAM041456,https://zenodo.org/record/4291095/files/CAM041456_d.JPG,0,38796,malleti,38796_CAM041456_d.JPG,mimic

--- a/reference_data/ref_val.csv
+++ b/reference_data/ref_val.csv
@@ -1,0 +1,1176 @@
+CAMID,file_url,hybrid_stat,split,X,subspecies_ref,filename,ssp_indicator
+CAM041834,https://zenodo.org/record/4291095/files/CAM041834_d.JPG,0,test,40303,lativitta,40303_CAM041834_d.JPG,major
+CAM045170,https://zenodo.org/record/5526257/files/CAM045170_d.JPG,0,test,43245,cyrbia,43245_CAM045170_d.JPG,minor
+CAM041210,https://zenodo.org/record/2714333/files/CAM041210_d.JPG,0,test-2,14057,malleti,14057_CAM041210_d.JPG,mimic
+CAM045261,https://zenodo.org/record/5526257/files/CAM045261_d.JPG,0,test,43607,cyrbia,43607_CAM045261_d.JPG,minor
+CAM016653,https://zenodo.org/record/3082688/files/CAM016653_d.JPG,1,test,3841,notabilis x lativitta,3841_CAM016653_d.JPG,major
+CAM041645,https://zenodo.org/record/4291095/files/CAM041645_d.JPG,0,test,39547,lativitta,39547_CAM041645_d.JPG,major
+CAM016353,https://zenodo.org/record/4153502/files/CAM016353_D.JPG,0,test,19124,notabilis,19124_CAM016353_D.JPG,major
+CAM041656,https://zenodo.org/record/4291095/files/CAM041656_d.JPG,0,test,39591,lativitta,39591_CAM041656_d.JPG,major
+CAM009332,https://zenodo.org/record/2686762/files/CAM009332_d.JPG,0,test,10516,hydara,10516_CAM009332_d.JPG,minor
+CAM016066,https://zenodo.org/record/3082688/files/CAM016066_d.JPG,1,test-2,3040,plesseni x malleti,3040_CAM016066_d.JPG,mimic
+15N320,https://zenodo.org/record/4289223/files/15N320_d.JPG,0,test,15230,venus,15230_15N320_d.JPG,minor
+CAM045041,https://zenodo.org/record/5526257/files/CAM045041_d.JPG,0,test,42729,cyrbia,42729_CAM045041_d.JPG,minor
+CAM017039,https://zenodo.org/record/3082688/files/CAM017039_d.JPG,1,test,4431,notabilis x lativitta,4431_CAM017039_d.JPG,major
+CAM045198,https://zenodo.org/record/5526257/files/CAM045198_d.JPG,0,test,43357,cyrbia,43357_CAM045198_d.JPG,minor
+CAM041542,https://zenodo.org/record/4291095/files/CAM041542_d.JPG,0,test-2,39140,malleti,39140_CAM041542_d.JPG,mimic
+F895,https://zenodo.org/record/2555086/files/F895_d.JPG,0,test,38160,demophoon,38160_F895_d.JPG,minor
+CAM045029,https://zenodo.org/record/5526257/files/CAM045029_d.JPG,0,test,42681,cyrbia,42681_CAM045029_d.JPG,minor
+CAM045245,https://zenodo.org/record/5526257/files/CAM045245_d.JPG,0,test,43543,cyrbia,43543_CAM045245_d.JPG,minor
+CAM017280,https://zenodo.org/record/3082688/files/CAM017280_d.JPG,1,test,4872,notabilis x lativitta,4872_CAM017280_d.JPG,major
+CAM045057,https://zenodo.org/record/5526257/files/CAM045057_d.JPG,0,test,42793,cyrbia,42793_CAM045057_d.JPG,minor
+CAM016462,https://zenodo.org/record/3082688/files/CAM016462_d.JPG,1,test,3621,notabilis x lativitta,3621_CAM016462_d.JPG,major
+15N192,https://zenodo.org/record/4289223/files/15N192_d.JPG,0,test,15202,venus,15202_15N192_d.JPG,minor
+19N0336,https://zenodo.org/record/4288311/files/19N0336_d.JPG,0,test-2,19778,malleti,19778_19N0336_d.JPG,mimic
+CAM045056,https://zenodo.org/record/5526257/files/CAM045056_d.JPG,0,test,42789,cyrbia,42789_CAM045056_d.JPG,minor
+CAM041668,https://zenodo.org/record/4291095/files/CAM041668_d.JPG,0,test,39639,lativitta,39639_CAM041668_d.JPG,major
+19N1743,https://zenodo.org/record/4288311/files/19N1743_d.JPG,0,test-2,20943,malleti,20943_19N1743_d.JPG,mimic
+CAM041683,https://zenodo.org/record/4291095/files/CAM041683_d.JPG,0,test,39699,lativitta,39699_CAM041683_d.JPG,major
+19N2252,https://zenodo.org/record/4288311/files/19N2252_d.JPG,0,test-2,21935,malleti,21935_19N2252_d.JPG,mimic
+CAM009018,https://zenodo.org/record/2686762/files/CAM009018_d.JPG,0,test,10141,hydara,10141_CAM009018_d.JPG,minor
+CAM016698,https://zenodo.org/record/4153502/files/CAM016698_d.JPG,0,test-2,18940,plesseni,18940_CAM016698_d.JPG,mimic
+CAM017410,https://zenodo.org/record/3082688/files/CAM017410_d.JPG,1,test,5059,notabilis x lativitta,5059_CAM017410_d.JPG,major
+CAM016500,https://zenodo.org/record/3082688/files/CAM016500_d.JPG,1,test-2,3633,plesseni x malleti,3633_CAM016500_d.JPG,mimic
+19N2119,https://zenodo.org/record/4288311/files/19N2119_d.JPG,0,test-2,21627,malleti,21627_19N2119_d.JPG,mimic
+CAM041691,https://zenodo.org/record/4291095/files/CAM041691_d.JPG,0,test,39731,lativitta,39731_CAM041691_d.JPG,major
+CAM017604,https://zenodo.org/record/3082688/files/CAM017604_d.JPG,1,test,5370,notabilis x lativitta,5370_CAM017604_d.JPG,major
+19N0648,https://zenodo.org/record/4288311/files/19N0648_d.JPG,0,test-2,19942,malleti,19942_19N0648_d.JPG,mimic
+CAM017258,https://zenodo.org/record/4153502/files/CAM017258_d.JPG,0,test-2,19004,plesseni,19004_CAM017258_d.JPG,mimic
+CAM016455,https://zenodo.org/record/3082688/files/CAM016455_d.JPG,1,test,3611,notabilis x lativitta,3611_CAM016455_d.JPG,major
+19N2020,https://zenodo.org/record/4288311/files/19N2020_d.JPG,0,test-2,21435,malleti,21435_19N2020_d.JPG,mimic
+CAM041207,https://zenodo.org/record/2714333/files/CAM041207_d.JPG,0,test-2,14051,malleti,14051_CAM041207_d.JPG,mimic
+19N0131,https://zenodo.org/record/4288311/files/19N0131_d.JPG,0,test-2,19407,malleti,19407_19N0131_d.JPG,mimic
+19N2235,https://zenodo.org/record/4288311/files/19N2235_d.JPG,0,test-2,21867,malleti,21867_19N2235_d.JPG,mimic
+CAM017337,https://zenodo.org/record/3082688/files/CAM017337_d.JPG,1,test,4952,notabilis x lativitta,4952_CAM017337_d.JPG,major
+19N1260,https://zenodo.org/record/4288311/files/19N1260_d.JPG,0,test-2,20255,malleti,20255_19N1260_d.JPG,mimic
+CAM009195,https://zenodo.org/record/2686762/files/CAM009195_d.JPG,0,test-2,10359,plesseni,10359_CAM009195_d.JPG,mimic
+CAM041879,https://zenodo.org/record/4291095/files/CAM041879_d.JPG,0,test,40480,lativitta,40480_CAM041879_d.JPG,major
+CAM016050,https://zenodo.org/record/3082688/files/CAM016050_d.JPG,1,test-2,3009,plesseni x malleti,3009_CAM016050_d.JPG,mimic
+CAM017004,https://zenodo.org/record/3082688/files/CAM017004_d.JPG,1,test,4367,notabilis x lativitta,4367_CAM017004_d.JPG,major
+CAM016350,https://zenodo.org/record/3082688/files/CAM016350_d.JPG,1,test-2,3436,plesseni x malleti,3436_CAM016350_d.JPG,mimic
+CAM041354,https://zenodo.org/record/4291095/files/CAM041354_d.JPG,0,test,38396,lativitta,38396_CAM041354_d.JPG,major
+CAM018402,https://zenodo.org/record/2702457/files/CAM018402_d.JPG,1,test-2,11168,plesseni x malleti,11168_CAM018402_d.JPG,mimic
+19N0101,https://zenodo.org/record/4288311/files/19N0101_d.JPG,0,test-2,19347,malleti,19347_19N0101_d.JPG,mimic
+CAM016595,https://zenodo.org/record/3082688/files/CAM016595_d.JPG,0,test-2,3779,malleti,3779_CAM016595_d.JPG,mimic
+CAM041659,https://zenodo.org/record/4291095/files/CAM041659_d.JPG,0,test,39603,lativitta,39603_CAM041659_d.JPG,major
+CAM016148,https://zenodo.org/record/3082688/files/CAM016148_d.JPG,1,test,3204,notabilis x lativitta,3204_CAM016148_d.JPG,major
+CAM040038,https://zenodo.org/record/2707828/files/CAM040038_d.JPG,0,test,11756,dignus,11756_CAM040038_d.JPG,minor
+CAM040077,https://zenodo.org/record/2707828/files/CAM040077_d.JPG,0,test,11818,dignus,11818_CAM040077_d.JPG,minor
+CAM021041,https://zenodo.org/record/2702457/files/CAM021041_d.JPG,0,test,11514,amalfreda,11514_CAM021041_d.JPG,minor
+CAM041640,https://zenodo.org/record/4291095/files/CAM041640_d.JPG,0,test,39527,lativitta,39527_CAM041640_d.JPG,major
+CAM041499,https://zenodo.org/record/4291095/files/CAM041499_d.JPG,0,test-2,38968,malleti,38968_CAM041499_d.JPG,mimic
+CAM017549,https://zenodo.org/record/3082688/files/CAM017549_d.JPG,1,test-2,5288,malleti x plesseni,5288_CAM017549_d.JPG,mimic
+CAM016268,https://zenodo.org/record/3082688/files/CAM016268_d.JPG,0,test-2,3382,malleti,3382_CAM016268_d.JPG,mimic
+CAM017614,https://zenodo.org/record/3082688/files/CAM017614_d.JPG,0,test-2,5388,plesseni,5388_CAM017614_d.JPG,mimic
+CAM041200,https://zenodo.org/record/2714333/files/CAM041200_d.JPG,0,test-2,14037,malleti,14037_CAM041200_d.JPG,mimic
+CAM041731,https://zenodo.org/record/4291095/files/CAM041731_d.JPG,0,test,39891,lativitta,39891_CAM041731_d.JPG,major
+15N149,https://zenodo.org/record/4289223/files/15N149_d.JPG,0,test,14961,venus,14961_15N149_d.JPG,minor
+CAM016393,https://zenodo.org/record/3082688/files/CAM016393_d.JPG,1,test-2,3499,plesseni x malleti,3499_CAM016393_d.JPG,mimic
+19N0135,https://zenodo.org/record/4288311/files/19N0135_d.JPG,0,test-2,19415,malleti,19415_19N0135_d.JPG,mimic
+19N0630,https://zenodo.org/record/4288311/files/19N0630_d.JPG,0,test-2,19920,malleti,19920_19N0630_d.JPG,mimic
+19N0180,https://zenodo.org/record/4288311/files/19N0180_d.JPG,0,test-2,19505,malleti,19505_19N0180_d.JPG,mimic
+CAM016225,https://zenodo.org/record/3082688/files/CAM016225_d.JPG,1,test-2,3336,plesseni x malleti,3336_CAM016225_d.JPG,mimic
+CAM016026,https://zenodo.org/record/3082688/files/CAM016026_d.JPG,1,test,2961,notabilis x lativitta,2961_CAM016026_d.JPG,major
+CAM016424,https://zenodo.org/record/3082688/files/CAM016424_d.JPG,1,test-2,3559,plesseni x malleti,3559_CAM016424_d.JPG,mimic
+CAM041857,https://zenodo.org/record/4291095/files/CAM041857_d.JPG,0,test,40392,lativitta,40392_CAM041857_d.JPG,major
+CAM016656,https://zenodo.org/record/3082688/files/CAM016656_d.JPG,1,test-2,3847,plesseni x malleti,3847_CAM016656_d.JPG,mimic
+CAM041428,https://zenodo.org/record/4291095/files/CAM041428_d.JPG,0,test,38684,lativitta,38684_CAM041428_d.JPG,major
+CAM008864,https://zenodo.org/record/2686762/files/CAM008864_d.JPG,0,test,9949,hydara,9949_CAM008864_d.JPG,minor
+CAM016505,https://zenodo.org/record/3082688/files/CAM016505_d.JPG,1,test-2,3643,plesseni x malleti,3643_CAM016505_d.JPG,mimic
+CAM016588,https://zenodo.org/record/3082688/files/CAM016588_d.JPG,1,test,3767,notabilis x lativitta,3767_CAM016588_d.JPG,major
+CAM041647,https://zenodo.org/record/4291095/files/CAM041647_d.JPG,0,test,39555,lativitta,39555_CAM041647_d.JPG,major
+CAM040210,https://zenodo.org/record/2707828/files/CAM040210_d.JPG,0,test-2,12044,malleti,12044_CAM040210_d.JPG,mimic
+CAM041815,https://zenodo.org/record/4291095/files/CAM041815_d.JPG,0,test,40227,lativitta,40227_CAM041815_d.JPG,major
+CAM016646,https://zenodo.org/record/3082688/files/CAM016646_d.JPG,1,test,3827,notabilis x lativitta,3827_CAM016646_d.JPG,major
+CAM016526,https://zenodo.org/record/3082688/files/CAM016526_d.JPG,1,test,3683,notabilis x lativitta,3683_CAM016526_d.JPG,major
+CAM016540,https://zenodo.org/record/3082688/files/CAM016540_d.JPG,0,test-2,3691,malleti,3691_CAM016540_d.JPG,mimic
+CAM041027,https://zenodo.org/record/2714333/files/CAM041027_d.JPG,0,test-2,13693,malleti,13693_CAM041027_d.JPG,mimic
+19N1856,https://zenodo.org/record/4288311/files/19N1856_d.JPG,0,test-2,21111,malleti,21111_19N1856_d.JPG,mimic
+CAM016302,https://zenodo.org/record/4153502/files/CAM016302_d.JPG,1,test,18862,notabilis x lativitta,18862_CAM016302_d.JPG,major
+CAM041885,https://zenodo.org/record/4291095/files/CAM041885_d.JPG,0,test,40504,lativitta,40504_CAM041885_d.JPG,major
+CAM017253,https://zenodo.org/record/3082688/files/CAM017253_d.JPG,0,test,4823,notabilis,4823_CAM017253_d.JPG,major
+CAM041658,https://zenodo.org/record/4291095/files/CAM041658_d.JPG,0,test,39599,lativitta,39599_CAM041658_d.JPG,major
+CAM017351,https://zenodo.org/record/3082688/files/CAM017351_d.JPG,1,test-2,4980,plesseni x malleti,4980_CAM017351_d.JPG,mimic
+CAM045069,https://zenodo.org/record/5526257/files/CAM045069_d.JPG,0,test,42841,cyrbia,42841_CAM045069_d.JPG,minor
+CAM045141,https://zenodo.org/record/5526257/files/CAM045141_d.JPG,0,test,43131,cyrbia,43131_CAM045141_d.JPG,minor
+CAM017264,https://zenodo.org/record/3082688/files/CAM017264_d.JPG,1,test-2,4840,plesseni x malleti,4840_CAM017264_d.JPG,mimic
+CAM018257,https://zenodo.org/record/2702457/files/CAM018257_d.JPG,1,test-2,10986,plesseni x malleti,10986_CAM018257_d.JPG,mimic
+19N0674,https://zenodo.org/record/4288311/files/19N0674_d.JPG,0,test-2,19970,malleti,19970_19N0674_d.JPG,mimic
+CAM008985,https://zenodo.org/record/2686762/files/CAM008985_d.JPG,0,test,10075,hydara,10075_CAM008985_d.JPG,minor
+CAM041888,https://zenodo.org/record/4291095/files/CAM041888_d.JPG,0,test,40516,lativitta,40516_CAM041888_d.JPG,major
+CAM041747,https://zenodo.org/record/4291095/files/CAM041747_d.JPG,0,test,39955,lativitta,39955_CAM041747_d.JPG,major
+19N2257,https://zenodo.org/record/4288311/files/19N2257_d.JPG,0,test-2,21955,malleti,21955_19N2257_d.JPG,mimic
+CAM041843,https://zenodo.org/record/4291095/files/CAM041843_d.JPG,0,test,40339,lativitta,40339_CAM041843_d.JPG,major
+CAM041912,https://zenodo.org/record/4291095/files/CAM041912_d.JPG,0,test,40612,lativitta,40612_CAM041912_d.JPG,major
+CAM041789,https://zenodo.org/record/4291095/files/CAM041789_d.JPG,0,test,40123,lativitta,40123_CAM041789_d.JPG,major
+CAM017063,https://zenodo.org/record/3082688/files/CAM017063_d.JPG,1,test,4475,notabilis x lativitta,4475_CAM017063_d.JPG,major
+CAM045171,https://zenodo.org/record/5526257/files/CAM045171_d.JPG,0,test,43249,cyrbia,43249_CAM045171_d.JPG,minor
+15N195,https://zenodo.org/record/4289223/files/15N195_d.JPG,0,test,15208,venus,15208_15N195_d.JPG,minor
+CAM016314,https://zenodo.org/record/4153502/files/CAM016314_d.JPG,1,test,18868,notabilis x lativitta,18868_CAM016314_d.JPG,major
+CAM041839,https://zenodo.org/record/4291095/files/CAM041839_d.JPG,0,test,40323,lativitta,40323_CAM041839_d.JPG,major
+CAM041614,https://zenodo.org/record/4291095/files/CAM041614_d.JPG,0,test,39423,lativitta,39423_CAM041614_d.JPG,major
+CAM045213,https://zenodo.org/record/5526257/files/CAM045213_d.JPG,0,test,43415,cyrbia,43415_CAM045213_d.JPG,minor
+CAM016654,https://zenodo.org/record/3082688/files/CAM016654_d.JPG,1,test-2,3843,plesseni x malleti,3843_CAM016654_d.JPG,mimic
+CAM045249,https://zenodo.org/record/5526257/files/CAM045249_d.JPG,0,test,43559,cyrbia,43559_CAM045249_d.JPG,minor
+19N2025,https://zenodo.org/record/4288311/files/19N2025_d.JPG,0,test-2,21451,malleti,21451_19N2025_d.JPG,mimic
+CAM016031,https://zenodo.org/record/3082688/files/CAM016031_d.JPG,1,test,2971,notabilis x lativitta,2971_CAM016031_d.JPG,major
+CAM017134,https://zenodo.org/record/3082688/files/CAM017134_d.JPG,0,test-2,4597,malleti,4597_CAM017134_d.JPG,mimic
+CAM017619,https://zenodo.org/record/4153502/files/CAM017619_d.JPG,0,test-2,19064,plesseni,19064_CAM017619_d.JPG,mimic
+CAM017451,https://zenodo.org/record/3082688/files/CAM017451_d.JPG,1,test-2,5134,malleti x plesseni,5134_CAM017451_d.JPG,mimic
+CAM011438,https://zenodo.org/record/2550097/files/CAM011438_d.JPG,0,test-2,28244,plesseni,28244_CAM011438_d.JPG,mimic
+CAM009520,https://zenodo.org/record/2686762/files/CAM009520_d.JPG,1,test,10782,hydara x petiverana,10782_CAM009520_d.JPG,minor
+CAM017154,https://zenodo.org/record/3082688/files/CAM017154_d.JPG,0,test-2,4633,malleti,4633_CAM017154_d.JPG,mimic
+19N0097,https://zenodo.org/record/4288311/files/19N0097_d.JPG,0,test-2,19339,malleti,19339_19N0097_d.JPG,mimic
+CAM016028,https://zenodo.org/record/3082688/files/CAM016028_d.JPG,1,test,2965,notabilis x lativitta,2965_CAM016028_d.JPG,major
+CAM045183,https://zenodo.org/record/5526257/files/CAM045183_d.JPG,0,test,43297,cyrbia,43297_CAM045183_d.JPG,minor
+CAM016146,https://zenodo.org/record/3082688/files/CAM016146_d.JPG,1,test,3200,notabilis x lativitta,3200_CAM016146_d.JPG,major
+CAM045219,https://zenodo.org/record/5526257/files/CAM045219_d.JPG,0,test,43439,cyrbia,43439_CAM045219_d.JPG,minor
+CAM016137,https://zenodo.org/record/3082688/files/CAM016137_d.JPG,1,test-2,3182,plesseni x malleti,3182_CAM016137_d.JPG,mimic
+CAM016361,https://zenodo.org/record/4153502/files/CAM016361_D.JPG,0,test,19128,notabilis,19128_CAM016361_D.JPG,major
+CAM016115,https://zenodo.org/record/3082688/files/CAM016115_d.JPG,1,test,3138,notabilis x lativitta,3138_CAM016115_d.JPG,major
+CAM041782,https://zenodo.org/record/4291095/files/CAM041782_d.JPG,0,test,40095,lativitta,40095_CAM041782_d.JPG,major
+19N1179,https://zenodo.org/record/4288311/files/19N1179_d.JPG,0,test-2,20213,malleti,20213_19N1179_d.JPG,mimic
+CAM009523,https://zenodo.org/record/2686762/files/CAM009523_d.JPG,1,test,10788,hydara x petiverana,10788_CAM009523_d.JPG,minor
+19N2228,https://zenodo.org/record/4288311/files/19N2228_d.JPG,0,test-2,21839,malleti,21839_19N2228_d.JPG,mimic
+CAM040992,https://zenodo.org/record/2714333/files/CAM040992_d.JPG,0,test-2,13623,malleti,13623_CAM040992_d.JPG,mimic
+CAM045217,https://zenodo.org/record/5526257/files/CAM045217_d.JPG,0,test,43431,cyrbia,43431_CAM045217_d.JPG,minor
+CAM009006,https://zenodo.org/record/2686762/files/CAM009006_d.JPG,0,test,10117,hydara,10117_CAM009006_d.JPG,minor
+CAM017453,https://zenodo.org/record/1748277/files/CAM017453_d_whitestandard.JPG,0,test-2,15275,plesseni,15275_CAM017453_d_whitestandard.JPG,mimic
+CAM041625,https://zenodo.org/record/4291095/files/CAM041625_d.JPG,0,test,39467,lativitta,39467_CAM041625_d.JPG,major
+CAM041646,https://zenodo.org/record/4291095/files/CAM041646_d.JPG,0,test,39551,lativitta,39551_CAM041646_d.JPG,major
+CAM000231,https://zenodo.org/record/2677821/files/CAM000231_d.JPG,0,test,6288,chestertonii,6288_CAM000231_d.JPG,minor
+CAM016860,https://zenodo.org/record/3082688/files/CAM016860_d.JPG,1,test-2,4139,plesseni x malleti,4139_CAM016860_d.JPG,mimic
+19N0212,https://zenodo.org/record/4288311/files/19N0212_d.JPG,0,test-2,19569,malleti,19569_19N0212_d.JPG,mimic
+CAM045043,https://zenodo.org/record/5526257/files/CAM045043_d.JPG,0,test,42737,cyrbia,42737_CAM045043_d.JPG,minor
+19N0035,https://zenodo.org/record/4288311/files/19N0035_d.JPG,0,test-2,19210,malleti,19210_19N0035_d.JPG,mimic
+CAM040066,https://zenodo.org/record/2707828/files/CAM040066_d.JPG,0,test,11812,dignus,11812_CAM040066_d.JPG,minor
+CAM040020,https://zenodo.org/record/2707828/files/CAM040020_d.JPG,0,test-2,11724,malleti,11724_CAM040020_d.JPG,mimic
+CAM009203,https://zenodo.org/record/2686762/files/CAM009203_d.JPG,0,test-2,10375,plesseni,10375_CAM009203_d.JPG,mimic
+CAM041437,https://zenodo.org/record/4291095/files/CAM041437_d.JPG,0,test,38720,lativitta,38720_CAM041437_d.JPG,major
+CAM016177,https://zenodo.org/record/3082688/files/CAM016177_d.JPG,1,test,3262,notabilis x lativitta,3262_CAM016177_d.JPG,major
+CAM008544,https://zenodo.org/record/2684906/files/CAM008544_d.JPG,0,test-2,9440,plesseni,9440_CAM008544_d.JPG,mimic
+CAM016956,https://zenodo.org/record/3082688/files/CAM016956_d.JPG,0,test-2,4289,malleti,4289_CAM016956_d.JPG,mimic
+19N0639,https://zenodo.org/record/4288311/files/19N0639_d.JPG,0,test-2,19934,malleti,19934_19N0639_d.JPG,mimic
+CAM017309,https://zenodo.org/record/3082688/files/CAM017309_d.JPG,1,test,4904,notabilis x lativitta,4904_CAM017309_d.JPG,major
+CAM016652,https://zenodo.org/record/3082688/files/CAM016652_d.JPG,1,test,3839,notabilis x lativitta,3839_CAM016652_d.JPG,major
+CAM016828,https://zenodo.org/record/3082688/files/CAM016828_d.JPG,1,test-2,4078,plesseni x malleti,4078_CAM016828_d.JPG,mimic
+19N0089,https://zenodo.org/record/4288311/files/19N0089_d.JPG,0,test-2,19323,malleti,19323_19N0089_d.JPG,mimic
+19N1387,https://zenodo.org/record/4288311/files/19N1387_d.JPG,0,test-2,20323,malleti,20323_19N1387_d.JPG,mimic
+CAM045257,https://zenodo.org/record/5526257/files/CAM045257_d.JPG,0,test,43591,cyrbia,43591_CAM045257_d.JPG,minor
+CAM045192,https://zenodo.org/record/5526257/files/CAM045192_d.JPG,0,test,43333,cyrbia,43333_CAM045192_d.JPG,minor
+CAM017219,https://zenodo.org/record/3082688/files/CAM017219_d.JPG,0,test,4755,notabilis,4755_CAM017219_d.JPG,major
+CAM041036,https://zenodo.org/record/2714333/files/CAM041036_d.JPG,0,test-2,13711,malleti,13711_CAM041036_d.JPG,mimic
+19N2225,https://zenodo.org/record/4288311/files/19N2225_d.JPG,0,test-2,21827,malleti,21827_19N2225_d.JPG,mimic
+CAM016580,https://zenodo.org/record/3082688/files/CAM016580_d.JPG,1,test,3751,notabilis x lativitta,3751_CAM016580_d.JPG,major
+19N0177,https://zenodo.org/record/4288311/files/19N0177_d.JPG,0,test-2,19499,malleti,19499_19N0177_d.JPG,mimic
+CAM016560,https://zenodo.org/record/3082688/files/CAM016560_d.JPG,1,test,3725,notabilis x lativitta,3725_CAM016560_d.JPG,major
+19N0281,https://zenodo.org/record/4288311/files/19N0281_d.JPG,0,test-2,19708,malleti,19708_19N0281_d.JPG,mimic
+19N0056,https://zenodo.org/record/4288311/files/19N0056_d.JPG,0,test-2,19254,malleti,19254_19N0056_d.JPG,mimic
+CAM016703,https://zenodo.org/record/4153502/files/CAM016703_d.JPG,0,test,18950,notabilis,18950_CAM016703_d.JPG,major
+15N135,https://zenodo.org/record/4289223/files/15N135_d.JPG,0,test,15182,chestertonii,15182_15N135_d.JPG,minor
+CAM016734,https://zenodo.org/record/4153502/files/CAM016734_d.JPG,0,test-2,18962,plesseni,18962_CAM016734_d.JPG,mimic
+CAM040222,https://zenodo.org/record/2707828/files/CAM040222_d.JPG,0,test-2,12064,malleti,12064_CAM040222_d.JPG,mimic
+19N0299,https://zenodo.org/record/4288311/files/19N0299_d.JPG,0,test-2,19732,malleti,19732_19N0299_d.JPG,mimic
+CAM017658,https://zenodo.org/record/3082688/files/CAM017658_d.JPG,1,test-2,5396,malleti x plesseni,5396_CAM017658_d.JPG,mimic
+19N1467,https://zenodo.org/record/4288311/files/19N1467_d.JPG,0,test-2,20379,malleti,20379_19N1467_d.JPG,mimic
+19N0133,https://zenodo.org/record/4288311/files/19N0133_d.JPG,0,test-2,19411,malleti,19411_19N0133_d.JPG,mimic
+CAM016922,https://zenodo.org/record/3082688/files/CAM016922_d.JPG,1,test-2,4245,plesseni x malleti,4245_CAM016922_d.JPG,mimic
+CS003728,https://zenodo.org/record/2553501/files/CS3728 dorsal.jpeg,0,test-2,25967,malleti,25967_CS3728 dorsal.jpeg,mimic
+CAM041596,https://zenodo.org/record/4291095/files/CAM041596_d.JPG,0,test,39351,lativitta,39351_CAM041596_d.JPG,major
+CAM045105,https://zenodo.org/record/5526257/files/CAM045105_d.JPG,0,test,42985,cyrbia,42985_CAM045105_d.JPG,minor
+CAM040129,https://zenodo.org/record/2707828/files/CAM040129_d.JPG,0,test-2,11898,malleti,11898_CAM040129_d.JPG,mimic
+CAM041737,https://zenodo.org/record/4291095/files/CAM041737_d.JPG,0,test,39915,lativitta,39915_CAM041737_d.JPG,major
+19N2189,https://zenodo.org/record/4288311/files/19N2189_d.JPG,0,test-2,21723,malleti,21723_19N2189_d.JPG,mimic
+CAM045260,https://zenodo.org/record/5526257/files/CAM045260_d.JPG,0,test,43603,cyrbia,43603_CAM045260_d.JPG,minor
+CAM041900,https://zenodo.org/record/4291095/files/CAM041900_d.JPG,0,test,40564,lativitta,40564_CAM041900_d.JPG,major
+CAM041667,https://zenodo.org/record/4291095/files/CAM041667_d.JPG,0,test,39635,lativitta,39635_CAM041667_d.JPG,major
+CAM041436,https://zenodo.org/record/4291095/files/CAM041436_d.JPG,0,test,38716,lativitta,38716_CAM041436_d.JPG,major
+F849,https://zenodo.org/record/2555086/files/F849_d.JPG,0,test,38076,demophoon,38076_F849_d.JPG,minor
+CAM036231,https://zenodo.org/record/5561246/files/CAM036231_d.JPG,0,test,41635,phyllis,41635_CAM036231_d.JPG,minor
+19N0075,https://zenodo.org/record/4288311/files/19N0075_d.JPG,0,test-2,19295,malleti,19295_19N0075_d.JPG,mimic
+CAM016608,https://zenodo.org/record/3082688/files/CAM016608_d.JPG,1,test-2,3801,plesseni x malleti,3801_CAM016608_d.JPG,mimic
+CAM041771,https://zenodo.org/record/4291095/files/CAM041771_d.JPG,0,test,40051,lativitta,40051_CAM041771_d.JPG,major
+CAM017301,https://zenodo.org/record/3082688/files/CAM017301_d.JPG,1,test,4892,notabilis x lativitta,4892_CAM017301_d.JPG,major
+CAM009510,https://zenodo.org/record/2686762/files/CAM009510_d.JPG,1,test,10762,hydara x petiverana,10762_CAM009510_d.JPG,minor
+CAM008546,https://zenodo.org/record/2684906/files/CAM008546_d.JPG,0,test-2,9444,plesseni,9444_CAM008546_d.JPG,mimic
+CAM017574,https://zenodo.org/record/3082688/files/CAM017574_d.JPG,1,test-2,5322,malleti x plesseni,5322_CAM017574_d.JPG,mimic
+CAM041629,https://zenodo.org/record/4291095/files/CAM041629_d.JPG,0,test,39483,lativitta,39483_CAM041629_d.JPG,major
+CAM009442,https://zenodo.org/record/2686762/files/CAM009442_d.JPG,0,test-2,10682,plesseni,10682_CAM009442_d.JPG,mimic
+CAM018438,https://zenodo.org/record/2548678/files/CAM018438_v_whitestandard.JPG,0,test-2,18165,malleti,18165_CAM018438_v_whitestandard.JPG,mimic
+CAM016161,https://zenodo.org/record/3082688/files/CAM016161_d.JPG,1,test-2,3230,plesseni x malleti,3230_CAM016161_d.JPG,mimic
+CAM017908,https://zenodo.org/record/1748277/files/CAM017908_v_whitestandard.JPG,0,test-2,16887,malleti,16887_CAM017908_v_whitestandard.JPG,mimic
+CAM041178,https://zenodo.org/record/2714333/files/CAM041178_d.JPG,0,test-2,13993,malleti,13993_CAM041178_d.JPG,mimic
+CAM016511,https://zenodo.org/record/3082688/files/CAM016511_d.JPG,1,test-2,3655,plesseni x malleti,3655_CAM016511_d.JPG,mimic
+CAM041780,https://zenodo.org/record/4291095/files/CAM041780_d.JPG,0,test,40087,lativitta,40087_CAM041780_d.JPG,major
+CAM041580,https://zenodo.org/record/4291095/files/CAM041580_d.JPG,0,test-2,39288,malleti,39288_CAM041580_d.JPG,mimic
+CAM016662,https://zenodo.org/record/3082688/files/CAM016662_d.JPG,1,test-2,3859,plesseni x malleti,3859_CAM016662_d.JPG,mimic
+CAM009233,https://zenodo.org/record/2686762/files/CAM009233_d.JPG,0,test-2,10434,plesseni,10434_CAM009233_d.JPG,mimic
+19N0160,https://zenodo.org/record/4288311/files/19N0160_d.JPG,0,test-2,19465,malleti,19465_19N0160_d.JPG,mimic
+CAM016456,https://zenodo.org/record/3082688/files/CAM016456_d.JPG,1,test,3613,notabilis x lativitta,3613_CAM016456_d.JPG,major
+CS002276,https://zenodo.org/record/2735056/files/CS002276_d.JPG,0,test,40859,venus,40859_CS002276_d.JPG,minor
+CAM016648,https://zenodo.org/record/3082688/files/CAM016648_d.JPG,1,test,3831,notabilis x lativitta,3831_CAM016648_d.JPG,major
+CAM008865,https://zenodo.org/record/2686762/files/CAM008865_d.JPG,0,test,9951,hydara,9951_CAM008865_d.JPG,minor
+19N1908,https://zenodo.org/record/4288311/files/19N1908_d.JPG,0,test-2,21211,malleti,21211_19N1908_d.JPG,mimic
+CAM016362,https://zenodo.org/record/4153502/files/CAM016362_D.JPG,0,test,19130,notabilis,19130_CAM016362_D.JPG,major
+CAM016738,https://zenodo.org/record/4153502/files/CAM016738_d.JPG,0,test-2,18966,plesseni,18966_CAM016738_d.JPG,mimic
+19N1112,https://zenodo.org/record/4288311/files/19N1112_d.JPG,0,test-2,20190,malleti,20190_19N1112_d.JPG,mimic
+19N1426,https://zenodo.org/record/4288311/files/19N1426_d.JPG,0,test-2,20357,malleti,20357_19N1426_d.JPG,mimic
+15N101,https://zenodo.org/record/4289223/files/15N101_d.JPG,0,test,14953,venus,14953_15N101_d.JPG,minor
+CAM041557,https://zenodo.org/record/4291095/files/CAM041557_d.JPG,0,test-2,39196,malleti,39196_CAM041557_d.JPG,mimic
+19N1744,https://zenodo.org/record/4288311/files/19N1744_d.JPG,0,test-2,20947,malleti,20947_19N1744_d.JPG,mimic
+CAM041858,https://zenodo.org/record/4291095/files/CAM041858_d.JPG,0,test,40396,lativitta,40396_CAM041858_d.JPG,major
+19N0091,https://zenodo.org/record/4288311/files/19N0091_d.JPG,0,test-2,19327,malleti,19327_19N0091_d.JPG,mimic
+CAM017616,https://zenodo.org/record/4153502/files/CAM017616_d.JPG,0,test-2,19058,plesseni,19058_CAM017616_d.JPG,mimic
+CAM041661,https://zenodo.org/record/4291095/files/CAM041661_d.JPG,0,test,39611,lativitta,39611_CAM041661_d.JPG,major
+19N0026,https://zenodo.org/record/4288311/files/19N0026_d.JPG,0,test-2,19191,malleti,19191_19N0026_d.JPG,mimic
+CAM016527,https://zenodo.org/record/3082688/files/CAM016527_d.JPG,1,test,3685,notabilis x lativitta,3685_CAM016527_d.JPG,major
+CAM041819,https://zenodo.org/record/4291095/files/CAM041819_d.JPG,0,test,40243,lativitta,40243_CAM041819_d.JPG,major
+CAM017446,https://zenodo.org/record/3082688/files/CAM017446_d.JPG,1,test,5126,notabilis x lativitta,5126_CAM017446_d.JPG,major
+CAM045182,https://zenodo.org/record/5526257/files/CAM045182_d.JPG,0,test,43293,cyrbia,43293_CAM045182_d.JPG,minor
+CAM017349,https://zenodo.org/record/3082688/files/CAM017349_d.JPG,1,test,4976,notabilis x lativitta,4976_CAM017349_d.JPG,major
+CAM009313,https://zenodo.org/record/2686762/files/CAM009313_d.JPG,0,test,10478,hydara,10478_CAM009313_d.JPG,minor
+19N1813,https://zenodo.org/record/4288311/files/19N1813_d.JPG,0,test-2,21059,malleti,21059_19N1813_d.JPG,mimic
+CAM041062,https://zenodo.org/record/2714333/files/CAM041062_d.JPG,0,test-2,13763,malleti,13763_CAM041062_d.JPG,mimic
+CAM040192,https://zenodo.org/record/2707828/files/CAM040192_d.JPG,0,test-2,12012,malleti,12012_CAM040192_d.JPG,mimic
+19N0094,https://zenodo.org/record/4288311/files/19N0094_d.JPG,0,test-2,19333,malleti,19333_19N0094_d.JPG,mimic
+CAM041579,https://zenodo.org/record/4291095/files/CAM041579_d.JPG,0,test-2,39284,malleti,39284_CAM041579_d.JPG,mimic
+CAM016125,https://zenodo.org/record/3082688/files/CAM016125_d.JPG,1,test-2,3158,plesseni x malleti,3158_CAM016125_d.JPG,mimic
+CAM018250,https://zenodo.org/record/2702457/files/CAM018250_d.JPG,1,test-2,10974,plesseni x malleti,10974_CAM018250_d.JPG,mimic
+CAM041902,https://zenodo.org/record/4291095/files/CAM041902_d.JPG,0,test,40572,lativitta,40572_CAM041902_d.JPG,major
+19N0954,https://zenodo.org/record/4288311/files/19N0954_d.JPG,0,test-2,20120,malleti,20120_19N0954_d.JPG,mimic
+CAM017118,https://zenodo.org/record/3082688/files/CAM017118_d.JPG,1,test,4565,notabilis x lativitta,4565_CAM017118_d.JPG,major
+CAM041649,https://zenodo.org/record/4291095/files/CAM041649_d.JPG,0,test,39563,lativitta,39563_CAM041649_d.JPG,major
+CAM009190,https://zenodo.org/record/2686762/files/CAM009190_d.JPG,0,test-2,10349,plesseni,10349_CAM009190_d.JPG,mimic
+CAM016205,https://zenodo.org/record/3082688/files/CAM016205_d.JPG,0,test-2,3316,malleti,3316_CAM016205_d.JPG,mimic
+CAM016127,https://zenodo.org/record/3082688/files/CAM016127_d.JPG,1,test-2,3162,plesseni x malleti,3162_CAM016127_d.JPG,mimic
+CAM041882,https://zenodo.org/record/4291095/files/CAM041882_d.JPG,0,test,40492,lativitta,40492_CAM041882_d.JPG,major
+19N1810,https://zenodo.org/record/4288311/files/19N1810_d.JPG,0,test-2,21047,malleti,21047_19N1810_d.JPG,mimic
+CAM016176,https://zenodo.org/record/3082688/files/CAM016176_d.JPG,1,test,3260,notabilis x lativitta,3260_CAM016176_d.JPG,major
+CAM036255,https://zenodo.org/record/5561246/files/CAM036255_d.JPG,0,test,41699,phyllis,41699_CAM036255_d.JPG,minor
+CAM017068,https://zenodo.org/record/3082688/files/CAM017068_d.JPG,1,test-2,4485,plesseni x malleti,4485_CAM017068_d.JPG,mimic
+19N0866,https://zenodo.org/record/4288311/files/19N0866_d.JPG,0,test-2,20072,malleti,20072_19N0866_d.JPG,mimic
+CAM045027,https://zenodo.org/record/5526257/files/CAM045027_d.JPG,0,test,42673,cyrbia,42673_CAM045027_d.JPG,minor
+CAM045246,https://zenodo.org/record/5526257/files/CAM045246_d.JPG,0,test,43547,cyrbia,43547_CAM045246_d.JPG,minor
+CAM017327,https://zenodo.org/record/4153502/files/CAM017327_d.JPG,0,test-2,19010,plesseni,19010_CAM017327_d.JPG,mimic
+CAM017277,https://zenodo.org/record/3082688/files/CAM017277_d.JPG,1,test,4866,notabilis x lativitta,4866_CAM017277_d.JPG,major
+CAM041582,https://zenodo.org/record/4291095/files/CAM041582_d.JPG,0,test-2,39296,malleti,39296_CAM041582_d.JPG,mimic
+CAM041720,https://zenodo.org/record/4291095/files/CAM041720_d.JPG,0,test,39847,lativitta,39847_CAM041720_d.JPG,major
+CAM017067,https://zenodo.org/record/3082688/files/CAM017067_d.JPG,1,test-2,4483,plesseni x malleti,4483_CAM017067_d.JPG,mimic
+CAM041576,https://zenodo.org/record/4291095/files/CAM041576_d.JPG,0,test-2,39272,malleti,39272_CAM041576_d.JPG,mimic
+CAM036165,https://zenodo.org/record/5561246/files/CAM036165_d.JPG,0,test,41431,phyllis,41431_CAM036165_d.JPG,minor
+19N0242,https://zenodo.org/record/4288311/files/19N0242_d.JPG,0,test-2,19629,malleti,19629_19N0242_d.JPG,mimic
+CAM000243,https://zenodo.org/record/2677821/files/CAM000243_d.JPG,0,test,6312,chestertonii,6312_CAM000243_d.JPG,minor
+CAM017450,https://zenodo.org/record/3082688/files/CAM017450_d.JPG,1,test-2,5132,malleti x plesseni,5132_CAM017450_d.JPG,mimic
+CAM017187,https://zenodo.org/record/3082688/files/CAM017187_d.JPG,0,test-2,4694,plesseni,4694_CAM017187_d.JPG,mimic
+CAM016178,https://zenodo.org/record/3082688/files/CAM016178_d.JPG,1,test,3264,notabilis x lativitta,3264_CAM016178_d.JPG,major
+CAM017355,https://zenodo.org/record/4153502/files/CAM017355_d.JPG,0,test-2,19016,plesseni,19016_CAM017355_d.JPG,mimic
+19N1020,https://zenodo.org/record/4288311/files/19N1020_d.JPG,0,test-2,20155,malleti,20155_19N1020_d.JPG,mimic
+CAM017227,https://zenodo.org/record/3082688/files/CAM017227_d.JPG,0,test,4771,notabilis,4771_CAM017227_d.JPG,major
+CAM045172,https://zenodo.org/record/5526257/files/CAM045172_d.JPG,0,test,43253,cyrbia,43253_CAM045172_d.JPG,minor
+19N0304,https://zenodo.org/record/4288311/files/19N0304_d.JPG,0,test-2,19740,malleti,19740_19N0304_d.JPG,mimic
+19N1316,https://zenodo.org/record/4288311/files/19N1316_d.JPG,0,test-2,20271,malleti,20271_19N1316_d.JPG,mimic
+CAM040171,https://zenodo.org/record/2707828/files/CAM040171_d.JPG,0,test-2,11972,malleti,11972_CAM040171_d.JPG,mimic
+CAM041804,https://zenodo.org/record/4291095/files/CAM041804_d.JPG,0,test,40183,lativitta,40183_CAM041804_d.JPG,major
+CAM016035,https://zenodo.org/record/3082688/files/CAM016035_d.JPG,1,test,2979,notabilis x lativitta,2979_CAM016035_d.JPG,major
+CAM017607,https://zenodo.org/record/3082688/files/CAM017607_d.JPG,1,test,5376,notabilis x lativitta,5376_CAM017607_d.JPG,major
+CAM016308,https://zenodo.org/record/4153502/files/CAM016308_D.JPG,1,test,19110,notabilis x lativitta,19110_CAM016308_D.JPG,major
+CAM016407,https://zenodo.org/record/3082688/files/CAM016407_d.JPG,1,test-2,3525,plesseni x malleti,3525_CAM016407_d.JPG,mimic
+CAM045168,https://zenodo.org/record/5526257/files/CAM045168_d.JPG,0,test,43237,cyrbia,43237_CAM045168_d.JPG,minor
+19N0175,https://zenodo.org/record/4288311/files/19N0175_d.JPG,0,test-2,19495,malleti,19495_19N0175_d.JPG,mimic
+CAM041368,https://zenodo.org/record/4291095/files/CAM041368_d.JPG,0,test-2,38452,malleti,38452_CAM041368_d.JPG,mimic
+CAM016712,https://zenodo.org/record/4153502/files/CAM016712_d.JPG,0,test,18960,notabilis,18960_CAM016712_d.JPG,major
+CAM016693,https://zenodo.org/record/4153502/files/CAM016693_d.JPG,0,test-2,18930,plesseni,18930_CAM016693_d.JPG,mimic
+CAM041432,https://zenodo.org/record/4291095/files/CAM041432_d.JPG,0,test,38700,lativitta,38700_CAM041432_d.JPG,major
+CAM040284,https://zenodo.org/record/2707828/files/CAM040284_d.JPG,0,test-2,12184,malleti,12184_CAM040284_d.JPG,mimic
+CAM021060,https://zenodo.org/record/2702457/files/CAM021060_d.JPG,0,test,11549,erato,11549_CAM021060_d.JPG,minor
+CAM009194,https://zenodo.org/record/2686762/files/CAM009194_d.JPG,0,test-2,10357,plesseni,10357_CAM009194_d.JPG,mimic
+CAM009534,https://zenodo.org/record/2686762/files/CAM009534_d.JPG,0,test,10810,petiverana,10810_CAM009534_d.JPG,minor
+F794,https://zenodo.org/record/2555086/files/F794_d.JPG,0,test,38040,demophoon,38040_F794_d.JPG,minor
+19N0955,https://zenodo.org/record/4288311/files/19N0955_d.JPG,0,test-2,20122,malleti,20122_19N0955_d.JPG,mimic
+CAM045174,https://zenodo.org/record/5526257/files/CAM045174_d.JPG,0,test,43261,cyrbia,43261_CAM045174_d.JPG,minor
+CAM017261,https://zenodo.org/record/3082688/files/CAM017261_d.JPG,0,test,4834,notabilis,4834_CAM017261_d.JPG,major
+19N1195,https://zenodo.org/record/4288311/files/19N1195_d.JPG,0,test-2,20223,malleti,20223_19N1195_d.JPG,mimic
+CAM041385,https://zenodo.org/record/4291095/files/CAM041385_d.JPG,0,test,38520,lativitta,38520_CAM041385_d.JPG,major
+CAM041844,https://zenodo.org/record/4291095/files/CAM041844_d.JPG,0,test,40343,lativitta,40343_CAM041844_d.JPG,major
+CAM017083,https://zenodo.org/record/3082688/files/CAM017083_d.JPG,0,test-2,4507,malleti,4507_CAM017083_d.JPG,mimic
+CAM016690,https://zenodo.org/record/4153502/files/CAM016690_d.JPG,0,test-2,18924,plesseni,18924_CAM016690_d.JPG,mimic
+19N1446,https://zenodo.org/record/4288311/files/19N1446_d.JPG,0,test-2,20371,malleti,20371_19N1446_d.JPG,mimic
+CAM041807,https://zenodo.org/record/4291095/files/CAM041807_d.JPG,0,test,40195,lativitta,40195_CAM041807_d.JPG,major
+19N0660,https://zenodo.org/record/4288311/files/19N0660_d.JPG,0,test-2,19950,malleti,19950_19N0660_d.JPG,mimic
+CAM017376,https://zenodo.org/record/4153502/files/CAM017376_d.JPG,0,test-2,19038,plesseni,19038_CAM017376_d.JPG,mimic
+CAM045104,https://zenodo.org/record/5526257/files/CAM045104_d.JPG,0,test,42981,cyrbia,42981_CAM045104_d.JPG,minor
+CAM041728,https://zenodo.org/record/4291095/files/CAM041728_d.JPG,0,test,39879,lativitta,39879_CAM041728_d.JPG,major
+CAM036230,https://zenodo.org/record/5561246/files/CAM036230_d.JPG,0,test,41631,phyllis,41631_CAM036230_d.JPG,minor
+CAM017437,https://zenodo.org/record/3082688/files/CAM017437_d.JPG,1,test-2,5109,plesseni x malleti,5109_CAM017437_d.JPG,mimic
+CAM017347,https://zenodo.org/record/3082688/files/CAM017347_d.JPG,1,test,4972,notabilis x lativitta,4972_CAM017347_d.JPG,major
+19N0255,https://zenodo.org/record/4288311/files/19N0255_d.JPG,0,test-2,19655,malleti,19655_19N0255_d.JPG,mimic
+CS003660,https://zenodo.org/record/2735056/files/CS003660_d.JPG,0,test,41075,venus,41075_CS003660_d.JPG,minor
+CAM016168,https://zenodo.org/record/3082688/files/CAM016168_d.JPG,1,test,3244,notabilis x lativitta,3244_CAM016168_d.JPG,major
+CAM040267,https://zenodo.org/record/2707828/files/CAM040267_d.JPG,0,test-2,12150,malleti,12150_CAM040267_d.JPG,mimic
+CAM017276,https://zenodo.org/record/3082688/files/CAM017276_d.JPG,1,test,4864,notabilis x lativitta,4864_CAM017276_d.JPG,major
+CAM045068,https://zenodo.org/record/5526257/files/CAM045068_d.JPG,0,test,42837,cyrbia,42837_CAM045068_d.JPG,minor
+CAM018520,https://zenodo.org/record/2702457/files/CAM018520_d.JPG,1,test-2,11375,malleti x plesseni,11375_CAM018520_d.JPG,mimic
+19N2078,https://zenodo.org/record/4288311/files/19N2078_d.JPG,0,test-2,21567,malleti,21567_19N2078_d.JPG,mimic
+19N1398,https://zenodo.org/record/4288311/files/19N1398_d.JPG,0,test-2,20339,malleti,20339_19N1398_d.JPG,mimic
+19N2027,https://zenodo.org/record/4288311/files/19N2027_d.JPG,0,test-2,21459,malleti,21459_19N2027_d.JPG,mimic
+CAM040197,https://zenodo.org/record/2707828/files/CAM040197_d.JPG,0,test-2,12020,malleti,12020_CAM040197_d.JPG,mimic
+19N0646,https://zenodo.org/record/4288311/files/19N0646_d.JPG,0,test-2,19938,malleti,19938_19N0646_d.JPG,mimic
+CAM017267,https://zenodo.org/record/3082688/files/CAM017267_d.JPG,1,test-2,4846,plesseni x malleti,4846_CAM017267_d.JPG,mimic
+19N0332,https://zenodo.org/record/4288311/files/19N0332_d.JPG,0,test,19774,erato,19774_19N0332_d.JPG,minor
+CAM017069,https://zenodo.org/record/3082688/files/CAM017069_d.JPG,0,test-2,4487,malleti,4487_CAM017069_d.JPG,mimic
+CAM016149,https://zenodo.org/record/3082688/files/CAM016149_d.JPG,1,test,3206,notabilis x lativitta,3206_CAM016149_d.JPG,major
+CAM016195,https://zenodo.org/record/3082688/files/CAM016195_d.JPG,1,test-2,3298,plesseni x malleti,3298_CAM016195_d.JPG,mimic
+CAM018294,https://zenodo.org/record/2702457/files/CAM018294_d.JPG,1,test-2,11030,plesseni x malleti,11030_CAM018294_d.JPG,mimic
+CAM011449,https://zenodo.org/record/2550097/files/CAM011449_d.JPG,0,test-2,28288,plesseni,28288_CAM011449_d.JPG,mimic
+CAM000169,https://zenodo.org/record/2677821/files/CAM000169_d.JPG,0,test,6170,chestertonii,6170_CAM000169_d.JPG,minor
+CAM016792,https://zenodo.org/record/3082688/files/CAM016792_d.JPG,1,test-2,4006,plesseni x malleti,4006_CAM016792_d.JPG,mimic
+19N0106,https://zenodo.org/record/4288311/files/19N0106_d.JPG,0,test-2,19357,malleti,19357_19N0106_d.JPG,mimic
+CAM016032,https://zenodo.org/record/3082688/files/CAM016032_d.JPG,1,test,2973,notabilis x lativitta,2973_CAM016032_d.JPG,major
+CAM045055,https://zenodo.org/record/5526257/files/CAM045055_d.JPG,0,test,42785,cyrbia,42785_CAM045055_d.JPG,minor
+CS003544,https://zenodo.org/record/2553501/files/CS3544 dorsal.jpeg,0,test-2,25941,malleti,25941_CS3544 dorsal.jpeg,mimic
+CAM045135,https://zenodo.org/record/5526257/files/CAM045135_d.JPG,0,test,43107,cyrbia,43107_CAM045135_d.JPG,minor
+CAM017213,https://zenodo.org/record/3082688/files/CAM017213_d.JPG,0,test,4743,notabilis,4743_CAM017213_d.JPG,major
+CAM017144,https://zenodo.org/record/3082688/files/CAM017144_d.JPG,1,test,4613,notabilis x lativitta,4613_CAM017144_d.JPG,major
+CAM016686,https://zenodo.org/record/4153502/files/CAM016686_d.JPG,0,test-2,18916,plesseni,18916_CAM016686_d.JPG,mimic
+CAM040294,https://zenodo.org/record/2707828/files/CAM040294_d.JPG,0,test-2,12204,malleti,12204_CAM040294_d.JPG,mimic
+CAM017103,https://zenodo.org/record/3082688/files/CAM017103_d.JPG,0,test-2,4543,malleti,4543_CAM017103_d.JPG,mimic
+19N0759,https://zenodo.org/record/4288311/files/19N0759_d.JPG,0,test-2,20024,malleti,20024_19N0759_d.JPG,mimic
+CAM016542,https://zenodo.org/record/3082688/files/CAM016542_d.JPG,0,test-2,3695,malleti,3695_CAM016542_d.JPG,mimic
+19N2279,https://zenodo.org/record/4288311/files/19N2279_d.JPG,0,test-2,22043,malleti,22043_19N2279_d.JPG,mimic
+CS003830,https://zenodo.org/record/2553501/files/CS3830 dorsal.jpeg,0,test-2,25987,malleti,25987_CS3830 dorsal.jpeg,mimic
+CAM041606,https://zenodo.org/record/4291095/files/CAM041606_d.JPG,0,test,39391,lativitta,39391_CAM041606_d.JPG,major
+CAM045158,https://zenodo.org/record/5526257/files/CAM045158_d.JPG,0,test,43197,cyrbia,43197_CAM045158_d.JPG,minor
+CAM016753,https://zenodo.org/record/3082688/files/CAM016753_d.JPG,1,test-2,3942,plesseni x malleti,3942_CAM016753_d.JPG,mimic
+CAM041384,https://zenodo.org/record/4291095/files/CAM041384_d.JPG,0,test,38516,lativitta,38516_CAM041384_d.JPG,major
+CAM017263,https://zenodo.org/record/3082688/files/CAM017263_d.JPG,0,test,4838,notabilis,4838_CAM017263_d.JPG,major
+19N1912,https://zenodo.org/record/4288311/files/19N1912_d.JPG,0,test-2,21219,malleti,21219_19N1912_d.JPG,mimic
+CAM045150,https://zenodo.org/record/5526257/files/CAM045150_d.JPG,0,test,43167,cyrbia,43167_CAM045150_d.JPG,minor
+CAM045061,https://zenodo.org/record/5526257/files/CAM045061_d.JPG,0,test,42809,cyrbia,42809_CAM045061_d.JPG,minor
+19N2250,https://zenodo.org/record/4288311/files/19N2250_d.JPG,0,test-2,21927,malleti,21927_19N2250_d.JPG,mimic
+CAM045035,https://zenodo.org/record/5526257/files/CAM045035_d.JPG,0,test,42705,cyrbia,42705_CAM045035_d.JPG,minor
+CAM045039,https://zenodo.org/record/5526257/files/CAM045039_d.JPG,0,test,42721,cyrbia,42721_CAM045039_d.JPG,minor
+15N136,https://zenodo.org/record/4289223/files/15N136_d.JPG,0,test,15184,chestertonii,15184_15N136_d.JPG,minor
+CAM017314,https://zenodo.org/record/3082688/files/CAM017314_d.JPG,1,test,4912,notabilis x lativitta,4912_CAM017314_d.JPG,major
+CAM041355,https://zenodo.org/record/4291095/files/CAM041355_d.JPG,0,test,38400,lativitta,38400_CAM041355_d.JPG,major
+CAM045255,https://zenodo.org/record/5526257/files/CAM045255_d.JPG,0,test,43583,cyrbia,43583_CAM045255_d.JPG,minor
+CAM041875,https://zenodo.org/record/4291095/files/CAM041875_d.JPG,0,test,40464,lativitta,40464_CAM041875_d.JPG,major
+CAM016154,https://zenodo.org/record/3082688/files/CAM016154_d.JPG,1,test,3216,notabilis x lativitta,3216_CAM016154_d.JPG,major
+CS001002,https://zenodo.org/record/2553501/files/CS1002 dorsal.jpeg,0,test-2,25591,malleti,25591_CS1002 dorsal.jpeg,mimic
+19N0323,https://zenodo.org/record/4288311/files/19N0323_d.JPG,0,test-2,19762,malleti,19762_19N0323_d.JPG,mimic
+19N0102,https://zenodo.org/record/4288311/files/19N0102_d.JPG,0,test-2,19349,malleti,19349_19N0102_d.JPG,mimic
+CAM000057,https://zenodo.org/record/2677821/files/CAM000057_d.JPG,1,test,5949,chestertonii x venus,5949_CAM000057_d.JPG,minor
+19N2011,https://zenodo.org/record/4288311/files/19N2011_d.JPG,0,test-2,21415,malleti,21415_19N2011_d.JPG,mimic
+CAM017265,https://zenodo.org/record/3082688/files/CAM017265_d.JPG,1,test,4842,notabilis x lativitta,4842_CAM017265_d.JPG,major
+19N2270,https://zenodo.org/record/4288311/files/19N2270_d.JPG,0,test-2,22007,malleti,22007_19N2270_d.JPG,mimic
+CAM017266,https://zenodo.org/record/3082688/files/CAM017266_d.JPG,1,test,4844,notabilis x lativitta,4844_CAM017266_d.JPG,major
+CAM017303,https://zenodo.org/record/3082688/files/CAM017303_d.JPG,1,test,4896,notabilis x lativitta,4896_CAM017303_d.JPG,major
+CAM017054,https://zenodo.org/record/3082688/files/CAM017054_d.JPG,1,test,4457,notabilis x lativitta,4457_CAM017054_d.JPG,major
+CAM018285,https://zenodo.org/record/2702457/files/CAM018285_d.JPG,1,test-2,11022,plesseni x malleti,11022_CAM018285_d.JPG,mimic
+19N1909,https://zenodo.org/record/4288311/files/19N1909_d.JPG,0,test-2,21215,malleti,21215_19N1909_d.JPG,mimic
+CAM016924,https://zenodo.org/record/3082688/files/CAM016924_d.JPG,1,test,4249,notabilis x lativitta,4249_CAM016924_d.JPG,major
+CAM016004,https://zenodo.org/record/4153502/files/CAM016004_d.JPG,0,test-2,18849,plesseni,18849_CAM016004_d.JPG,mimic
+CAM040018,https://zenodo.org/record/2707828/files/CAM040018_d.JPG,0,test,11720,dignus,11720_CAM040018_d.JPG,minor
+15N193,https://zenodo.org/record/4289223/files/15N193_d.JPG,0,test,15204,venus,15204_15N193_d.JPG,minor
+CAM016598,https://zenodo.org/record/3082688/files/CAM016598_d.JPG,0,test-2,3783,malleti,3783_CAM016598_d.JPG,mimic
+CAM040039,https://zenodo.org/record/2707828/files/CAM040039_d.JPG,0,test,11758,dignus,11758_CAM040039_d.JPG,minor
+19N1945,https://zenodo.org/record/4288311/files/19N1945_d.JPG,0,test-2,21275,malleti,21275_19N1945_d.JPG,mimic
+CAM016102,https://zenodo.org/record/3082688/files/CAM016102_d.JPG,1,test,3112,notabilis x lativitta,3112_CAM016102_d.JPG,major
+CAM016610,https://zenodo.org/record/3082688/files/CAM016610_d.JPG,0,test-2,3805,malleti,3805_CAM016610_d.JPG,mimic
+CAM017372,https://zenodo.org/record/4153502/files/CAM017372_d.JPG,0,test-2,19034,plesseni,19034_CAM017372_d.JPG,mimic
+CAM045223,https://zenodo.org/record/5526257/files/CAM045223_d.JPG,0,test,43455,cyrbia,43455_CAM045223_d.JPG,minor
+CAM016998,https://zenodo.org/record/3082688/files/CAM016998_d.JPG,1,test,4355,notabilis x lativitta,4355_CAM016998_d.JPG,major
+CAM040281,https://zenodo.org/record/2707828/files/CAM040281_d.JPG,0,test-2,12178,malleti,12178_CAM040281_d.JPG,mimic
+19N0278,https://zenodo.org/record/4288311/files/19N0278_d.JPG,0,test-2,19702,malleti,19702_19N0278_d.JPG,mimic
+CAM017330,https://zenodo.org/record/3082688/files/CAM017330_d.JPG,1,test,4938,notabilis x lativitta,4938_CAM017330_d.JPG,major
+CAM018353,https://zenodo.org/record/2548678/files/CAM018353_v_whitestandard.JPG,0,test-2,17829,malleti,17829_CAM018353_v_whitestandard.JPG,mimic
+CAM017037,https://zenodo.org/record/3082688/files/CAM017037_d.JPG,1,test,4427,notabilis x lativitta,4427_CAM017037_d.JPG,major
+CAM016448,https://zenodo.org/record/3082688/files/CAM016448_d.JPG,1,test,3601,notabilis x lativitta,3601_CAM016448_d.JPG,major
+CAM017192,https://zenodo.org/record/3082688/files/CAM017192_d.JPG,1,test,4704,notabilis x lativitta,4704_CAM017192_d.JPG,major
+15N309,https://zenodo.org/record/4289223/files/15N309_d.JPG,0,test,15228,venus,15228_15N309_d.JPG,minor
+CAM045060,https://zenodo.org/record/5526257/files/CAM045060_d.JPG,0,test,42805,cyrbia,42805_CAM045060_d.JPG,minor
+CAM040282,https://zenodo.org/record/2707828/files/CAM040282_d.JPG,0,test-2,12180,malleti,12180_CAM040282_d.JPG,mimic
+CAM041828,https://zenodo.org/record/4291095/files/CAM041828_d.JPG,0,test,40279,lativitta,40279_CAM041828_d.JPG,major
+CAM016043,https://zenodo.org/record/3082688/files/CAM016043_d.JPG,1,test-2,2995,plesseni x malleti,2995_CAM016043_d.JPG,mimic
+19N0288,https://zenodo.org/record/4288311/files/19N0288_d.JPG,0,test-2,19720,malleti,19720_19N0288_d.JPG,mimic
+19N1348,https://zenodo.org/record/4288311/files/19N1348_d.JPG,0,test-2,20287,malleti,20287_19N1348_d.JPG,mimic
+CAM016863,https://zenodo.org/record/3082688/files/CAM016863_d.JPG,1,test-2,4145,plesseni x malleti,4145_CAM016863_d.JPG,mimic
+19N0107,https://zenodo.org/record/4288311/files/19N0107_d.JPG,0,test-2,19359,malleti,19359_19N0107_d.JPG,mimic
+CAM017074,https://zenodo.org/record/3082688/files/CAM017074_d.JPG,1,test,4497,notabilis x lativitta,4497_CAM017074_d.JPG,major
+CAM016036,https://zenodo.org/record/3082688/files/CAM016036_d.JPG,1,test-2,2981,plesseni x malleti,2981_CAM016036_d.JPG,mimic
+CAM009407,https://zenodo.org/record/2686762/files/CAM009407_d.JPG,0,test-2,10612,malleti,10612_CAM009407_d.JPG,mimic
+CAM016861,https://zenodo.org/record/3082688/files/CAM016861_d.JPG,1,test-2,4141,plesseni x malleti,4141_CAM016861_d.JPG,mimic
+CAM017141,https://zenodo.org/record/3082688/files/CAM017141_d.JPG,1,test,4607,notabilis x lativitta,4607_CAM017141_d.JPG,major
+CAM045155,https://zenodo.org/record/5526257/files/CAM045155_d.JPG,0,test,43187,cyrbia,43187_CAM045155_d.JPG,minor
+CAM017185,https://zenodo.org/record/3082688/files/CAM017185_d.JPG,0,test-2,4690,plesseni,4690_CAM017185_d.JPG,mimic
+CAM041718,https://zenodo.org/record/4291095/files/CAM041718_d.JPG,0,test,39839,lativitta,39839_CAM041718_d.JPG,major
+CAM016184,https://zenodo.org/record/3082688/files/CAM016184_d.JPG,1,test,3276,notabilis x lativitta,3276_CAM016184_d.JPG,major
+CAM041174,https://zenodo.org/record/2714333/files/CAM041174_d.JPG,0,test-2,13985,malleti,13985_CAM041174_d.JPG,mimic
+CAM045036,https://zenodo.org/record/5526257/files/CAM045036_d.JPG,0,test,42709,cyrbia,42709_CAM045036_d.JPG,minor
+CAM017070,https://zenodo.org/record/3082688/files/CAM017070_d.JPG,0,test-2,4489,malleti,4489_CAM017070_d.JPG,mimic
+F907,https://zenodo.org/record/2555086/files/F907_d.JPG,0,test,38184,demophoon,38184_F907_d.JPG,minor
+CAM041657,https://zenodo.org/record/4291095/files/CAM041657_d.JPG,0,test,39595,lativitta,39595_CAM041657_d.JPG,major
+CAM017228,https://zenodo.org/record/3082688/files/CAM017228_d.JPG,0,test,4773,notabilis,4773_CAM017228_d.JPG,major
+CAM016001,https://zenodo.org/record/4153502/files/CAM016001_d.JPG,0,test-2,18843,plesseni,18843_CAM016001_d.JPG,mimic
+CAM018365,https://zenodo.org/record/2702457/files/CAM018365_d.JPG,1,test-2,11130,malleti x plesseni,11130_CAM018365_d.JPG,mimic
+CAM041741,https://zenodo.org/record/4291095/files/CAM041741_d.JPG,0,test,39931,lativitta,39931_CAM041741_d.JPG,major
+CAM017145,https://zenodo.org/record/3082688/files/CAM017145_d.JPG,1,test,4615,notabilis x lativitta,4615_CAM017145_d.JPG,major
+CAM016315,https://zenodo.org/record/4153502/files/CAM016315_D.JPG,0,test,19116,notabilis,19116_CAM016315_D.JPG,major
+CAM041525,https://zenodo.org/record/4291095/files/CAM041525_d.JPG,0,test-2,39072,malleti,39072_CAM041525_d.JPG,mimic
+CAM040258,https://zenodo.org/record/2707828/files/CAM040258_d.JPG,0,test-2,12132,malleti,12132_CAM040258_d.JPG,mimic
+CAM041547,https://zenodo.org/record/4291095/files/CAM041547_d.JPG,0,test-2,39160,malleti,39160_CAM041547_d.JPG,mimic
+CAM016293,https://zenodo.org/record/2553977/files/16293_H_melpomene_plesseni_D.JPG.jpg,0,test-2,26047,plesseni,26047_16293_H_melpomene_plesseni_D.JPG.jpg,mimic
+F809,https://zenodo.org/record/2555086/files/F809_d.JPG,0,test,38048,demophoon,38048_F809_d.JPG,minor
+CAM016170,https://zenodo.org/record/3082688/files/CAM016170_d.JPG,1,test,3248,notabilis x lativitta,3248_CAM016170_d.JPG,major
+19N1333,https://zenodo.org/record/4288311/files/19N1333_d.JPG,0,test-2,20281,malleti,20281_19N1333_d.JPG,mimic
+19N0528,https://zenodo.org/record/4288311/files/19N0528_d.JPG,0,test-2,19882,malleti,19882_19N0528_d.JPG,mimic
+15N115,https://zenodo.org/record/4289223/files/15N115_d.JPG,0,test,14955,venus,14955_15N115_d.JPG,minor
+CAM016644,https://zenodo.org/record/3082688/files/CAM016644_d.JPG,1,test,3823,notabilis x lativitta,3823_CAM016644_d.JPG,major
+CAM041713,https://zenodo.org/record/4291095/files/CAM041713_d.JPG,0,test,39819,lativitta,39819_CAM041713_d.JPG,major
+CAM041052,https://zenodo.org/record/2714333/files/CAM041052_d.JPG,0,test-2,13743,malleti,13743_CAM041052_d.JPG,mimic
+CAM016826,https://zenodo.org/record/3082688/files/CAM016826_d.JPG,1,test-2,4074,plesseni x malleti,4074_CAM016826_d.JPG,mimic
+19N2118,https://zenodo.org/record/4288311/files/19N2118_d.JPG,0,test-2,21623,malleti,21623_19N2118_d.JPG,mimic
+CAM009309,https://zenodo.org/record/2686762/files/CAM009309_d.JPG,0,test,10470,hydara,10470_CAM009309_d.JPG,minor
+CAM017236,https://zenodo.org/record/3082688/files/CAM017236_d.JPG,0,test,4789,notabilis,4789_CAM017236_d.JPG,major
+19N2144,https://zenodo.org/record/4288311/files/19N2144_d.JPG,0,test-2,21679,malleti,21679_19N2144_d.JPG,mimic
+CAM045254,https://zenodo.org/record/5526257/files/CAM045254_d.JPG,0,test,43579,cyrbia,43579_CAM045254_d.JPG,minor
+CAM009188,https://zenodo.org/record/2686762/files/CAM009188_d.JPG,0,test-2,10345,plesseni,10345_CAM009188_d.JPG,mimic
+F864,https://zenodo.org/record/2555086/files/F864_d.JPG,0,test,38104,demophoon,38104_F864_d.JPG,minor
+CAM016521,https://zenodo.org/record/3082688/files/CAM016521_d.JPG,1,test,3673,notabilis x lativitta,3673_CAM016521_d.JPG,major
+CAM016913,https://zenodo.org/record/4153502/files/CAM016913_d.JPG,0,test-2,18988,plesseni,18988_CAM016913_d.JPG,mimic
+CAM040149,https://zenodo.org/record/2707828/files/CAM040149_d.JPG,0,test-2,11934,malleti,11934_CAM040149_d.JPG,mimic
+19N0280,https://zenodo.org/record/4288311/files/19N0280_d.JPG,0,test-2,19706,malleti,19706_19N0280_d.JPG,mimic
+CS002277,https://zenodo.org/record/2735056/files/CS002277_d.JPG,0,test,40863,venus,40863_CS002277_d.JPG,minor
+19N0372,https://zenodo.org/record/4288311/files/19N0372_d.JPG,0,test-2,19786,malleti,19786_19N0372_d.JPG,mimic
+CAM045175,https://zenodo.org/record/5526257/files/CAM045175_d.JPG,0,test,43265,cyrbia,43265_CAM045175_d.JPG,minor
+CAM041390,https://zenodo.org/record/4291095/files/CAM041390_d.JPG,0,test,38540,lativitta,38540_CAM041390_d.JPG,major
+19N0983,https://zenodo.org/record/4288311/files/19N0983_d.JPG,0,test-2,20139,malleti,20139_19N0983_d.JPG,mimic
+CAM045045,https://zenodo.org/record/5526257/files/CAM045045_d.JPG,0,test,42745,cyrbia,42745_CAM045045_d.JPG,minor
+CAM016100,https://zenodo.org/record/3082688/files/CAM016100_d.JPG,1,test-2,3108,plesseni x malleti,3108_CAM016100_d.JPG,mimic
+19N0150,https://zenodo.org/record/4288311/files/19N0150_d.JPG,0,test-2,19445,malleti,19445_19N0150_d.JPG,mimic
+CAM041706,https://zenodo.org/record/4291095/files/CAM041706_d.JPG,0,test,39791,lativitta,39791_CAM041706_d.JPG,major
+CAM017199,https://zenodo.org/record/3082688/files/CAM017199_d.JPG,0,test,4717,notabilis,4717_CAM017199_d.JPG,major
+CAM045022,https://zenodo.org/record/5526257/files/CAM045022_d.JPG,0,test,42653,cyrbia,42653_CAM045022_d.JPG,minor
+CAM041693,https://zenodo.org/record/4291095/files/CAM041693_d.JPG,0,test,39739,lativitta,39739_CAM041693_d.JPG,major
+CAM017250,https://zenodo.org/record/3082688/files/CAM017250_d.JPG,0,test,4817,notabilis,4817_CAM017250_d.JPG,major
+CAM036290,https://zenodo.org/record/5561246/files/CAM036290_d.JPG,0,test,41815,phyllis,41815_CAM036290_d.JPG,minor
+19N1212,https://zenodo.org/record/4288311/files/19N1212_d.JPG,0,test-2,20231,malleti,20231_19N1212_d.JPG,mimic
+CAM036214,https://zenodo.org/record/5561246/files/CAM036214_d.JPG,0,test,41571,phyllis,41571_CAM036214_d.JPG,minor
+CAM017084,https://zenodo.org/record/3082688/files/CAM017084_d.JPG,1,test-2,4509,plesseni x malleti,4509_CAM017084_d.JPG,mimic
+CAM045003,https://zenodo.org/record/5526257/files/CAM045003_d.JPG,0,test,42571,cyrbia,42571_CAM045003_d.JPG,minor
+CAM041380,https://zenodo.org/record/4291095/files/CAM041380_d.JPG,0,test,38500,lativitta,38500_CAM041380_d.JPG,major
+CAM016305,https://zenodo.org/record/4153502/files/CAM016305_d.JPG,0,test,18864,notabilis,18864_CAM016305_d.JPG,major
+19N1377,https://zenodo.org/record/4288311/files/19N1377_d.JPG,0,test-2,20309,malleti,20309_19N1377_d.JPG,mimic
+F866,https://zenodo.org/record/2555086/files/F866_d.JPG,0,test,38112,demophoon,38112_F866_d.JPG,minor
+CAM040253,https://zenodo.org/record/2707828/files/CAM040253_d.JPG,0,test-2,12122,malleti,12122_CAM040253_d.JPG,mimic
+CAM016317,https://zenodo.org/record/4153502/files/CAM016317_D.JPG,1,test,19120,notabilis x lativitta,19120_CAM016317_D.JPG,major
+CAM045264,https://zenodo.org/record/5526257/files/CAM045264_d.JPG,0,test,43619,cyrbia,43619_CAM045264_d.JPG,minor
+CAM016458,https://zenodo.org/record/3082688/files/CAM016458_d.JPG,1,test,3615,notabilis x lativitta,3615_CAM016458_d.JPG,major
+CAM016073,https://zenodo.org/record/3082688/files/CAM016073_d.JPG,0,test-2,3054,plesseni,3054_CAM016073_d.JPG,mimic
+CAM016541,https://zenodo.org/record/3082688/files/CAM016541_d.JPG,0,test-2,3693,malleti,3693_CAM016541_d.JPG,mimic
+19N1389,https://zenodo.org/record/4288311/files/19N1389_d.JPG,0,test-2,20327,malleti,20327_19N1389_d.JPG,mimic
+CAM017776,https://zenodo.org/record/3082688/files/CAM017776_d.JPG,1,test-2,5540,malleti x plesseni,5540_CAM017776_d.JPG,mimic
+CAM016506,https://zenodo.org/record/3082688/files/CAM016506_d.JPG,0,test-2,3645,malleti,3645_CAM016506_d.JPG,mimic
+19N0061,https://zenodo.org/record/4288311/files/19N0061_d.JPG,0,test-2,19267,malleti,19267_19N0061_d.JPG,mimic
+CAM016042,https://zenodo.org/record/3082688/files/CAM016042_d.JPG,1,test-2,2993,plesseni x malleti,2993_CAM016042_d.JPG,mimic
+CAM017178,https://zenodo.org/record/3082688/files/CAM017178_d.JPG,0,test,4676,notabilis,4676_CAM017178_d.JPG,major
+CAM045136,https://zenodo.org/record/5526257/files/CAM045136_d.JPG,0,test,43111,cyrbia,43111_CAM045136_d.JPG,minor
+F8621,https://zenodo.org/record/2555086/files/F8621_d.JPG,0,test,38392,demophoon,38392_F8621_d.JPG,minor
+CS000586,https://zenodo.org/record/2553501/files/CS586 dorsal.jpeg,0,test-2,26005,malleti,26005_CS586 dorsal.jpeg,mimic
+CAM016251,https://zenodo.org/record/3082688/files/CAM016251_d.JPG,1,test-2,3362,plesseni x malleti,3362_CAM016251_d.JPG,mimic
+CAM017296,https://zenodo.org/record/3082688/files/CAM017296_d.JPG,1,test,4884,notabilis x lativitta,4884_CAM017296_d.JPG,major
+19N0015,https://zenodo.org/record/4288311/files/19N0015_d.JPG,0,test-2,19169,malleti,19169_19N0015_d.JPG,mimic
+CAM045226,https://zenodo.org/record/5526257/files/CAM045226_d.JPG,0,test,43467,cyrbia,43467_CAM045226_d.JPG,minor
+CAM017215,https://zenodo.org/record/3082688/files/CAM017215_d.JPG,1,test,4747,notabilis x lativitta,4747_CAM017215_d.JPG,major
+CAM016098,https://zenodo.org/record/3082688/files/CAM016098_d.JPG,1,test-2,3104,plesseni x malleti,3104_CAM016098_d.JPG,mimic
+CAM041611,https://zenodo.org/record/4291095/files/CAM041611_d.JPG,0,test,39411,lativitta,39411_CAM041611_d.JPG,major
+CAM009553,https://zenodo.org/record/2686762/files/CAM009553_d.JPG,1,test,10848,hydara x petiverana,10848_CAM009553_d.JPG,minor
+CAM041884,https://zenodo.org/record/4291095/files/CAM041884_d.JPG,0,test,40500,lativitta,40500_CAM041884_d.JPG,major
+CAM041429,https://zenodo.org/record/4291095/files/CAM041429_d.JPG,0,test,38688,lativitta,38688_CAM041429_d.JPG,major
+CAM009310,https://zenodo.org/record/2686762/files/CAM009310_d.JPG,0,test,10472,hydara,10472_CAM009310_d.JPG,minor
+CAM017867,https://zenodo.org/record/3082688/files/CAM017867_d.JPG,1,test-2,5661,malleti x plesseni,5661_CAM017867_d.JPG,mimic
+CAM017282,https://zenodo.org/record/3082688/files/CAM017282_d.JPG,1,test-2,4876,plesseni x malleti,4876_CAM017282_d.JPG,mimic
+CAM041654,https://zenodo.org/record/4291095/files/CAM041654_d.JPG,0,test,39583,lativitta,39583_CAM041654_d.JPG,major
+CAM045167,https://zenodo.org/record/5526257/files/CAM045167_d.JPG,0,test,43233,cyrbia,43233_CAM045167_d.JPG,minor
+CAM036188,https://zenodo.org/record/5561246/files/CAM036188_d.JPG,0,test,41483,phyllis,41483_CAM036188_d.JPG,minor
+CAM041595,https://zenodo.org/record/4291095/files/CAM041595_d.JPG,0,test,39347,lativitta,39347_CAM041595_d.JPG,major
+CAM017019,https://zenodo.org/record/3082688/files/CAM017019_d.JPG,0,test-2,4393,malleti,4393_CAM017019_d.JPG,mimic
+CAM000239,https://zenodo.org/record/2677821/files/CAM000239_d.JPG,0,test,6304,chestertonii,6304_CAM000239_d.JPG,minor
+CAM016005,https://zenodo.org/record/4153502/files/CAM016005_d.JPG,0,test-2,18851,plesseni,18851_CAM016005_d.JPG,mimic
+CAM041736,https://zenodo.org/record/4291095/files/CAM041736_d.JPG,0,test,39911,lativitta,39911_CAM041736_d.JPG,major
+CAM016139,https://zenodo.org/record/3082688/files/CAM016139_d.JPG,1,test,3186,notabilis x lativitta,3186_CAM016139_d.JPG,major
+CAM017356,https://zenodo.org/record/4153502/files/CAM017356_d.JPG,0,test-2,19018,plesseni,19018_CAM017356_d.JPG,mimic
+CAM041841,https://zenodo.org/record/4291095/files/CAM041841_d.JPG,0,test,40331,lativitta,40331_CAM041841_d.JPG,major
+CAM016809,https://zenodo.org/record/3082688/files/CAM016809_d.JPG,1,test-2,4040,plesseni x malleti,4040_CAM016809_d.JPG,mimic
+CAM016452,https://zenodo.org/record/3082688/files/CAM016452_d.JPG,1,test,3607,notabilis x lativitta,3607_CAM016452_d.JPG,major
+CAM011411,https://zenodo.org/record/2550097/files/CAM011411_d.JPG,0,test-2,28144,plesseni,28144_CAM011411_d.JPG,mimic
+19N1110,https://zenodo.org/record/4288311/files/19N1110_d.JPG,0,test-2,20186,malleti,20186_19N1110_d.JPG,mimic
+19N0746,https://zenodo.org/record/4288311/files/19N0746_d.JPG,0,test-2,20022,malleti,20022_19N0746_d.JPG,mimic
+CAM009161,https://zenodo.org/record/2686762/files/CAM009161_d.JPG,0,test-2,10291,plesseni,10291_CAM009161_d.JPG,mimic
+CAM045262,https://zenodo.org/record/5526257/files/CAM045262_d.JPG,0,test,43611,cyrbia,43611_CAM045262_d.JPG,minor
+CAM017454,https://zenodo.org/record/3082688/files/CAM017454_d.JPG,1,test-2,5138,plesseni x malleti,5138_CAM017454_d.JPG,mimic
+CAM016164,https://zenodo.org/record/3082688/files/CAM016164_d.JPG,1,test,3236,notabilis x lativitta,3236_CAM016164_d.JPG,major
+CAM016990,https://zenodo.org/record/3082688/files/CAM016990_d.JPG,0,test-2,4342,malleti,4342_CAM016990_d.JPG,mimic
+19N0095,https://zenodo.org/record/4288311/files/19N0095_d.JPG,0,test-2,19335,malleti,19335_19N0095_d.JPG,mimic
+CAM017773,https://zenodo.org/record/3082688/files/CAM017773_d.JPG,1,test,5534,lativitta x notabilis,5534_CAM017773_d.JPG,major
+CAM041873,https://zenodo.org/record/4291095/files/CAM041873_d.JPG,0,test,40456,lativitta,40456_CAM041873_d.JPG,major
+19N0115,https://zenodo.org/record/4288311/files/19N0115_d.JPG,0,test-2,19375,malleti,19375_19N0115_d.JPG,mimic
+19N1763,https://zenodo.org/record/4288311/files/19N1763_d.JPG,0,test-2,20979,malleti,20979_19N1763_d.JPG,mimic
+CAM041431,https://zenodo.org/record/4291095/files/CAM041431_d.JPG,0,test,38696,lativitta,38696_CAM041431_d.JPG,major
+CAM016323,https://zenodo.org/record/3082688/files/CAM016323_d.JPG,0,test-2,3420,plesseni,3420_CAM016323_d.JPG,mimic
+CAM017620,https://zenodo.org/record/4153502/files/CAM017620_d.JPG,0,test-2,19066,plesseni,19066_CAM017620_d.JPG,mimic
+CAM041768,https://zenodo.org/record/4291095/files/CAM041768_d.JPG,0,test,40039,lativitta,40039_CAM041768_d.JPG,major
+CAM040023,https://zenodo.org/record/2707828/files/CAM040023_d.JPG,0,test-2,11730,malleti,11730_CAM040023_d.JPG,mimic
+CAM041655,https://zenodo.org/record/4291095/files/CAM041655_d.JPG,0,test,39587,lativitta,39587_CAM041655_d.JPG,major
+19N1063,https://zenodo.org/record/4288311/files/19N1063_d.JPG,0,test-2,20170,malleti,20170_19N1063_d.JPG,mimic
+CAM017704,https://zenodo.org/record/1748277/files/CAM017704_d_whitestandard.JPG,0,test-2,16079,plesseni,16079_CAM017704_d_whitestandard.JPG,mimic
+CAM041773,https://zenodo.org/record/4291095/files/CAM041773_d.JPG,0,test,40059,lativitta,40059_CAM041773_d.JPG,major
+CAM045019,https://zenodo.org/record/5526257/files/CAM045019_d.JPG,0,test,42641,cyrbia,42641_CAM045019_d.JPG,minor
+CAM041886,https://zenodo.org/record/4291095/files/CAM041886_d.JPG,0,test,40508,lativitta,40508_CAM041886_d.JPG,major
+CAM016356,https://zenodo.org/record/4153502/files/CAM016356_D.JPG,0,test,19126,notabilis,19126_CAM016356_D.JPG,major
+CAM016034,https://zenodo.org/record/3082688/files/CAM016034_d.JPG,1,test,2977,notabilis x lativitta,2977_CAM016034_d.JPG,major
+CAM016234,https://zenodo.org/record/3082688/files/CAM016234_d.JPG,0,test-2,3344,malleti,3344_CAM016234_d.JPG,mimic
+19N1850,https://zenodo.org/record/4288311/files/19N1850_d.JPG,0,test-2,21103,malleti,21103_19N1850_d.JPG,mimic
+CAM017692,https://zenodo.org/record/3082688/files/CAM017692_d.JPG,1,test-2,5448,malleti x plesseni,5448_CAM017692_d.JPG,mimic
+CAM016145,https://zenodo.org/record/3082688/files/CAM016145_d.JPG,1,test,3198,notabilis x lativitta,3198_CAM016145_d.JPG,major
+CAM017238,https://zenodo.org/record/3082688/files/CAM017238_d.JPG,0,test,4793,notabilis,4793_CAM017238_d.JPG,major
+19N0715,https://zenodo.org/record/4288311/files/19N0715_d.JPG,0,test-2,20008,malleti,20008_19N0715_d.JPG,mimic
+CAM016122,https://zenodo.org/record/3082688/files/CAM016122_d.JPG,1,test-2,3152,plesseni x malleti,3152_CAM016122_d.JPG,mimic
+CAM016023,https://zenodo.org/record/3082688/files/CAM016023_d.JPG,1,test,2955,notabilis x lativitta,2955_CAM016023_d.JPG,major
+CAM045177,https://zenodo.org/record/5526257/files/CAM045177_d.JPG,0,test,43273,cyrbia,43273_CAM045177_d.JPG,minor
+CAM041715,https://zenodo.org/record/4291095/files/CAM041715_d.JPG,0,test,39827,lativitta,39827_CAM041715_d.JPG,major
+15N113,https://zenodo.org/record/4289223/files/15N113_d.JPG,0,test,15173,venus,15173_15N113_d.JPG,minor
+CAM016906,https://zenodo.org/record/4153502/files/CAM016906_d.JPG,0,test-2,18976,plesseni,18976_CAM016906_d.JPG,mimic
+CAM016295,https://zenodo.org/record/3082688/files/CAM016295_d.JPG,0,test-2,3406,plesseni,3406_CAM016295_d.JPG,mimic
+CS003109,https://zenodo.org/record/2553501/files/CS3109 dorsal.jpeg,0,test-2,25847,malleti,25847_CS3109 dorsal.jpeg,mimic
+CAM017127,https://zenodo.org/record/3082688/files/CAM017127_d.JPG,1,test,4583,notabilis x lativitta,4583_CAM017127_d.JPG,major
+CAM016021,https://zenodo.org/record/3082688/files/CAM016021_d.JPG,1,test,2951,notabilis x lativitta,2951_CAM016021_d.JPG,major
+CAM017087,https://zenodo.org/record/3082688/files/CAM017087_d.JPG,1,test,4515,notabilis x lativitta,4515_CAM017087_d.JPG,major
+CAM021054,https://zenodo.org/record/2702457/files/CAM021054_d.JPG,1,test,11540,hydara x erato,11540_CAM021054_d.JPG,minor
+CAM041219,https://zenodo.org/record/2714333/files/CAM041219_d.JPG,0,test-2,14075,malleti,14075_CAM041219_d.JPG,mimic
+CAM017287,https://zenodo.org/record/3082688/files/CAM017287_d.JPG,1,test,4882,notabilis x lativitta,4882_CAM017287_d.JPG,major
+CAM016174,https://zenodo.org/record/3082688/files/CAM016174_d.JPG,1,test,3256,notabilis x lativitta,3256_CAM016174_d.JPG,major
+CAM016567,https://zenodo.org/record/3082688/files/CAM016567_d.JPG,0,test-2,3739,malleti,3739_CAM016567_d.JPG,mimic
+CAM041618,https://zenodo.org/record/4291095/files/CAM041618_d.JPG,0,test,39439,lativitta,39439_CAM041618_d.JPG,major
+CAM017163,https://zenodo.org/record/3082688/files/CAM017163_d.JPG,1,test,4649,notabilis x lativitta,4649_CAM017163_d.JPG,major
+CAM016696,https://zenodo.org/record/4153502/files/CAM016696_d.JPG,0,test-2,18936,plesseni,18936_CAM016696_d.JPG,mimic
+CAM041438,https://zenodo.org/record/4291095/files/CAM041438_d.JPG,0,test,38724,lativitta,38724_CAM041438_d.JPG,major
+CAM016969,https://zenodo.org/record/3082688/files/CAM016969_d.JPG,1,test,4308,notabilis x lativitta,4308_CAM016969_d.JPG,major
+CAM041363,https://zenodo.org/record/4291095/files/CAM041363_d.JPG,0,test,38432,lativitta,38432_CAM041363_d.JPG,major
+CAM017615,https://zenodo.org/record/4153502/files/CAM017615_d.JPG,0,test-2,19056,plesseni,19056_CAM017615_d.JPG,mimic
+CAM041276,https://zenodo.org/record/2714333/files/CAM041276_d.JPG,0,test-2,14188,malleti,14188_CAM041276_d.JPG,mimic
+CAM009306,https://zenodo.org/record/2686762/files/CAM009306_d.JPG,0,test,10464,hydara,10464_CAM009306_d.JPG,minor
+CAM016151,https://zenodo.org/record/3082688/files/CAM016151_d.JPG,1,test,3210,notabilis x lativitta,3210_CAM016151_d.JPG,major
+CAM017053,https://zenodo.org/record/3082688/files/CAM017053_d.JPG,1,test-2,4455,plesseni x malleti,4455_CAM017053_d.JPG,mimic
+CAM017747,https://zenodo.org/record/3082688/files/CAM017747_d.JPG,1,test-2,5504,malleti x plesseni,5504_CAM017747_d.JPG,mimic
+19N0667,https://zenodo.org/record/4288311/files/19N0667_d.JPG,0,test-2,19958,malleti,19958_19N0667_d.JPG,mimic
+CAM041604,https://zenodo.org/record/4291095/files/CAM041604_d.JPG,0,test,39383,lativitta,39383_CAM041604_d.JPG,major
+CAM045173,https://zenodo.org/record/5526257/files/CAM045173_d.JPG,0,test,43257,cyrbia,43257_CAM045173_d.JPG,minor
+CAM016544,https://zenodo.org/record/3082688/files/CAM016544_d.JPG,0,test-2,3697,malleti,3697_CAM016544_d.JPG,mimic
+CAM041613,https://zenodo.org/record/4291095/files/CAM041613_d.JPG,0,test,39419,lativitta,39419_CAM041613_d.JPG,major
+19N2260,https://zenodo.org/record/4288311/files/19N2260_d.JPG,0,test-2,21967,malleti,21967_19N2260_d.JPG,mimic
+CAM017033,https://zenodo.org/record/3082688/files/CAM017033_d.JPG,1,test,4421,notabilis x lativitta,4421_CAM017033_d.JPG,major
+CAM017089,https://zenodo.org/record/3082688/files/CAM017089_d.JPG,0,test-2,4519,malleti,4519_CAM017089_d.JPG,mimic
+19N2082,https://zenodo.org/record/4288311/files/19N2082_d.JPG,0,test-2,21579,malleti,21579_19N2082_d.JPG,mimic
+CAM016428,https://zenodo.org/record/3082688/files/CAM016428_d.JPG,1,test-2,3567,plesseni x malleti,3567_CAM016428_d.JPG,mimic
+CAM017315,https://zenodo.org/record/3082688/files/CAM017315_d.JPG,1,test,4914,notabilis x lativitta,4914_CAM017315_d.JPG,major
+CAM017179,https://zenodo.org/record/3082688/files/CAM017179_d.JPG,0,test,4678,notabilis,4678_CAM017179_d.JPG,major
+CAM009228,https://zenodo.org/record/2686762/files/CAM009228_d.JPG,0,test-2,10424,plesseni,10424_CAM009228_d.JPG,mimic
+19N0946,https://zenodo.org/record/4288311/files/19N0946_d.JPG,0,test-2,20112,malleti,20112_19N0946_d.JPG,mimic
+CAM016702,https://zenodo.org/record/4153502/files/CAM016702_d.JPG,0,test,18948,notabilis,18948_CAM016702_d.JPG,major
+19N0673,https://zenodo.org/record/4288311/files/19N0673_d.JPG,0,test-2,19968,malleti,19968_19N0673_d.JPG,mimic
+CAM017398,https://zenodo.org/record/3082688/files/CAM017398_d.JPG,1,test,5039,notabilis x lativitta,5039_CAM017398_d.JPG,major
+CAM016117,https://zenodo.org/record/3082688/files/CAM016117_d.JPG,1,test-2,3142,plesseni x malleti,3142_CAM016117_d.JPG,mimic
+F858,https://zenodo.org/record/2555086/files/F858_d.JPG,0,test,38096,demophoon,38096_F858_d.JPG,minor
+19N0809,https://zenodo.org/record/4288311/files/19N0809_d.JPG,0,test-2,20034,malleti,20034_19N0809_d.JPG,mimic
+CAM045218,https://zenodo.org/record/5526257/files/CAM045218_d.JPG,0,test,43435,cyrbia,43435_CAM045218_d.JPG,minor
+CAM016024,https://zenodo.org/record/3082688/files/CAM016024_d.JPG,1,test,2957,notabilis x lativitta,2957_CAM016024_d.JPG,major
+CAM017703,https://zenodo.org/record/3082688/files/CAM017703_d.JPG,1,test,5458,lativitta x notabilis,5458_CAM017703_d.JPG,major
+CS000583,https://zenodo.org/record/2553501/files/CS583 dorsal.jpeg,0,test-2,26003,malleti,26003_CS583 dorsal.jpeg,mimic
+CAM017123,https://zenodo.org/record/3082688/files/CAM017123_d.JPG,1,test-2,4575,plesseni x malleti,4575_CAM017123_d.JPG,mimic
+CAM017000,https://zenodo.org/record/3082688/files/CAM017000_d.JPG,1,test,4359,notabilis x lativitta,4359_CAM017000_d.JPG,major
+19N1997,https://zenodo.org/record/4288311/files/19N1997_d.JPG,0,test-2,21387,malleti,21387_19N1997_d.JPG,mimic
+CAM016313,https://zenodo.org/record/3082688/files/CAM016313_d.JPG,1,test-2,3418,plesseni x malleti,3418_CAM016313_d.JPG,mimic
+CAM041697,https://zenodo.org/record/4291095/files/CAM041697_d.JPG,0,test,39755,lativitta,39755_CAM041697_d.JPG,major
+CAM041216,https://zenodo.org/record/2714333/files/CAM041216_d.JPG,0,test-2,14069,malleti,14069_CAM041216_d.JPG,mimic
+CAM016765,https://zenodo.org/record/3082688/files/CAM016765_d.JPG,1,test-2,3966,plesseni x malleti,3966_CAM016765_d.JPG,mimic
+19N0647,https://zenodo.org/record/4288311/files/19N0647_d.JPG,0,test-2,19940,malleti,19940_19N0647_d.JPG,mimic
+19N0033,https://zenodo.org/record/4288311/files/19N0033_d.JPG,0,test-2,19206,malleti,19206_19N0033_d.JPG,mimic
+CAM017085,https://zenodo.org/record/3082688/files/CAM017085_d.JPG,1,test,4511,notabilis x lativitta,4511_CAM017085_d.JPG,major
+CAM045186,https://zenodo.org/record/5526257/files/CAM045186_d.JPG,0,test,43309,cyrbia,43309_CAM045186_d.JPG,minor
+19N0012,https://zenodo.org/record/4288311/files/19N0012_d.JPG,0,test-2,19163,malleti,19163_19N0012_d.JPG,mimic
+CAM041435,https://zenodo.org/record/4291095/files/CAM041435_d.JPG,0,test,38712,lativitta,38712_CAM041435_d.JPG,major
+CAM041765,https://zenodo.org/record/4291095/files/CAM041765_d.JPG,0,test,40027,lativitta,40027_CAM041765_d.JPG,major
+19N0666,https://zenodo.org/record/4288311/files/19N0666_d.JPG,0,test-2,19956,malleti,19956_19N0666_d.JPG,mimic
+CAM041051,https://zenodo.org/record/2714333/files/CAM041051_d.JPG,0,test-2,13741,malleti,13741_CAM041051_d.JPG,mimic
+CAM021031,https://zenodo.org/record/2702457/files/CAM021031_d.JPG,1,test,11496,hydara x amalfreda,11496_CAM021031_d.JPG,minor
+CAM009438,https://zenodo.org/record/2686762/files/CAM009438_d.JPG,0,test-2,10674,plesseni,10674_CAM009438_d.JPG,mimic
+CAM017408,https://zenodo.org/record/3082688/files/CAM017408_d.JPG,1,test,5057,notabilis x lativitta,5057_CAM017408_d.JPG,major
+CAM045066,https://zenodo.org/record/5526257/files/CAM045066_d.JPG,0,test,42829,cyrbia,42829_CAM045066_d.JPG,minor
+CAM009321,https://zenodo.org/record/2686762/files/CAM009321_d.JPG,0,test,10494,hydara,10494_CAM009321_d.JPG,minor
+CAM016659,https://zenodo.org/record/3082688/files/CAM016659_d.JPG,1,test-2,3853,plesseni x malleti,3853_CAM016659_d.JPG,mimic
+CAM041727,https://zenodo.org/record/4291095/files/CAM041727_d.JPG,0,test,39875,lativitta,39875_CAM041727_d.JPG,major
+CAM041608,https://zenodo.org/record/4291095/files/CAM041608_d.JPG,0,test,39399,lativitta,39399_CAM041608_d.JPG,major
+CAM009206,https://zenodo.org/record/2686762/files/CAM009206_d.JPG,0,test-2,10381,plesseni,10381_CAM009206_d.JPG,mimic
+19N2253,https://zenodo.org/record/4288311/files/19N2253_d.JPG,0,test-2,21939,malleti,21939_19N2253_d.JPG,mimic
+CAM041892,https://zenodo.org/record/4291095/files/CAM041892_d.JPG,0,test,40532,lativitta,40532_CAM041892_d.JPG,major
+CAM017217,https://zenodo.org/record/3082688/files/CAM017217_d.JPG,0,test,4751,notabilis,4751_CAM017217_d.JPG,major
+19N0437,https://zenodo.org/record/4288311/files/19N0437_d.JPG,0,test-2,19820,malleti,19820_19N0437_d.JPG,mimic
+CAM041627,https://zenodo.org/record/4291095/files/CAM041627_d.JPG,0,test,39475,lativitta,39475_CAM041627_d.JPG,major
+CAM016408,https://zenodo.org/record/3082688/files/CAM016408_d.JPG,1,test-2,3527,plesseni x malleti,3527_CAM016408_d.JPG,mimic
+CAM045015,https://zenodo.org/record/5526257/files/CAM045015_d.JPG,0,test,42625,cyrbia,42625_CAM045015_d.JPG,minor
+CAM041209,https://zenodo.org/record/2714333/files/CAM041209_d.JPG,0,test-2,14055,malleti,14055_CAM041209_d.JPG,mimic
+CAM041822,https://zenodo.org/record/4291095/files/CAM041822_d.JPG,0,test,40255,lativitta,40255_CAM041822_d.JPG,major
+CAM041883,https://zenodo.org/record/4291095/files/CAM041883_d.JPG,0,test,40496,lativitta,40496_CAM041883_d.JPG,major
+F846,https://zenodo.org/record/2555086/files/F846_d.JPG,0,test,38068,demophoon,38068_F846_d.JPG,minor
+CAM017324,https://zenodo.org/record/3082688/files/CAM017324_d.JPG,0,test,4932,notabilis,4932_CAM017324_d.JPG,major
+CAM041838,https://zenodo.org/record/4291095/files/CAM041838_d.JPG,0,test,40319,lativitta,40319_CAM041838_d.JPG,major
+CAM041897,https://zenodo.org/record/4291095/files/CAM041897_d.JPG,0,test,40552,lativitta,40552_CAM041897_d.JPG,major
+CAM017302,https://zenodo.org/record/3082688/files/CAM017302_d.JPG,1,test,4894,notabilis x lativitta,4894_CAM017302_d.JPG,major
+CAM017136,https://zenodo.org/record/3082688/files/CAM017136_d.JPG,0,test-2,4601,malleti,4601_CAM017136_d.JPG,mimic
+CAM017427,https://zenodo.org/record/3082688/files/CAM017427_d.JPG,1,test,5091,notabilis x lativitta,5091_CAM017427_d.JPG,major
+19N1932,https://zenodo.org/record/4288311/files/19N1932_d.JPG,0,test-2,21251,malleti,21251_19N1932_d.JPG,mimic
+CAM041906,https://zenodo.org/record/4291095/files/CAM041906_d.JPG,0,test,40588,lativitta,40588_CAM041906_d.JPG,major
+CAM016232,https://zenodo.org/record/4153502/files/CAM016232_D.JPG,1,test,19086,notabilis x lativitta,19086_CAM016232_D.JPG,major
+CAM016699,https://zenodo.org/record/4153502/files/CAM016699_d.JPG,0,test-2,18942,plesseni,18942_CAM016699_d.JPG,mimic
+CAM041801,https://zenodo.org/record/4291095/files/CAM041801_d.JPG,0,test,40171,lativitta,40171_CAM041801_d.JPG,major
+CAM045058,https://zenodo.org/record/5526257/files/CAM045058_d.JPG,0,test,42797,cyrbia,42797_CAM045058_d.JPG,minor
+CAM120448,https://zenodo.org/record/2813153/files/CAM120448_d.JPG,0,test-2,14885,malleti,14885_CAM120448_d.JPG,mimic
+F837,https://zenodo.org/record/2555086/files/F837_d.JPG,0,test,38060,demophoon,38060_F837_d.JPG,minor
+CAM016907,https://zenodo.org/record/4153502/files/CAM016907_d.JPG,0,test-2,18978,plesseni,18978_CAM016907_d.JPG,mimic
+CAM016404,https://zenodo.org/record/3082688/files/CAM016404_d.JPG,0,test-2,3519,plesseni,3519_CAM016404_d.JPG,mimic
+CAM017344,https://zenodo.org/record/3082688/files/CAM017344_d.JPG,1,test,4966,notabilis x lativitta,4966_CAM017344_d.JPG,major
+CAM011443,https://zenodo.org/record/2550097/files/CAM011443_d.JPG,0,test-2,28264,plesseni,28264_CAM011443_d.JPG,mimic
+CAM016640,https://zenodo.org/record/4153502/files/CAM016640_d.JPG,1,test,18906,notabilis x lativitta,18906_CAM016640_d.JPG,major
+19N2079,https://zenodo.org/record/4288311/files/19N2079_d.JPG,0,test-2,21571,malleti,21571_19N2079_d.JPG,mimic
+CAM041753,https://zenodo.org/record/4291095/files/CAM041753_d.JPG,0,test,39979,lativitta,39979_CAM041753_d.JPG,major
+CAM016955,https://zenodo.org/record/3082688/files/CAM016955_d.JPG,0,test-2,4287,malleti,4287_CAM016955_d.JPG,mimic
+19N0279,https://zenodo.org/record/4288311/files/19N0279_d.JPG,0,test-2,19704,malleti,19704_19N0279_d.JPG,mimic
+CAM016642,https://zenodo.org/record/4153502/files/CAM016642_d.JPG,1,test,18908,notabilis x lativitta,18908_CAM016642_d.JPG,major
+CAM009191,https://zenodo.org/record/2686762/files/CAM009191_d.JPG,0,test-2,10351,plesseni,10351_CAM009191_d.JPG,mimic
+CAM045064,https://zenodo.org/record/5526257/files/CAM045064_d.JPG,0,test,42821,cyrbia,42821_CAM045064_d.JPG,minor
+CAM016094,https://zenodo.org/record/3082688/files/CAM016094_d.JPG,1,test,3096,notabilis x lativitta,3096_CAM016094_d.JPG,major
+CAM017022,https://zenodo.org/record/3082688/files/CAM017022_d.JPG,1,test,4399,notabilis x lativitta,4399_CAM017022_d.JPG,major
+CAM017030,https://zenodo.org/record/3082688/files/CAM017030_d.JPG,0,test-2,4415,malleti,4415_CAM017030_d.JPG,mimic
+CAM008867,https://zenodo.org/record/2686762/files/CAM008867_d.JPG,0,test,9955,hydara,9955_CAM008867_d.JPG,minor
+CAM041217,https://zenodo.org/record/2714333/files/CAM041217_d.JPG,0,test-2,14071,malleti,14071_CAM041217_d.JPG,mimic
+CAM041896,https://zenodo.org/record/4291095/files/CAM041896_d.JPG,0,test,40548,lativitta,40548_CAM041896_d.JPG,major
+CAM008161,https://zenodo.org/record/2684906/files/CAM008161_d.JPG,0,test-2,8768,malleti,8768_CAM008161_d.JPG,mimic
+CAM045134,https://zenodo.org/record/5526257/files/CAM045134_d.JPG,0,test,43103,cyrbia,43103_CAM045134_d.JPG,minor
+19N0658,https://zenodo.org/record/4288311/files/19N0658_d.JPG,0,test-2,19946,malleti,19946_19N0658_d.JPG,mimic
+CAM017034,https://zenodo.org/record/3082688/files/CAM017034_d.JPG,1,test,4423,notabilis x lativitta,4423_CAM017034_d.JPG,major
+CAM041851,https://zenodo.org/record/4291095/files/CAM041851_d.JPG,0,test,40371,lativitta,40371_CAM041851_d.JPG,major
+CAM016457,https://zenodo.org/record/4153502/files/CAM016457_d.JPG,1,test,18882,notabilis x lativitta,18882_CAM016457_d.JPG,major
+CAM017237,https://zenodo.org/record/3082688/files/CAM017237_d.JPG,0,test,4791,notabilis,4791_CAM017237_d.JPG,major
+CAM016547,https://zenodo.org/record/3082688/files/CAM016547_d.JPG,0,test-2,3703,malleti,3703_CAM016547_d.JPG,mimic
+CAM017363,https://zenodo.org/record/4153502/files/CAM017363_d.JPG,0,test-2,19022,plesseni,19022_CAM017363_d.JPG,mimic
+CAM040078,https://zenodo.org/record/2707828/files/CAM040078_d.JPG,0,test,11820,dignus,11820_CAM040078_d.JPG,minor
+CAM016086,https://zenodo.org/record/3082688/files/CAM016086_d.JPG,1,test-2,3080,plesseni x malleti,3080_CAM016086_d.JPG,mimic
+19N1762,https://zenodo.org/record/4288311/files/19N1762_d.JPG,0,test-2,20975,malleti,20975_19N1762_d.JPG,mimic
+CAM009320,https://zenodo.org/record/2686762/files/CAM009320_d.JPG,0,test,10492,hydara,10492_CAM009320_d.JPG,minor
+CAM017420,https://zenodo.org/record/3082688/files/CAM017420_d.JPG,1,test,5077,notabilis x lativitta,5077_CAM017420_d.JPG,major
+CAM017421,https://zenodo.org/record/3082688/files/CAM017421_d.JPG,1,test,5079,notabilis x lativitta,5079_CAM017421_d.JPG,major
+CAM041746,https://zenodo.org/record/4291095/files/CAM041746_d.JPG,0,test,39951,lativitta,39951_CAM041746_d.JPG,major
+CAM016512,https://zenodo.org/record/3082688/files/CAM016512_d.JPG,1,test,3657,notabilis x lativitta,3657_CAM016512_d.JPG,major
+CAM017441,https://zenodo.org/record/3082688/files/CAM017441_d.JPG,1,test,5117,notabilis x lativitta,5117_CAM017441_d.JPG,major
+CAM045040,https://zenodo.org/record/5526257/files/CAM045040_d.JPG,0,test,42725,cyrbia,42725_CAM045040_d.JPG,minor
+CAM041598,https://zenodo.org/record/4291095/files/CAM041598_d.JPG,0,test,39359,lativitta,39359_CAM041598_d.JPG,major
+19N2283,https://zenodo.org/record/4288311/files/19N2283_d.JPG,0,test-2,22059,malleti,22059_19N2283_d.JPG,mimic
+CAM045139,https://zenodo.org/record/5526257/files/CAM045139_d.JPG,0,test,43123,cyrbia,43123_CAM045139_d.JPG,minor
+CAM016196,https://zenodo.org/record/3082688/files/CAM016196_d.JPG,1,test-2,3300,plesseni x malleti,3300_CAM016196_d.JPG,mimic
+CAM041633,https://zenodo.org/record/4291095/files/CAM041633_d.JPG,0,test,39499,lativitta,39499_CAM041633_d.JPG,major
+CAM017223,https://zenodo.org/record/3082688/files/CAM017223_d.JPG,0,test,4763,notabilis,4763_CAM017223_d.JPG,major
+CAM016163,https://zenodo.org/record/3082688/files/CAM016163_d.JPG,1,test,3234,notabilis x lativitta,3234_CAM016163_d.JPG,major
+CS002311,https://zenodo.org/record/2553501/files/CS2311 dorsal.jpeg,0,test-2,25701,malleti,25701_CS2311 dorsal.jpeg,mimic
+CAM045138,https://zenodo.org/record/5526257/files/CAM045138_d.JPG,0,test,43119,cyrbia,43119_CAM045138_d.JPG,minor
+19N2115,https://zenodo.org/record/4288311/files/19N2115_d.JPG,0,test-2,21611,malleti,21611_19N2115_d.JPG,mimic
+19N1158,https://zenodo.org/record/4288311/files/19N1158_d.JPG,0,test-2,20204,malleti,20204_19N1158_d.JPG,mimic
+CAM041223,https://zenodo.org/record/2714333/files/CAM041223_d.JPG,0,test-2,14083,malleti,14083_CAM041223_d.JPG,mimic
+CAM041177,https://zenodo.org/record/2714333/files/CAM041177_d.JPG,0,test-2,13991,malleti,13991_CAM041177_d.JPG,mimic
+CAM016707,https://zenodo.org/record/4153502/files/CAM016707_d.JPG,0,test,18956,notabilis,18956_CAM016707_d.JPG,major
+CAM045210,https://zenodo.org/record/5526257/files/CAM045210_d.JPG,0,test,43403,cyrbia,43403_CAM045210_d.JPG,minor
+CAM016280,https://zenodo.org/record/3082688/files/CAM016280_d.JPG,0,test-2,3394,plesseni,3394_CAM016280_d.JPG,mimic
+CAM017456,https://zenodo.org/record/3082688/files/CAM017456_d.JPG,1,test-2,5140,malleti x plesseni,5140_CAM017456_d.JPG,mimic
+CAM016192,https://zenodo.org/record/3082688/files/CAM016192_d.JPG,1,test,3292,notabilis x lativitta,3292_CAM016192_d.JPG,major
+19N2068,https://zenodo.org/record/4288311/files/19N2068_d.JPG,0,test-2,21547,malleti,21547_19N2068_d.JPG,mimic
+19N0700,https://zenodo.org/record/4288311/files/19N0700_d.JPG,0,test-2,19996,malleti,19996_19N0700_d.JPG,mimic
+CAM045263,https://zenodo.org/record/5526257/files/CAM045263_d.JPG,0,test,43615,cyrbia,43615_CAM045263_d.JPG,minor
+CAM016546,https://zenodo.org/record/3082688/files/CAM016546_d.JPG,0,test-2,3701,malleti,3701_CAM016546_d.JPG,mimic
+CAM016132,https://zenodo.org/record/3082688/files/CAM016132_d.JPG,1,test-2,3172,plesseni x malleti,3172_CAM016132_d.JPG,mimic
+19N1771,https://zenodo.org/record/4288311/files/19N1771_d.JPG,0,test-2,20999,malleti,20999_19N1771_d.JPG,mimic
+CAM016410,https://zenodo.org/record/3082688/files/CAM016410_d.JPG,1,test,3531,notabilis x lativitta,3531_CAM016410_d.JPG,major
+CAM018447,https://zenodo.org/record/2548678/files/CAM018447_v_whitestandard.JPG,0,test-2,18201,plesseni,18201_CAM018447_v_whitestandard.JPG,mimic
+CAM016859,https://zenodo.org/record/3082688/files/CAM016859_d.JPG,1,test-2,4137,plesseni x malleti,4137_CAM016859_d.JPG,mimic
+CAM016157,https://zenodo.org/record/3082688/files/CAM016157_d.JPG,1,test,3222,notabilis x lativitta,3222_CAM016157_d.JPG,major
+CAM041672,https://zenodo.org/record/4291095/files/CAM041672_d.JPG,0,test,39655,lativitta,39655_CAM041672_d.JPG,major
+CAM018528,https://zenodo.org/record/2548678/files/CAM018528_v_whitestandard.JPG,0,test-2,18525,malleti,18525_CAM018528_v_whitestandard.JPG,mimic
+19N0162,https://zenodo.org/record/4288311/files/19N0162_d.JPG,0,test-2,19469,malleti,19469_19N0162_d.JPG,mimic
+CAM041740,https://zenodo.org/record/4291095/files/CAM041740_d.JPG,0,test,39927,lativitta,39927_CAM041740_d.JPG,major
+CAM041864,https://zenodo.org/record/4291095/files/CAM041864_d.JPG,0,test,40420,lativitta,40420_CAM041864_d.JPG,major
+CAM016099,https://zenodo.org/record/3082688/files/CAM016099_d.JPG,1,test,3106,notabilis x lativitta,3106_CAM016099_d.JPG,major
+19N0261,https://zenodo.org/record/4288311/files/19N0261_d.JPG,0,test-2,19667,malleti,19667_19N0261_d.JPG,mimic
+CAM016460,https://zenodo.org/record/4153502/files/CAM016460_d.JPG,1,test,18884,notabilis x lativitta,18884_CAM016460_d.JPG,major
+CAM008163,https://zenodo.org/record/2684906/files/CAM008163_d.JPG,0,test-2,8772,malleti,8772_CAM008163_d.JPG,mimic
+CAM009551,https://zenodo.org/record/2686762/files/CAM009551_d.JPG,1,test,10844,hydara x petiverana,10844_CAM009551_d.JPG,minor
+CAM016105,https://zenodo.org/record/3082688/files/CAM016105_d.JPG,1,test,3118,notabilis x lativitta,3118_CAM016105_d.JPG,major
+CAM040245,https://zenodo.org/record/2707828/files/CAM040245_d.JPG,0,test-2,12106,malleti,12106_CAM040245_d.JPG,mimic
+CAM016522,https://zenodo.org/record/3082688/files/CAM016522_d.JPG,1,test,3675,notabilis x lativitta,3675_CAM016522_d.JPG,major
+CAM016551,https://zenodo.org/record/3082688/files/CAM016551_d.JPG,0,test-2,3711,malleti,3711_CAM016551_d.JPG,mimic
+CAM040172,https://zenodo.org/record/2707828/files/CAM040172_d.JPG,0,test-2,11974,malleti,11974_CAM040172_d.JPG,mimic
+CAM017133,https://zenodo.org/record/3082688/files/CAM017133_d.JPG,1,test,4595,notabilis x lativitta,4595_CAM017133_d.JPG,major
+CAM017835,https://zenodo.org/record/3082688/files/CAM017835_d.JPG,1,test-2,5615,plesseni x malleti,5615_CAM017835_d.JPG,mimic
+15N120,https://zenodo.org/record/4289223/files/15N120_d.JPG,0,test,15174,venus,15174_15N120_d.JPG,minor
+CAM016113,https://zenodo.org/record/3082688/files/CAM016113_d.JPG,0,test-2,3134,plesseni,3134_CAM016113_d.JPG,mimic
+CAM041695,https://zenodo.org/record/4291095/files/CAM041695_d.JPG,0,test,39747,lativitta,39747_CAM041695_d.JPG,major
+CAM045145,https://zenodo.org/record/5526257/files/CAM045145_d.JPG,0,test,43147,cyrbia,43147_CAM045145_d.JPG,minor
+CAM017339,https://zenodo.org/record/3082688/files/CAM017339_d.JPG,1,test,4956,notabilis x lativitta,4956_CAM017339_d.JPG,major
+CAM041035,https://zenodo.org/record/2714333/files/CAM041035_d.JPG,0,test-2,13709,malleti,13709_CAM041035_d.JPG,mimic
+CAM018466,https://zenodo.org/record/2702457/files/CAM018466_d.JPG,1,test-2,11274,plesseni x malleti,11274_CAM018466_d.JPG,mimic
+19N0137,https://zenodo.org/record/4288311/files/19N0137_d.JPG,0,test-2,19419,malleti,19419_19N0137_d.JPG,mimic
+CAM041221,https://zenodo.org/record/2714333/files/CAM041221_d.JPG,0,test-2,14079,malleti,14079_CAM041221_d.JPG,mimic
+19N0712,https://zenodo.org/record/4288311/files/19N0712_d.JPG,0,test-2,20002,malleti,20002_19N0712_d.JPG,mimic
+CAM041621,https://zenodo.org/record/4291095/files/CAM041621_d.JPG,0,test,39451,lativitta,39451_CAM041621_d.JPG,major
+CAM036229,https://zenodo.org/record/5561246/files/CAM036229_d.JPG,0,test,41627,phyllis,41627_CAM036229_d.JPG,minor
+CAM017244,https://zenodo.org/record/3082688/files/CAM017244_d.JPG,0,test,4805,notabilis,4805_CAM017244_d.JPG,major
+CAM016121,https://zenodo.org/record/3082688/files/CAM016121_d.JPG,1,test,3150,notabilis x lativitta,3150_CAM016121_d.JPG,major
+CAM041911,https://zenodo.org/record/4291095/files/CAM041911_d.JPG,0,test,40608,lativitta,40608_CAM041911_d.JPG,major
+19N0897,https://zenodo.org/record/4288311/files/19N0897_d.JPG,0,test-2,20090,malleti,20090_19N0897_d.JPG,mimic
+CAM017602,https://zenodo.org/record/3082688/files/CAM017602_d.JPG,1,test,5366,notabilis x lativitta,5366_CAM017602_d.JPG,major
+CAM016187,https://zenodo.org/record/3082688/files/CAM016187_d.JPG,1,test,3282,notabilis x lativitta,3282_CAM016187_d.JPG,major
+CAM041763,https://zenodo.org/record/4291095/files/CAM041763_d.JPG,0,test,40019,lativitta,40019_CAM041763_d.JPG,major
+CAM016374,https://zenodo.org/record/3082688/files/CAM016374_d.JPG,0,test-2,3462,plesseni,3462_CAM016374_d.JPG,mimic
+CAM041774,https://zenodo.org/record/4291095/files/CAM041774_d.JPG,0,test,40063,lativitta,40063_CAM041774_d.JPG,major
+CAM041823,https://zenodo.org/record/4291095/files/CAM041823_d.JPG,0,test,40259,lativitta,40259_CAM041823_d.JPG,major
+CAM017442,https://zenodo.org/record/3082688/files/CAM017442_d.JPG,1,test,5119,notabilis x lativitta,5119_CAM017442_d.JPG,major
+CAM041739,https://zenodo.org/record/4291095/files/CAM041739_d.JPG,0,test,39923,lativitta,39923_CAM041739_d.JPG,major
+CAM041053,https://zenodo.org/record/2714333/files/CAM041053_d.JPG,0,test-2,13745,malleti,13745_CAM041053_d.JPG,mimic
+CAM045161,https://zenodo.org/record/5526257/files/CAM045161_d.JPG,0,test,43209,cyrbia,43209_CAM045161_d.JPG,minor
+CAM016126,https://zenodo.org/record/3082688/files/CAM016126_d.JPG,1,test-2,3160,plesseni x malleti,3160_CAM016126_d.JPG,mimic
+CAM041690,https://zenodo.org/record/4291095/files/CAM041690_d.JPG,0,test,39727,lativitta,39727_CAM041690_d.JPG,major
+CAM016324,https://zenodo.org/record/3082688/files/CAM016324_d.JPG,0,test-2,3422,plesseni,3422_CAM016324_d.JPG,mimic
+CAM041650,https://zenodo.org/record/4291095/files/CAM041650_d.JPG,0,test,39567,lativitta,39567_CAM041650_d.JPG,major
+CAM017232,https://zenodo.org/record/3082688/files/CAM017232_d.JPG,1,test-2,4781,plesseni x malleti,4781_CAM017232_d.JPG,mimic
+CAM017259,https://zenodo.org/record/3082688/files/CAM017259_d.JPG,0,test,4830,notabilis,4830_CAM017259_d.JPG,major
+CAM045250,https://zenodo.org/record/5526257/files/CAM045250_d.JPG,0,test,43563,cyrbia,43563_CAM045250_d.JPG,minor
+19N0956,https://zenodo.org/record/4288311/files/19N0956_d.JPG,0,test-2,20124,malleti,20124_19N0956_d.JPG,mimic
+CAM016557,https://zenodo.org/record/3082688/files/CAM016557_d.JPG,1,test,3719,notabilis x lativitta,3719_CAM016557_d.JPG,major
+CAM017156,https://zenodo.org/record/3082688/files/CAM017156_d.JPG,0,test-2,4637,malleti,4637_CAM017156_d.JPG,mimic
+CAM016236,https://zenodo.org/record/4153502/files/CAM016236_D.JPG,1,test,19090,notabilis x lativitta,19090_CAM016236_D.JPG,major
+CAM041060,https://zenodo.org/record/2714333/files/CAM041060_d.JPG,0,test-2,13759,malleti,13759_CAM041060_d.JPG,mimic
+CAM041871,https://zenodo.org/record/4291095/files/CAM041871_d.JPG,0,test,40448,lativitta,40448_CAM041871_d.JPG,major
+CAM041872,https://zenodo.org/record/4291095/files/CAM041872_d.JPG,0,test,40452,lativitta,40452_CAM041872_d.JPG,major
+CAM041620,https://zenodo.org/record/4291095/files/CAM041620_d.JPG,0,test,39447,lativitta,39447_CAM041620_d.JPG,major
+CAM041863,https://zenodo.org/record/4291095/files/CAM041863_d.JPG,0,test,40416,lativitta,40416_CAM041863_d.JPG,major
+CAM016087,https://zenodo.org/record/3082688/files/CAM016087_d.JPG,1,test-2,3082,plesseni x malleti,3082_CAM016087_d.JPG,mimic
+CAM016322,https://zenodo.org/record/4153502/files/CAM016322_d.JPG,0,test,18870,notabilis,18870_CAM016322_d.JPG,major
+CAM016378,https://zenodo.org/record/3082688/files/CAM016378_d.JPG,0,test-2,3470,plesseni,3470_CAM016378_d.JPG,mimic
+CAM017239,https://zenodo.org/record/3082688/files/CAM017239_d.JPG,0,test,4795,notabilis,4795_CAM017239_d.JPG,major
+CAM016978,https://zenodo.org/record/3082688/files/CAM016978_d.JPG,1,test,4326,notabilis x lativitta,4326_CAM016978_d.JPG,major
+CAM041772,https://zenodo.org/record/4291095/files/CAM041772_d.JPG,0,test,40055,lativitta,40055_CAM041772_d.JPG,major
+CAM017057,https://zenodo.org/record/3082688/files/CAM017057_d.JPG,1,test,4463,notabilis x lativitta,4463_CAM017057_d.JPG,major
+CAM041891,https://zenodo.org/record/4291095/files/CAM041891_d.JPG,0,test,40528,lativitta,40528_CAM041891_d.JPG,major
+CAM016507,https://zenodo.org/record/3082688/files/CAM016507_d.JPG,1,test,3647,notabilis x lativitta,3647_CAM016507_d.JPG,major
+CAM045211,https://zenodo.org/record/5526257/files/CAM045211_d.JPG,0,test,43407,cyrbia,43407_CAM045211_d.JPG,minor
+CAM017222,https://zenodo.org/record/3082688/files/CAM017222_d.JPG,1,test,4761,notabilis x lativitta,4761_CAM017222_d.JPG,major
+CAM045200,https://zenodo.org/record/5526257/files/CAM045200_d.JPG,0,test,43365,cyrbia,43365_CAM045200_d.JPG,minor
+CAM009546,https://zenodo.org/record/2686762/files/CAM009546_d.JPG,1,test,10834,hydara x petiverana,10834_CAM009546_d.JPG,minor
+CAM045137,https://zenodo.org/record/5526257/files/CAM045137_d.JPG,0,test,43115,cyrbia,43115_CAM045137_d.JPG,minor
+CAM041479,https://zenodo.org/record/4291095/files/CAM041479_d.JPG,0,test,38888,lativitta,38888_CAM041479_d.JPG,major
+CAM041599,https://zenodo.org/record/4291095/files/CAM041599_d.JPG,0,test,39363,lativitta,39363_CAM041599_d.JPG,major
+CAM017412,https://zenodo.org/record/3082688/files/CAM017412_d.JPG,0,test-2,5061,malleti,5061_CAM017412_d.JPG,mimic
+CAM041809,https://zenodo.org/record/4291095/files/CAM041809_d.JPG,0,test,40203,lativitta,40203_CAM041809_d.JPG,major
+CAM041825,https://zenodo.org/record/4291095/files/CAM041825_d.JPG,0,test,40267,lativitta,40267_CAM041825_d.JPG,major
+CAM017023,https://zenodo.org/record/3082688/files/CAM017023_d.JPG,1,test,4401,notabilis x lativitta,4401_CAM017023_d.JPG,major
+CAM041777,https://zenodo.org/record/4291095/files/CAM041777_d.JPG,0,test,40075,lativitta,40075_CAM041777_d.JPG,major
+19N2141,https://zenodo.org/record/4288311/files/19N2141_d.JPG,0,test-2,21667,malleti,21667_19N2141_d.JPG,mimic
+CAM041369,https://zenodo.org/record/4291095/files/CAM041369_d.JPG,0,test-2,38456,malleti,38456_CAM041369_d.JPG,mimic
+CAM021029,https://zenodo.org/record/2702457/files/CAM021029_d.JPG,1,test,11492,hydara x amalfreda,11492_CAM021029_d.JPG,minor
+CAM041894,https://zenodo.org/record/4291095/files/CAM041894_d.JPG,0,test,40540,lativitta,40540_CAM041894_d.JPG,major
+CAM040298,https://zenodo.org/record/2707828/files/CAM040298_d.JPG,0,test-2,12212,malleti,12212_CAM040298_d.JPG,mimic
+CAM016247,https://zenodo.org/record/3082688/files/CAM016247_d.JPG,0,test-2,3356,plesseni,3356_CAM016247_d.JPG,mimic
+CAM016118,https://zenodo.org/record/3082688/files/CAM016118_d.JPG,1,test-2,3144,plesseni x malleti,3144_CAM016118_d.JPG,mimic
+CAM040180,https://zenodo.org/record/2707828/files/CAM040180_d.JPG,0,test-2,11990,malleti,11990_CAM040180_d.JPG,mimic
+CAM016092,https://zenodo.org/record/3082688/files/CAM016092_d.JPG,1,test-2,3092,plesseni x malleti,3092_CAM016092_d.JPG,mimic
+19N2230,https://zenodo.org/record/4288311/files/19N2230_d.JPG,0,test-2,21847,malleti,21847_19N2230_d.JPG,mimic
+CAM041767,https://zenodo.org/record/4291095/files/CAM041767_d.JPG,0,test,40035,lativitta,40035_CAM041767_d.JPG,major
+CAM017214,https://zenodo.org/record/3082688/files/CAM017214_d.JPG,0,test,4745,notabilis,4745_CAM017214_d.JPG,major
+CAM009003,https://zenodo.org/record/2686762/files/CAM009003_d.JPG,0,test,10111,hydara,10111_CAM009003_d.JPG,minor
+CAM041813,https://zenodo.org/record/4291095/files/CAM041813_d.JPG,0,test,40219,lativitta,40219_CAM041813_d.JPG,major
+CS003709,https://zenodo.org/record/2553501/files/CS3709 dorsal.jpeg,0,test-2,25965,malleti,25965_CS3709 dorsal.jpeg,mimic
+CAM045146,https://zenodo.org/record/5526257/files/CAM045146_d.JPG,0,test,43151,cyrbia,43151_CAM045146_d.JPG,minor
+CAM017384,https://zenodo.org/record/3082688/files/CAM017384_d.JPG,1,test-2,5018,plesseni x malleti,5018_CAM017384_d.JPG,mimic
+19N0246,https://zenodo.org/record/4288311/files/19N0246_d.JPG,0,test-2,19637,malleti,19637_19N0246_d.JPG,mimic
+CAM017333,https://zenodo.org/record/3082688/files/CAM017333_d.JPG,1,test,4944,notabilis x lativitta,4944_CAM017333_d.JPG,major
+19N1236,https://zenodo.org/record/4288311/files/19N1236_d.JPG,0,test-2,20245,malleti,20245_19N1236_d.JPG,mimic
+19N0034,https://zenodo.org/record/4288311/files/19N0034_d.JPG,0,test-2,19208,malleti,19208_19N0034_d.JPG,mimic
+CAM017055,https://zenodo.org/record/3082688/files/CAM017055_d.JPG,1,test,4459,notabilis x lativitta,4459_CAM017055_d.JPG,major
+CAM045248,https://zenodo.org/record/5526257/files/CAM045248_d.JPG,0,test,43555,cyrbia,43555_CAM045248_d.JPG,minor
+CAM016040,https://zenodo.org/record/3082688/files/CAM016040_d.JPG,1,test,2989,notabilis x lativitta,2989_CAM016040_d.JPG,major
+CAM017350,https://zenodo.org/record/3082688/files/CAM017350_d.JPG,1,test,4978,notabilis x lativitta,4978_CAM017350_d.JPG,major
+CAM017226,https://zenodo.org/record/3082688/files/CAM017226_d.JPG,1,test,4769,notabilis x lativitta,4769_CAM017226_d.JPG,major
+CS003542,https://zenodo.org/record/2553501/files/CS3542 dorsal.jpeg,0,test-2,25937,malleti,25937_CS3542 dorsal.jpeg,mimic
+19N1238,https://zenodo.org/record/4288311/files/19N1238_d.JPG,0,test,20249,erato,20249_19N1238_d.JPG,minor
+CAM016582,https://zenodo.org/record/3082688/files/CAM016582_d.JPG,1,test,3755,notabilis x lativitta,3755_CAM016582_d.JPG,major
+CAM009524,https://zenodo.org/record/2686762/files/CAM009524_d.JPG,0,test,10790,petiverana,10790_CAM009524_d.JPG,minor
+CAM017153,https://zenodo.org/record/3082688/files/CAM017153_d.JPG,1,test-2,4631,plesseni x malleti,4631_CAM017153_d.JPG,mimic
+CAM018309,https://zenodo.org/record/2702457/files/CAM018309_d.JPG,1,test-2,11052,plesseni x malleti,11052_CAM018309_d.JPG,mimic
+CAM016156,https://zenodo.org/record/3082688/files/CAM016156_d.JPG,1,test,3220,notabilis x lativitta,3220_CAM016156_d.JPG,major
+CAM017247,https://zenodo.org/record/3082688/files/CAM017247_d.JPG,0,test,4811,notabilis,4811_CAM017247_d.JPG,major
+CAM016846,https://zenodo.org/record/3082688/files/CAM016846_d.JPG,1,test-2,4111,plesseni x malleti,4111_CAM016846_d.JPG,mimic
+19N0867,https://zenodo.org/record/4288311/files/19N0867_d.JPG,0,test-2,20074,malleti,20074_19N0867_d.JPG,mimic
+CAM017328,https://zenodo.org/record/3082688/files/CAM017328_d.JPG,1,test,4934,notabilis x lativitta,4934_CAM017328_d.JPG,major
+19N1983,https://zenodo.org/record/4288311/files/19N1983_d.JPG,0,test-2,21347,malleti,21347_19N1983_d.JPG,mimic
+CAM041637,https://zenodo.org/record/4291095/files/CAM041637_d.JPG,0,test,39515,lativitta,39515_CAM041637_d.JPG,major
+CAM016689,https://zenodo.org/record/4153502/files/CAM016689_d.JPG,0,test-2,18922,plesseni,18922_CAM016689_d.JPG,mimic
+19N1381,https://zenodo.org/record/4288311/files/19N1381_d.JPG,0,test-2,20317,malleti,20317_19N1381_d.JPG,mimic
+CAM009156,https://zenodo.org/record/2686762/files/CAM009156_d.JPG,0,test-2,10281,plesseni,10281_CAM009156_d.JPG,mimic
+CAM009424,https://zenodo.org/record/2686762/files/CAM009424_d.JPG,0,test-2,10646,plesseni,10646_CAM009424_d.JPG,mimic
+19N0205,https://zenodo.org/record/4288311/files/19N0205_d.JPG,0,test-2,19555,malleti,19555_19N0205_d.JPG,mimic
+CAM017313,https://zenodo.org/record/4153502/files/CAM017313_d.JPG,1,test-2,19006,plesseni x malleti,19006_CAM017313_d.JPG,mimic
+CAM009126,https://zenodo.org/record/2686762/files/CAM009126_d.JPG,0,test,10221,etylus,10221_CAM009126_d.JPG,minor
+CAM041730,https://zenodo.org/record/4291095/files/CAM041730_d.JPG,0,test,39887,lativitta,39887_CAM041730_d.JPG,major
+19N2166,https://zenodo.org/record/4288311/files/19N2166_d.JPG,0,test-2,21699,malleti,21699_19N2166_d.JPG,mimic
+CAM045190,https://zenodo.org/record/5526257/files/CAM045190_d.JPG,0,test,43325,cyrbia,43325_CAM045190_d.JPG,minor
+CAM041643,https://zenodo.org/record/4291095/files/CAM041643_d.JPG,0,test,39539,lativitta,39539_CAM041643_d.JPG,major
+CAM017001,https://zenodo.org/record/3082688/files/CAM017001_d.JPG,1,test,4361,notabilis x lativitta,4361_CAM017001_d.JPG,major
+CAM041678,https://zenodo.org/record/4291095/files/CAM041678_d.JPG,0,test,39679,lativitta,39679_CAM041678_d.JPG,major
+CAM041811,https://zenodo.org/record/4291095/files/CAM041811_d.JPG,0,test,40211,lativitta,40211_CAM041811_d.JPG,major
+19N0187,https://zenodo.org/record/4288311/files/19N0187_d.JPG,0,test-2,19519,malleti,19519_19N0187_d.JPG,mimic
+CAM041833,https://zenodo.org/record/4291095/files/CAM041833_d.JPG,0,test,40299,lativitta,40299_CAM041833_d.JPG,major
+CAM016027,https://zenodo.org/record/3082688/files/CAM016027_d.JPG,1,test,2963,notabilis x lativitta,2963_CAM016027_d.JPG,major
+CAM017455,https://zenodo.org/record/1748277/files/CAM017455_d_whitestandard.JPG,0,test-2,15283,malleti,15283_CAM017455_d_whitestandard.JPG,mimic
+CAM017129,https://zenodo.org/record/3082688/files/CAM017129_d.JPG,1,test,4587,notabilis x lativitta,4587_CAM017129_d.JPG,major
+CAM041660,https://zenodo.org/record/4291095/files/CAM041660_d.JPG,0,test,39607,lativitta,39607_CAM041660_d.JPG,major
+CAM010089,https://zenodo.org/record/2549524/files/CAM010089_d.JPG,0,test-2,26347,malleti,26347_CAM010089_d.JPG,mimic
+CAM008866,https://zenodo.org/record/2686762/files/CAM008866_d.JPG,0,test,9953,hydara,9953_CAM008866_d.JPG,minor
+CAM041275,https://zenodo.org/record/2714333/files/CAM041275_d.JPG,0,test-2,14186,malleti,14186_CAM041275_d.JPG,mimic
+CAM017002,https://zenodo.org/record/3082688/files/CAM017002_d.JPG,1,test,4363,notabilis x lativitta,4363_CAM017002_d.JPG,major
+CAM016055,https://zenodo.org/record/3082688/files/CAM016055_d.JPG,1,test-2,3019,plesseni x malleti,3019_CAM016055_d.JPG,mimic
+CAM017426,https://zenodo.org/record/3082688/files/CAM017426_d.JPG,1,test,5089,notabilis x lativitta,5089_CAM017426_d.JPG,major
+CAM041458,https://zenodo.org/record/4291095/files/CAM041458_d.JPG,0,test-2,38804,malleti,38804_CAM041458_d.JPG,mimic
+CAM016517,https://zenodo.org/record/3082688/files/CAM016517_d.JPG,1,test,3667,notabilis x lativitta,3667_CAM016517_d.JPG,major
+CAM009544,https://zenodo.org/record/2686762/files/CAM009544_d.JPG,1,test,10830,hydara x petiverana,10830_CAM009544_d.JPG,minor
+CAM017148,https://zenodo.org/record/3082688/files/CAM017148_d.JPG,1,test,4621,notabilis x lativitta,4621_CAM017148_d.JPG,major
+CAM041147,https://zenodo.org/record/2714333/files/CAM041147_d.JPG,0,test-2,13931,malleti,13931_CAM041147_d.JPG,mimic
+CAM009417,https://zenodo.org/record/2686762/files/CAM009417_d.JPG,0,test-2,10632,plesseni,10632_CAM009417_d.JPG,mimic
+CAM017252,https://zenodo.org/record/3082688/files/CAM017252_d.JPG,0,test,4821,notabilis,4821_CAM017252_d.JPG,major
+CAM009237,https://zenodo.org/record/2686762/files/CAM009237_d.JPG,0,test-2,10442,plesseni,10442_CAM009237_d.JPG,mimic
+19N1861,https://zenodo.org/record/4288311/files/19N1861_d.JPG,0,test-2,21123,malleti,21123_19N1861_d.JPG,mimic
+CAM017618,https://zenodo.org/record/4153502/files/CAM017618_d.JPG,0,test-2,19062,plesseni,19062_CAM017618_d.JPG,mimic
+CAM041588,https://zenodo.org/record/4291095/files/CAM041588_d.JPG,0,test-2,39319,malleti,39319_CAM041588_d.JPG,mimic
+CAM017032,https://zenodo.org/record/3082688/files/CAM017032_d.JPG,1,test,4419,notabilis x lativitta,4419_CAM017032_d.JPG,major
+CAM040297,https://zenodo.org/record/2707828/files/CAM040297_d.JPG,0,test-2,12210,malleti,12210_CAM040297_d.JPG,mimic
+CAM036168,https://zenodo.org/record/5561246/files/CAM036168_d.JPG,0,test,41443,phyllis,41443_CAM036168_d.JPG,minor
+CAM041439,https://zenodo.org/record/4291095/files/CAM041439_d.JPG,0,test,38728,lativitta,38728_CAM041439_d.JPG,major
+CAM017311,https://zenodo.org/record/3082688/files/CAM017311_d.JPG,1,test,4908,notabilis x lativitta,4908_CAM017311_d.JPG,major
+19N1769,https://zenodo.org/record/4288311/files/19N1769_d.JPG,0,test-2,20991,malleti,20991_19N1769_d.JPG,mimic
+CAM045166,https://zenodo.org/record/5526257/files/CAM045166_d.JPG,0,test,43229,cyrbia,43229_CAM045166_d.JPG,minor
+19N0691,https://zenodo.org/record/4288311/files/19N0691_d.JPG,0,test-2,19984,malleti,19984_19N0691_d.JPG,mimic
+CAM000230,https://zenodo.org/record/2677821/files/CAM000230_d.JPG,0,test,6286,chestertonii,6286_CAM000230_d.JPG,minor
+CAM041497,https://zenodo.org/record/4291095/files/CAM041497_d.JPG,0,test-2,38960,malleti,38960_CAM041497_d.JPG,mimic
+CAM009230,https://zenodo.org/record/2686762/files/CAM009230_d.JPG,0,test-2,10428,plesseni,10428_CAM009230_d.JPG,mimic
+CAM041712,https://zenodo.org/record/4291095/files/CAM041712_d.JPG,0,test,39815,lativitta,39815_CAM041712_d.JPG,major
+19N2237,https://zenodo.org/record/4288311/files/19N2237_d.JPG,0,test-2,21875,malleti,21875_19N2237_d.JPG,mimic
+CAM009158,https://zenodo.org/record/2686762/files/CAM009158_d.JPG,0,test-2,10285,plesseni,10285_CAM009158_d.JPG,mimic
+CAM017159,https://zenodo.org/record/3082688/files/CAM017159_d.JPG,1,test,4643,notabilis x lativitta,4643_CAM017159_d.JPG,major
+19N2127,https://zenodo.org/record/4288311/files/19N2127_d.JPG,0,test-2,21647,malleti,21647_19N2127_d.JPG,mimic
+CAM016509,https://zenodo.org/record/3082688/files/CAM016509_d.JPG,1,test-2,3651,plesseni x malleti,3651_CAM016509_d.JPG,mimic
+CAM016084,https://zenodo.org/record/3082688/files/CAM016084_d.JPG,1,test-2,3076,plesseni x malleti,3076_CAM016084_d.JPG,mimic
+CAM016065,https://zenodo.org/record/3082688/files/CAM016065_d.JPG,1,test-2,3038,plesseni x malleti,3038_CAM016065_d.JPG,mimic
+CAM045195,https://zenodo.org/record/5526257/files/CAM045195_d.JPG,0,test,43345,cyrbia,43345_CAM045195_d.JPG,minor
+CAM016566,https://zenodo.org/record/3082688/files/CAM016566_d.JPG,1,test,3737,notabilis x lativitta,3737_CAM016566_d.JPG,major
+19N0123,https://zenodo.org/record/4288311/files/19N0123_d.JPG,0,test-2,19391,malleti,19391_19N0123_d.JPG,mimic
+CAM017125,https://zenodo.org/record/3082688/files/CAM017125_d.JPG,1,test-2,4579,plesseni x malleti,4579_CAM017125_d.JPG,mimic
+19N0169,https://zenodo.org/record/4288311/files/19N0169_d.JPG,0,test-2,19483,malleti,19483_19N0169_d.JPG,mimic
+CAM045021,https://zenodo.org/record/5526257/files/CAM045021_d.JPG,0,test,42649,cyrbia,42649_CAM045021_d.JPG,minor
+CAM041743,https://zenodo.org/record/4291095/files/CAM041743_d.JPG,0,test,39939,lativitta,39939_CAM041743_d.JPG,major
+CAM017092,https://zenodo.org/record/3082688/files/CAM017092_d.JPG,0,test-2,4525,malleti,4525_CAM017092_d.JPG,mimic
+15N111,https://zenodo.org/record/4289223/files/15N111_d.JPG,0,test,15169,venus,15169_15N111_d.JPG,minor
+CAM041517,https://zenodo.org/record/4291095/files/CAM041517_d.JPG,0,test-2,39040,malleti,39040_CAM041517_d.JPG,mimic
+19N0863,https://zenodo.org/record/4288311/files/19N0863_d.JPG,0,test-2,20066,malleti,20066_19N0863_d.JPG,mimic
+CAM017605,https://zenodo.org/record/3082688/files/CAM017605_d.JPG,1,test-2,5372,plesseni x malleti,5372_CAM017605_d.JPG,mimic
+CAM045020,https://zenodo.org/record/5526257/files/CAM045020_d.JPG,0,test,42645,cyrbia,42645_CAM045020_d.JPG,minor
+CAM016821,https://zenodo.org/record/3082688/files/CAM016821_d.JPG,1,test-2,4064,plesseni x malleti,4064_CAM016821_d.JPG,mimic
+CAM016190,https://zenodo.org/record/3082688/files/CAM016190_d.JPG,0,test-2,3288,malleti,3288_CAM016190_d.JPG,mimic
+CAM009234,https://zenodo.org/record/2686762/files/CAM009234_d.JPG,0,test-2,10436,plesseni,10436_CAM009234_d.JPG,mimic
+CAM016167,https://zenodo.org/record/3082688/files/CAM016167_d.JPG,1,test,3242,notabilis x lativitta,3242_CAM016167_d.JPG,major
+CAM009307,https://zenodo.org/record/2686762/files/CAM009307_d.JPG,0,test,10466,hydara,10466_CAM009307_d.JPG,minor
+CAM017174,https://zenodo.org/record/3082688/files/CAM017174_d.JPG,0,test,4669,notabilis,4669_CAM017174_d.JPG,major
+CAM045231,https://zenodo.org/record/5526257/files/CAM045231_d.JPG,0,test,43487,cyrbia,43487_CAM045231_d.JPG,minor
+CAM041862,https://zenodo.org/record/4291095/files/CAM041862_d.JPG,0,test,40412,lativitta,40412_CAM041862_d.JPG,major
+CAM041204,https://zenodo.org/record/2714333/files/CAM041204_d.JPG,0,test-2,14045,malleti,14045_CAM041204_d.JPG,mimic
+CAM041806,https://zenodo.org/record/4291095/files/CAM041806_d.JPG,0,test,40191,lativitta,40191_CAM041806_d.JPG,major
+CAM041371,https://zenodo.org/record/4291095/files/CAM041371_d.JPG,0,test-2,38464,malleti,38464_CAM041371_d.JPG,mimic
+CAM045209,https://zenodo.org/record/5526257/files/CAM045209_d.JPG,0,test,43399,cyrbia,43399_CAM045209_d.JPG,minor
+CAM120557,https://zenodo.org/record/2813153/files/CAM120557_d.JPG,0,test-2,14891,malleti,14891_CAM120557_d.JPG,mimic
+CAM016181,https://zenodo.org/record/3082688/files/CAM016181_d.JPG,1,test,3270,notabilis x lativitta,3270_CAM016181_d.JPG,major
+CS001321,https://zenodo.org/record/2553501/files/CS1321 dorsal.jpeg,0,test-2,25627,malleti,25627_CS1321 dorsal.jpeg,mimic
+CAM045148,https://zenodo.org/record/5526257/files/CAM045148_d.JPG,0,test,43159,cyrbia,43159_CAM045148_d.JPG,minor
+CAM000170,https://zenodo.org/record/2677821/files/CAM000170_d.JPG,0,test,6172,chestertonii,6172_CAM000170_d.JPG,minor
+CAM017180,https://zenodo.org/record/3082688/files/CAM017180_d.JPG,0,test,4680,notabilis,4680_CAM017180_d.JPG,major
+CAM010077,https://zenodo.org/record/2549524/files/CAM010077_d.JPG,0,test-2,26327,malleti,26327_CAM010077_d.JPG,mimic
+CAM017621,https://zenodo.org/record/4153502/files/CAM017621_d.JPG,0,test-2,19068,plesseni,19068_CAM017621_d.JPG,mimic
+CAM045270,https://zenodo.org/record/5526257/files/CAM045270_d.JPG,0,test,43643,cyrbia,43643_CAM045270_d.JPG,minor
+CAM017158,https://zenodo.org/record/3082688/files/CAM017158_d.JPG,1,test,4641,notabilis x lativitta,4641_CAM017158_d.JPG,major
+CAM017257,https://zenodo.org/record/3082688/files/CAM017257_d.JPG,1,test-2,4828,plesseni x malleti,4828_CAM017257_d.JPG,mimic
+19N1761,https://zenodo.org/record/4288311/files/19N1761_d.JPG,0,test-2,20971,malleti,20971_19N1761_d.JPG,mimic
+CAM017612,https://zenodo.org/record/3082688/files/CAM017612_d.JPG,1,test-2,5386,plesseni x malleti,5386_CAM017612_d.JPG,mimic
+19N2224,https://zenodo.org/record/4288311/files/19N2224_d.JPG,0,test-2,21823,malleti,21823_19N2224_d.JPG,mimic
+19N1888,https://zenodo.org/record/4288311/files/19N1888_d.JPG,0,test-2,21171,malleti,21171_19N1888_d.JPG,mimic
+CAM009526,https://zenodo.org/record/2686762/files/CAM009526_d.JPG,1,test,10794,hydara x petiverana,10794_CAM009526_d.JPG,minor
+CAM041605,https://zenodo.org/record/4291095/files/CAM041605_d.JPG,0,test,39387,lativitta,39387_CAM041605_d.JPG,major
+CAM016649,https://zenodo.org/record/3082688/files/CAM016649_d.JPG,1,test,3833,notabilis x lativitta,3833_CAM016649_d.JPG,major
+CAM045229,https://zenodo.org/record/5526257/files/CAM045229_d.JPG,0,test,43479,cyrbia,43479_CAM045229_d.JPG,minor
+CAM016228,https://zenodo.org/record/3082688/files/CAM016228_d.JPG,1,test-2,3340,plesseni x malleti,3340_CAM016228_d.JPG,mimic
+CAM016033,https://zenodo.org/record/3082688/files/CAM016033_d.JPG,1,test,2975,notabilis x lativitta,2975_CAM016033_d.JPG,major
+CS002274,https://zenodo.org/record/2735056/files/CS002274_d.JPG,0,test,40851,venus,40851_CS002274_d.JPG,minor
+CAM041601,https://zenodo.org/record/4291095/files/CAM041601_d.JPG,0,test,39371,lativitta,39371_CAM041601_d.JPG,major
+CAM018315,https://zenodo.org/record/2702457/files/CAM018315_d.JPG,1,test-2,11060,plesseni x malleti,11060_CAM018315_d.JPG,mimic
+CAM040295,https://zenodo.org/record/2707828/files/CAM040295_d.JPG,0,test-2,12206,malleti,12206_CAM040295_d.JPG,mimic
+CAM017188,https://zenodo.org/record/3082688/files/CAM017188_d.JPG,0,test,4696,notabilis,4696_CAM017188_d.JPG,major
+CAM036232,https://zenodo.org/record/5561246/files/CAM036232_d.JPG,0,test,41639,phyllis,41639_CAM036232_d.JPG,minor
+CAM017325,https://zenodo.org/record/4153502/files/CAM017325_d.JPG,0,test-2,19008,plesseni,19008_CAM017325_d.JPG,mimic
+19N2158,https://zenodo.org/record/4288311/files/19N2158_d.JPG,0,test-2,21687,malleti,21687_19N2158_d.JPG,mimic
+CAM017240,https://zenodo.org/record/3082688/files/CAM017240_d.JPG,0,test,4797,notabilis,4797_CAM017240_d.JPG,major
+CAM040266,https://zenodo.org/record/2707828/files/CAM040266_d.JPG,0,test-2,12148,malleti,12148_CAM040266_d.JPG,mimic
+CAM018529,https://zenodo.org/record/2702457/files/CAM018529_d.JPG,1,test-2,11389,malleti x plesseni,11389_CAM018529_d.JPG,mimic
+CAM045154,https://zenodo.org/record/5526257/files/CAM045154_d.JPG,0,test,43183,cyrbia,43183_CAM045154_d.JPG,minor
+CAM041855,https://zenodo.org/record/4291095/files/CAM041855_d.JPG,0,test,40384,lativitta,40384_CAM041855_d.JPG,major
+F868,https://zenodo.org/record/2555086/files/F868_d.JPG,0,test,38120,demophoon,38120_F868_d.JPG,minor
+CAM009189,https://zenodo.org/record/2686762/files/CAM009189_d.JPG,0,test-2,10347,plesseni,10347_CAM009189_d.JPG,mimic
+19N2249,https://zenodo.org/record/4288311/files/19N2249_d.JPG,0,test-2,21923,malleti,21923_19N2249_d.JPG,mimic
+CAM041817,https://zenodo.org/record/4291095/files/CAM041817_d.JPG,0,test,40235,lativitta,40235_CAM041817_d.JPG,major
+CAM045007,https://zenodo.org/record/5526257/files/CAM045007_d.JPG,0,test,42591,cyrbia,42591_CAM045007_d.JPG,minor
+CAM011428,https://zenodo.org/record/2550097/files/CAM011428_d.JPG,0,test-2,28212,malleti,28212_CAM011428_d.JPG,mimic
+CAM040731,https://zenodo.org/record/2714333/files/CAM040731_d.JPG,0,test-2,13093,malleti,13093_CAM040731_d.JPG,mimic
+CAM041711,https://zenodo.org/record/4291095/files/CAM041711_d.JPG,0,test,39811,lativitta,39811_CAM041711_d.JPG,major
+CAM017274,https://zenodo.org/record/3082688/files/CAM017274_d.JPG,1,test,4860,notabilis x lativitta,4860_CAM017274_d.JPG,major
+CAM017114,https://zenodo.org/record/3082688/files/CAM017114_d.JPG,1,test,4557,notabilis x lativitta,4557_CAM017114_d.JPG,major
+CAM017109,https://zenodo.org/record/3082688/files/CAM017109_d.JPG,1,test,4547,notabilis x lativitta,4547_CAM017109_d.JPG,major
+CAM016423,https://zenodo.org/record/3082688/files/CAM016423_d.JPG,1,test,3557,notabilis x lativitta,3557_CAM016423_d.JPG,major
+CAM016683,https://zenodo.org/record/4153502/files/CAM016683_d.JPG,0,test-2,18910,plesseni,18910_CAM016683_d.JPG,mimic
+CAM000233,https://zenodo.org/record/2677821/files/CAM000233_d.JPG,0,test,6292,chestertonii,6292_CAM000233_d.JPG,minor
+CAM045160,https://zenodo.org/record/5526257/files/CAM045160_d.JPG,0,test,43205,cyrbia,43205_CAM045160_d.JPG,minor
+CAM018295,https://zenodo.org/record/2702457/files/CAM018295_d.JPG,1,test-2,11032,plesseni x malleti,11032_CAM018295_d.JPG,mimic
+CAM017331,https://zenodo.org/record/3082688/files/CAM017331_d.JPG,1,test,4940,notabilis x lativitta,4940_CAM017331_d.JPG,major
+CAM016316,https://zenodo.org/record/4153502/files/CAM016316_D.JPG,1,test,19118,notabilis x lativitta,19118_CAM016316_D.JPG,major
+CAM045032,https://zenodo.org/record/5526257/files/CAM045032_d.JPG,0,test,42693,cyrbia,42693_CAM045032_d.JPG,minor
+CAM017041,https://zenodo.org/record/3082688/files/CAM017041_d.JPG,0,test-2,4435,malleti,4435_CAM017041_d.JPG,mimic
+CAM017608,https://zenodo.org/record/3082688/files/CAM017608_d.JPG,1,test,5378,notabilis x lativitta,5378_CAM017608_d.JPG,major
+CAM041360,https://zenodo.org/record/4291095/files/CAM041360_d.JPG,0,test,38420,lativitta,38420_CAM041360_d.JPG,major
+CAM041719,https://zenodo.org/record/4291095/files/CAM041719_d.JPG,0,test,39843,lativitta,39843_CAM041719_d.JPG,major
+19N2273,https://zenodo.org/record/4288311/files/19N2273_d.JPG,0,test-2,22019,malleti,22019_19N2273_d.JPG,mimic
+CAM045201,https://zenodo.org/record/5526257/files/CAM045201_d.JPG,0,test,43367,cyrbia,43367_CAM045201_d.JPG,minor
+CAM017091,https://zenodo.org/record/3082688/files/CAM017091_d.JPG,0,test-2,4523,malleti,4523_CAM017091_d.JPG,mimic
+CAM041367,https://zenodo.org/record/4291095/files/CAM041367_d.JPG,0,test-2,38448,malleti,38448_CAM041367_d.JPG,mimic
+CAM016545,https://zenodo.org/record/3082688/files/CAM016545_d.JPG,0,test-2,3699,malleti,3699_CAM016545_d.JPG,mimic
+CAM040198,https://zenodo.org/record/2707828/files/CAM040198_d.JPG,0,test-2,12022,malleti,12022_CAM040198_d.JPG,mimic
+CAM036172,https://zenodo.org/record/5561246/files/CAM036172_d.JPG,0,test,41459,phyllis,41459_CAM036172_d.JPG,minor
+CAM017365,https://zenodo.org/record/4153502/files/CAM017365_d.JPG,0,test-2,19026,plesseni,19026_CAM017365_d.JPG,mimic
+CAM017316,https://zenodo.org/record/3082688/files/CAM017316_d.JPG,1,test,4916,notabilis x lativitta,4916_CAM017316_d.JPG,major
+CAM045054,https://zenodo.org/record/5526257/files/CAM045054_d.JPG,0,test,42781,cyrbia,42781_CAM045054_d.JPG,minor
+CAM045244,https://zenodo.org/record/5526257/files/CAM045244_d.JPG,0,test,43539,cyrbia,43539_CAM045244_d.JPG,minor
+CAM000236,https://zenodo.org/record/2677821/files/CAM000236_d.JPG,0,test,6298,chestertonii,6298_CAM000236_d.JPG,minor
+CAM017319,https://zenodo.org/record/3082688/files/CAM017319_d.JPG,1,test,4922,notabilis x lativitta,4922_CAM017319_d.JPG,major
+CAM045033,https://zenodo.org/record/5526257/files/CAM045033_d.JPG,0,test,42697,cyrbia,42697_CAM045033_d.JPG,minor
+CAM017308,https://zenodo.org/record/3082688/files/CAM017308_d.JPG,1,test,4902,notabilis x lativitta,4902_CAM017308_d.JPG,major
+CAM041850,https://zenodo.org/record/4291095/files/CAM041850_d.JPG,0,test,40367,lativitta,40367_CAM041850_d.JPG,major
+CAM045011,https://zenodo.org/record/5526257/files/CAM045011_d.JPG,0,test,42609,cyrbia,42609_CAM045011_d.JPG,minor
+CAM045243,https://zenodo.org/record/5526257/files/CAM045243_d.JPG,0,test,43535,cyrbia,43535_CAM045243_d.JPG,minor
+CAM016020,https://zenodo.org/record/3082688/files/CAM016020_d.JPG,1,test,2949,notabilis x lativitta,2949_CAM016020_d.JPG,major
+F824,https://zenodo.org/record/2555086/files/F824_d.JPG,0,test,38052,demophoon,38052_F824_d.JPG,minor
+CAM016655,https://zenodo.org/record/3082688/files/CAM016655_d.JPG,1,test-2,3845,plesseni x malleti,3845_CAM016655_d.JPG,mimic
+CAM016171,https://zenodo.org/record/3082688/files/CAM016171_d.JPG,1,test,3250,notabilis x lativitta,3250_CAM016171_d.JPG,major
+CAM016022,https://zenodo.org/record/3082688/files/CAM016022_d.JPG,1,test,2953,notabilis x lativitta,2953_CAM016022_d.JPG,major
+CAM041702,https://zenodo.org/record/4291095/files/CAM041702_d.JPG,0,test,39775,lativitta,39775_CAM041702_d.JPG,major
+CAM016645,https://zenodo.org/record/3082688/files/CAM016645_d.JPG,1,test,3825,notabilis x lativitta,3825_CAM016645_d.JPG,major
+CAM016309,https://zenodo.org/record/3082688/files/CAM016309_d.JPG,1,test-2,3414,plesseni x malleti,3414_CAM016309_d.JPG,mimic
+CAM018482,https://zenodo.org/record/2702457/files/CAM018482_d.JPG,1,test-2,11305,plesseni x malleti,11305_CAM018482_d.JPG,mimic
+CAM041781,https://zenodo.org/record/4291095/files/CAM041781_d.JPG,0,test,40091,lativitta,40091_CAM041781_d.JPG,major
+CAM017748,https://zenodo.org/record/3082688/files/CAM017748_d.JPG,1,test,5506,lativitta x notabilis,5506_CAM017748_d.JPG,major
+CAM041787,https://zenodo.org/record/4291095/files/CAM041787_d.JPG,0,test,40115,lativitta,40115_CAM041787_d.JPG,major
+15N146,https://zenodo.org/record/4289223/files/15N146_d.JPG,0,test,14959,venus,14959_15N146_d.JPG,minor
+CAM021028,https://zenodo.org/record/2702457/files/CAM021028_d.JPG,1,test,11490,hydara x amalfreda,11490_CAM021028_d.JPG,minor
+CAM041890,https://zenodo.org/record/4291095/files/CAM041890_d.JPG,0,test,40524,lativitta,40524_CAM041890_d.JPG,major
+CAM041904,https://zenodo.org/record/4291095/files/CAM041904_d.JPG,0,test,40580,lativitta,40580_CAM041904_d.JPG,major
+CAM041639,https://zenodo.org/record/4291095/files/CAM041639_d.JPG,0,test,39523,lativitta,39523_CAM041639_d.JPG,major
+CAM016096,https://zenodo.org/record/3082688/files/CAM016096_d.JPG,1,test,3100,notabilis x lativitta,3100_CAM016096_d.JPG,major
+CAM017603,https://zenodo.org/record/3082688/files/CAM017603_d.JPG,1,test,5368,notabilis x lativitta,5368_CAM017603_d.JPG,major
+CAM016183,https://zenodo.org/record/3082688/files/CAM016183_d.JPG,1,test,3274,notabilis x lativitta,3274_CAM016183_d.JPG,major
+CAM045008,https://zenodo.org/record/5526257/files/CAM045008_d.JPG,0,test,42595,cyrbia,42595_CAM045008_d.JPG,minor
+19N1393,https://zenodo.org/record/4288311/files/19N1393_d.JPG,0,test-2,20331,malleti,20331_19N1393_d.JPG,mimic
+CAM016282,https://zenodo.org/record/3082688/files/CAM016282_d.JPG,0,test-2,3396,plesseni,3396_CAM016282_d.JPG,mimic
+CAM008539,https://zenodo.org/record/2684906/files/CAM008539_d.JPG,0,test-2,9432,plesseni,9432_CAM008539_d.JPG,mimic
+CAM016785,https://zenodo.org/record/3082688/files/CAM016785_d.JPG,1,test-2,3992,plesseni x malleti,3992_CAM016785_d.JPG,mimic
+19N2259,https://zenodo.org/record/4288311/files/19N2259_d.JPG,0,test-2,21963,malleti,21963_19N2259_d.JPG,mimic
+CAM045001,https://zenodo.org/record/5526257/files/CAM045001_d.JPG,0,test,42563,cyrbia,42563_CAM045001_d.JPG,minor
+CAM017713,https://zenodo.org/record/3082688/files/CAM017713_d.JPG,1,test,5466,lativitta x notabilis,5466_CAM017713_d.JPG,major
+CAM040263,https://zenodo.org/record/2707828/files/CAM040263_d.JPG,0,test-2,12142,malleti,12142_CAM040263_d.JPG,mimic
+F875,https://zenodo.org/record/2555086/files/F875_d.JPG,0,test,38136,demophoon,38136_F875_d.JPG,minor
+CAM041357,https://zenodo.org/record/4291095/files/CAM041357_d.JPG,0,test,38408,lativitta,38408_CAM041357_d.JPG,major
+CAM016849,https://zenodo.org/record/3082688/files/CAM016849_d.JPG,1,test-2,4117,plesseni x malleti,4117_CAM016849_d.JPG,mimic
+CAM016130,https://zenodo.org/record/3082688/files/CAM016130_d.JPG,1,test-2,3168,plesseni x malleti,3168_CAM016130_d.JPG,mimic
+CAM017104,https://zenodo.org/record/3082688/files/CAM017104_d.JPG,0,test-2,4545,malleti,4545_CAM017104_d.JPG,mimic
+CAM016672,https://zenodo.org/record/3082688/files/CAM016672_d.JPG,1,test-2,3878,plesseni x malleti,3878_CAM016672_d.JPG,mimic
+CAM041769,https://zenodo.org/record/4291095/files/CAM041769_d.JPG,0,test,40043,lativitta,40043_CAM041769_d.JPG,major
+CAM016602,https://zenodo.org/record/3082688/files/CAM016602_d.JPG,1,test-2,3791,plesseni x malleti,3791_CAM016602_d.JPG,mimic
+19N1864,https://zenodo.org/record/4288311/files/19N1864_d.JPG,0,test-2,21131,malleti,21131_19N1864_d.JPG,mimic
+CAM041064,https://zenodo.org/record/2714333/files/CAM041064_d.JPG,0,test-2,13767,malleti,13767_CAM041064_d.JPG,mimic
+CAM041212,https://zenodo.org/record/2714333/files/CAM041212_d.JPG,0,test-2,14061,malleti,14061_CAM041212_d.JPG,mimic
+19N1646,https://zenodo.org/record/4288311/files/19N1646_d.JPG,0,test-2,20835,malleti,20835_19N1646_d.JPG,mimic
+19N2229,https://zenodo.org/record/4288311/files/19N2229_d.JPG,0,test-2,21843,malleti,21843_19N2229_d.JPG,mimic
+CAM045024,https://zenodo.org/record/5526257/files/CAM045024_d.JPG,0,test,42661,cyrbia,42661_CAM045024_d.JPG,minor
+CAM017248,https://zenodo.org/record/3082688/files/CAM017248_d.JPG,0,test,4813,notabilis,4813_CAM017248_d.JPG,major
+CAM045050,https://zenodo.org/record/5526257/files/CAM045050_d.JPG,0,test,42765,cyrbia,42765_CAM045050_d.JPG,minor
+CAM009568,https://zenodo.org/record/2686762/files/CAM009568_d.JPG,1,test,10878,hydara x petiverana,10878_CAM009568_d.JPG,minor
+CAM008226,https://zenodo.org/record/2684906/files/CAM008226_d.JPG,0,test-2,8895,malleti,8895_CAM008226_d.JPG,mimic
+CAM017190,https://zenodo.org/record/3082688/files/CAM017190_d.JPG,0,test,4700,notabilis,4700_CAM017190_d.JPG,major
+CAM040259,https://zenodo.org/record/2707828/files/CAM040259_d.JPG,0,test-2,12134,malleti,12134_CAM040259_d.JPG,mimic
+CAM016819,https://zenodo.org/record/3082688/files/CAM016819_d.JPG,1,test-2,4060,plesseni x malleti,4060_CAM016819_d.JPG,mimic
+CAM009300,https://zenodo.org/record/2686762/files/CAM009300_d.JPG,0,test,10452,hydara,10452_CAM009300_d.JPG,minor
+CAM009429,https://zenodo.org/record/2686762/files/CAM009429_d.JPG,0,test-2,10656,plesseni,10656_CAM009429_d.JPG,mimic
+CAM017235,https://zenodo.org/record/3082688/files/CAM017235_d.JPG,1,test,4787,notabilis x lativitta,4787_CAM017235_d.JPG,major
+CAM016186,https://zenodo.org/record/3082688/files/CAM016186_d.JPG,1,test,3280,notabilis x lativitta,3280_CAM016186_d.JPG,major
+CAM041682,https://zenodo.org/record/4291095/files/CAM041682_d.JPG,0,test,39695,lativitta,39695_CAM041682_d.JPG,major
+CAM016141,https://zenodo.org/record/3082688/files/CAM016141_d.JPG,1,test-2,3190,plesseni x malleti,3190_CAM016141_d.JPG,mimic
+19N1471,https://zenodo.org/record/4288311/files/19N1471_d.JPG,0,test-2,20381,malleti,20381_19N1471_d.JPG,mimic
+CAM041000,https://zenodo.org/record/2714333/files/CAM041000_d.JPG,0,test-2,13639,malleti,13639_CAM041000_d.JPG,mimic
+CAM041818,https://zenodo.org/record/4291095/files/CAM041818_d.JPG,0,test,40239,lativitta,40239_CAM041818_d.JPG,major
+CAM009304,https://zenodo.org/record/2686762/files/CAM009304_d.JPG,0,test,10460,hydara,10460_CAM009304_d.JPG,minor
+CAM041434,https://zenodo.org/record/4291095/files/CAM041434_d.JPG,0,test,38708,lativitta,38708_CAM041434_d.JPG,major
+CAM021073,https://zenodo.org/record/2702457/files/CAM021073_d.JPG,0,test,11575,erato,11575_CAM021073_d.JPG,minor
+19N1349,https://zenodo.org/record/4288311/files/19N1349_d.JPG,0,test-2,20289,malleti,20289_19N1349_d.JPG,mimic
+19N1907,https://zenodo.org/record/4288311/files/19N1907_d.JPG,0,test-2,21207,malleti,21207_19N1907_d.JPG,mimic
+CAM041732,https://zenodo.org/record/4291095/files/CAM041732_d.JPG,0,test,39895,lativitta,39895_CAM041732_d.JPG,major
+19N0068,https://zenodo.org/record/4288311/files/19N0068_d.JPG,0,test-2,19281,malleti,19281_19N0068_d.JPG,mimic
+CAM017051,https://zenodo.org/record/3082688/files/CAM017051_d.JPG,1,test,4451,notabilis x lativitta,4451_CAM017051_d.JPG,major
+CAM041359,https://zenodo.org/record/4291095/files/CAM041359_d.JPG,0,test,38416,lativitta,38416_CAM041359_d.JPG,major
+19N0076,https://zenodo.org/record/4288311/files/19N0076_d.JPG,0,test-2,19297,malleti,19297_19N0076_d.JPG,mimic
+19N0153,https://zenodo.org/record/4288311/files/19N0153_d.JPG,0,test-2,19451,malleti,19451_19N0153_d.JPG,mimic
+19N0981,https://zenodo.org/record/4288311/files/19N0981_d.JPG,0,test-2,20135,malleti,20135_19N0981_d.JPG,mimic
+CAM041093,https://zenodo.org/record/2714333/files/CAM041093_d.JPG,0,test-2,13824,malleti,13824_CAM041093_d.JPG,mimic
+CAM040269,https://zenodo.org/record/2707828/files/CAM040269_d.JPG,0,test-2,12154,malleti,12154_CAM040269_d.JPG,mimic
+CAM041880,https://zenodo.org/record/4291095/files/CAM041880_d.JPG,0,test,40484,lativitta,40484_CAM041880_d.JPG,major
+CAM000238,https://zenodo.org/record/2677821/files/CAM000238_d.JPG,0,test,6302,chestertonii,6302_CAM000238_d.JPG,minor
+CAM018268,https://zenodo.org/record/2548678/files/CAM018268_v_whitestandard.JPG,0,test-2,17501,plesseni,17501_CAM018268_v_whitestandard.JPG,mimic
+CAM016466,https://zenodo.org/record/3082688/files/CAM016466_d.JPG,1,test,3629,notabilis x lativitta,3629_CAM016466_d.JPG,major
+19N0613,https://zenodo.org/record/4288311/files/19N0613_d.JPG,0,test-2,19910,malleti,19910_19N0613_d.JPG,mimic
+CAM041831,https://zenodo.org/record/4291095/files/CAM041831_d.JPG,0,test,40291,lativitta,40291_CAM041831_d.JPG,major
+CAM017668,https://zenodo.org/record/3082688/files/CAM017668_d.JPG,1,test-2,5414,malleti x plesseni,5414_CAM017668_d.JPG,mimic
+CAM021035,https://zenodo.org/record/2702457/files/CAM021035_d.JPG,1,test,11504,hydara x amalfreda,11504_CAM021035_d.JPG,minor
+CAM017186,https://zenodo.org/record/3082688/files/CAM017186_d.JPG,0,test-2,4692,plesseni,4692_CAM017186_d.JPG,mimic
+F852,https://zenodo.org/record/2555086/files/F852_d.JPG,0,test,38084,demophoon,38084_F852_d.JPG,minor
+CAM041903,https://zenodo.org/record/4291095/files/CAM041903_d.JPG,0,test,40576,lativitta,40576_CAM041903_d.JPG,major
+F853,https://zenodo.org/record/2555086/files/F853_d.JPG,0,test,38088,demophoon,38088_F853_d.JPG,minor
+CAM041206,https://zenodo.org/record/2714333/files/CAM041206_d.JPG,0,test-2,14049,malleti,14049_CAM041206_d.JPG,mimic
+CAM017200,https://zenodo.org/record/3082688/files/CAM017200_d.JPG,0,test,4719,notabilis,4719_CAM017200_d.JPG,major
+CAM041186,https://zenodo.org/record/2714333/files/CAM041186_d.JPG,0,test-2,14009,malleti,14009_CAM041186_d.JPG,mimic
+CAM017312,https://zenodo.org/record/3082688/files/CAM017312_d.JPG,1,test,4910,notabilis x lativitta,4910_CAM017312_d.JPG,major
+CAM016143,https://zenodo.org/record/3082688/files/CAM016143_d.JPG,1,test-2,3194,plesseni x malleti,3194_CAM016143_d.JPG,mimic
+CAM040732,https://zenodo.org/record/2714333/files/CAM040732_d.JPG,0,test-2,13097,malleti,13097_CAM040732_d.JPG,mimic
+CAM016231,https://zenodo.org/record/4153502/files/CAM016231_D.JPG,1,test,19084,notabilis x lativitta,19084_CAM016231_D.JPG,major
+CAM016044,https://zenodo.org/record/3082688/files/CAM016044_d.JPG,1,test-2,2997,plesseni x malleti,2997_CAM016044_d.JPG,mimic
+CAM016221,https://zenodo.org/record/4153502/files/CAM016221_D.JPG,1,test,19080,notabilis x lativitta,19080_CAM016221_D.JPG,major
+CAM045179,https://zenodo.org/record/5526257/files/CAM045179_d.JPG,0,test,43281,cyrbia,43281_CAM045179_d.JPG,minor
+CS001815,https://zenodo.org/record/2553501/files/CS1815 dorsal.jpeg,0,test-2,25643,malleti,25643_CS1815 dorsal.jpeg,mimic
+CAM017243,https://zenodo.org/record/3082688/files/CAM017243_d.JPG,0,test,4803,notabilis,4803_CAM017243_d.JPG,major
+F844,https://zenodo.org/record/2555086/files/F844_d.JPG,0,test,38064,demophoon,38064_F844_d.JPG,minor
+CAM045067,https://zenodo.org/record/5526257/files/CAM045067_d.JPG,0,test,42833,cyrbia,42833_CAM045067_d.JPG,minor
+CAM017195,https://zenodo.org/record/3082688/files/CAM017195_d.JPG,0,test,4710,notabilis,4710_CAM017195_d.JPG,major
+CAM017095,https://zenodo.org/record/3082688/files/CAM017095_d.JPG,1,test-2,4531,plesseni x malleti,4531_CAM017095_d.JPG,mimic
+CAM017099,https://zenodo.org/record/3082688/files/CAM017099_d.JPG,0,test-2,4537,malleti,4537_CAM017099_d.JPG,mimic
+19N0174,https://zenodo.org/record/4288311/files/19N0174_d.JPG,0,test-2,19493,malleti,19493_19N0174_d.JPG,mimic
+CAM017212,https://zenodo.org/record/3082688/files/CAM017212_d.JPG,0,test,4741,notabilis,4741_CAM017212_d.JPG,major
+CAM009193,https://zenodo.org/record/2686762/files/CAM009193_d.JPG,0,test-2,10355,plesseni,10355_CAM009193_d.JPG,mimic
+CAM021034,https://zenodo.org/record/2702457/files/CAM021034_d.JPG,1,test,11502,hydara x amalfreda,11502_CAM021034_d.JPG,minor
+19N0948,https://zenodo.org/record/4288311/files/19N0948_d.JPG,0,test-2,20116,malleti,20116_19N0948_d.JPG,mimic
+19N0864,https://zenodo.org/record/4288311/files/19N0864_d.JPG,0,test-2,20068,malleti,20068_19N0864_d.JPG,mimic
+19N0114,https://zenodo.org/record/4288311/files/19N0114_d.JPG,0,test-2,19373,malleti,19373_19N0114_d.JPG,mimic
+CAM017056,https://zenodo.org/record/3082688/files/CAM017056_d.JPG,1,test,4461,notabilis x lativitta,4461_CAM017056_d.JPG,major
+CAM000148,https://zenodo.org/record/2677821/files/CAM000148_d.JPG,0,test,6128,chestertonii,6128_CAM000148_d.JPG,minor
+CAM041203,https://zenodo.org/record/2714333/files/CAM041203_d.JPG,0,test-2,14043,malleti,14043_CAM041203_d.JPG,mimic
+CAM017233,https://zenodo.org/record/3082688/files/CAM017233_d.JPG,1,test-2,4783,plesseni x malleti,4783_CAM017233_d.JPG,mimic
+CAM045140,https://zenodo.org/record/5526257/files/CAM045140_d.JPG,0,test,43127,cyrbia,43127_CAM045140_d.JPG,minor
+19N1194,https://zenodo.org/record/4288311/files/19N1194_d.JPG,0,test-2,20221,malleti,20221_19N1194_d.JPG,mimic
+CAM017040,https://zenodo.org/record/3082688/files/CAM017040_d.JPG,1,test-2,4433,plesseni x malleti,4433_CAM017040_d.JPG,mimic
+CAM018360,https://zenodo.org/record/2702457/files/CAM018360_d.JPG,1,test-2,11127,plesseni x malleti,11127_CAM018360_d.JPG,mimic
+CAM016769,https://zenodo.org/record/3082688/files/CAM016769_d.JPG,1,test-2,3974,plesseni x malleti,3974_CAM016769_d.JPG,mimic
+CAM016525,https://zenodo.org/record/3082688/files/CAM016525_d.JPG,1,test,3681,notabilis x lativitta,3681_CAM016525_d.JPG,major
+CAM045157,https://zenodo.org/record/5526257/files/CAM045157_d.JPG,0,test,43193,cyrbia,43193_CAM045157_d.JPG,minor
+CAM017272,https://zenodo.org/record/3082688/files/CAM017272_d.JPG,0,test-2,4856,malleti,4856_CAM017272_d.JPG,mimic
+CAM016197,https://zenodo.org/record/3082688/files/CAM016197_d.JPG,0,test-2,3302,malleti,3302_CAM016197_d.JPG,mimic
+CAM045205,https://zenodo.org/record/5526257/files/CAM045205_d.JPG,0,test,43383,cyrbia,43383_CAM045205_d.JPG,minor
+CAM002903,https://zenodo.org/record/2684906/files/CAM002903_d.JPG,1,test,8491,hydara x petiverana,8491_CAM002903_d.JPG,minor
+19N1392,https://zenodo.org/record/4288311/files/19N1392_d.JPG,0,test-2,20329,malleti,20329_19N1392_d.JPG,mimic
+CAM016406,https://zenodo.org/record/3082688/files/CAM016406_d.JPG,1,test-2,3523,plesseni x malleti,3523_CAM016406_d.JPG,mimic
+CAM016954,https://zenodo.org/record/3082688/files/CAM016954_d.JPG,0,test-2,4285,malleti,4285_CAM016954_d.JPG,mimic
+CAM021239,https://zenodo.org/record/2702457/files/CAM021239_d.JPG,0,test,11688,hydara,11688_CAM021239_d.JPG,minor
+CAM016111,https://zenodo.org/record/3082688/files/CAM016111_d.JPG,1,test-2,3130,plesseni x malleti,3130_CAM016111_d.JPG,mimic
+CAM016017,https://zenodo.org/record/3082688/files/CAM016017_d.JPG,1,test,2943,notabilis x lativitta,2943_CAM016017_d.JPG,major
+CAM009202,https://zenodo.org/record/2686762/files/CAM009202_d.JPG,0,test-2,10373,plesseni,10373_CAM009202_d.JPG,mimic
+CAM036274,https://zenodo.org/record/5561246/files/CAM036274_d.JPG,0,test,41751,phyllis,41751_CAM036274_d.JPG,minor
+CAM045159,https://zenodo.org/record/5526257/files/CAM045159_d.JPG,0,test,43201,cyrbia,43201_CAM045159_d.JPG,minor
+CAM045118,https://zenodo.org/record/5526257/files/CAM045118_d.JPG,0,test,43039,cyrbia,43039_CAM045118_d.JPG,minor
+CAM017348,https://zenodo.org/record/3082688/files/CAM017348_d.JPG,1,test,4974,notabilis x lativitta,4974_CAM017348_d.JPG,major
+19N2221,https://zenodo.org/record/4288311/files/19N2221_d.JPG,0,test-2,21811,malleti,21811_19N2221_d.JPG,mimic
+CAM018281,https://zenodo.org/record/2702457/files/CAM018281_d.JPG,1,test-2,11018,plesseni x malleti,11018_CAM018281_d.JPG,mimic
+CAM016131,https://zenodo.org/record/3082688/files/CAM016131_d.JPG,1,test-2,3170,plesseni x malleti,3170_CAM016131_d.JPG,mimic
+19N1312,https://zenodo.org/record/4288311/files/19N1312_d.JPG,0,test-2,20269,malleti,20269_19N1312_d.JPG,mimic
+19N0899,https://zenodo.org/record/4288311/files/19N0899_d.JPG,0,test-2,20094,malleti,20094_19N0899_d.JPG,mimic
+CAM041366,https://zenodo.org/record/4291095/files/CAM041366_d.JPG,0,test,38444,lativitta,38444_CAM041366_d.JPG,major
+CAM041698,https://zenodo.org/record/4291095/files/CAM041698_d.JPG,0,test,39759,lativitta,39759_CAM041698_d.JPG,major
+CAM016287,https://zenodo.org/record/3082688/files/CAM016287_d.JPG,0,test-2,3400,plesseni,3400_CAM016287_d.JPG,mimic
+19N1421,https://zenodo.org/record/4288311/files/19N1421_d.JPG,0,test-2,20351,malleti,20351_19N1421_d.JPG,mimic
+CAM008997,https://zenodo.org/record/2686762/files/CAM008997_d.JPG,0,test,10099,hydara,10099_CAM008997_d.JPG,minor
+F867,https://zenodo.org/record/2555086/files/F867_d.JPG,0,test,38116,demophoon,38116_F867_d.JPG,minor
+CAM017064,https://zenodo.org/record/3082688/files/CAM017064_d.JPG,0,test-2,4477,malleti,4477_CAM017064_d.JPG,mimic
+19N0116,https://zenodo.org/record/4288311/files/19N0116_d.JPG,0,test-2,19377,malleti,19377_19N0116_d.JPG,mimic
+CAM009205,https://zenodo.org/record/2686762/files/CAM009205_d.JPG,0,test-2,10379,plesseni,10379_CAM009205_d.JPG,mimic
+CAM045059,https://zenodo.org/record/5526257/files/CAM045059_d.JPG,0,test,42801,cyrbia,42801_CAM045059_d.JPG,minor
+CAM017754,https://zenodo.org/record/3082688/files/CAM017754_d.JPG,1,test,5514,lativitta x notabilis,5514_CAM017754_d.JPG,major
+CAM036292,https://zenodo.org/record/5561246/files/CAM036292_d.JPG,0,test,41823,phyllis,41823_CAM036292_d.JPG,minor
+CAM017447,https://zenodo.org/record/3082688/files/CAM017447_d.JPG,1,test,5128,notabilis x lativitta,5128_CAM017447_d.JPG,major
+CAM017826,https://zenodo.org/record/3082688/files/CAM017826_d.JPG,1,test,5599,lativitta x notabilis,5599_CAM017826_d.JPG,major
+CAM017338,https://zenodo.org/record/3082688/files/CAM017338_d.JPG,1,test,4954,notabilis x lativitta,4954_CAM017338_d.JPG,major
+CAM041591,https://zenodo.org/record/4291095/files/CAM041591_d.JPG,0,test,39331,lativitta,39331_CAM041591_d.JPG,major
+CAM016349,https://zenodo.org/record/3082688/files/CAM016349_d.JPG,0,test-2,3434,plesseni,3434_CAM016349_d.JPG,mimic
+CAM009200,https://zenodo.org/record/2686762/files/CAM009200_d.JPG,0,test-2,10369,plesseni,10369_CAM009200_d.JPG,mimic
+CAM016242,https://zenodo.org/record/3082688/files/CAM016242_d.JPG,1,test-2,3352,plesseni x malleti,3352_CAM016242_d.JPG,mimic
+CAM016867,https://zenodo.org/record/3082688/files/CAM016867_d.JPG,1,test-2,4153,plesseni x malleti,4153_CAM016867_d.JPG,mimic
+CAM041744,https://zenodo.org/record/4291095/files/CAM041744_d.JPG,0,test,39943,lativitta,39943_CAM041744_d.JPG,major
+CAM017142,https://zenodo.org/record/3082688/files/CAM017142_d.JPG,1,test,4609,notabilis x lativitta,4609_CAM017142_d.JPG,major
+CAM016029,https://zenodo.org/record/3082688/files/CAM016029_d.JPG,1,test,2967,notabilis x lativitta,2967_CAM016029_d.JPG,major
+CAM041867,https://zenodo.org/record/4291095/files/CAM041867_d.JPG,0,test,40432,lativitta,40432_CAM041867_d.JPG,major
+CAM016136,https://zenodo.org/record/3082688/files/CAM016136_d.JPG,1,test-2,3180,plesseni x malleti,3180_CAM016136_d.JPG,mimic
+19N0341,https://zenodo.org/record/4288311/files/19N0341_d.JPG,0,test-2,19780,malleti,19780_19N0341_d.JPG,mimic
+CAM040021,https://zenodo.org/record/2707828/files/CAM040021_d.JPG,0,test-2,11726,malleti,11726_CAM040021_d.JPG,mimic
+CAM041442,https://zenodo.org/record/4291095/files/CAM041442_d.JPG,0,test,38740,lativitta,38740_CAM041442_d.JPG,major
+CAM009199,https://zenodo.org/record/2686762/files/CAM009199_d.JPG,0,test-2,10367,plesseni,10367_CAM009199_d.JPG,mimic
+CAM041704,https://zenodo.org/record/4291095/files/CAM041704_d.JPG,0,test,39783,lativitta,39783_CAM041704_d.JPG,major
+CAM016691,https://zenodo.org/record/4153502/files/CAM016691_d.JPG,0,test-2,18926,plesseni,18926_CAM016691_d.JPG,mimic
+CAM016249,https://zenodo.org/record/3082688/files/CAM016249_d.JPG,1,test-2,3358,plesseni x malleti,3358_CAM016249_d.JPG,mimic
+CAM016079,https://zenodo.org/record/3082688/files/CAM016079_d.JPG,1,test,3066,notabilis x lativitta,3066_CAM016079_d.JPG,major
+CAM041856,https://zenodo.org/record/4291095/files/CAM041856_d.JPG,0,test,40388,lativitta,40388_CAM041856_d.JPG,major
+CS000594,https://zenodo.org/record/2553501/files/CS594 dorsal.jpeg,0,test-2,26007,malleti,26007_CS594 dorsal.jpeg,mimic
+CAM041587,https://zenodo.org/record/4291095/files/CAM041587_d.JPG,0,test-2,39315,malleti,39315_CAM041587_d.JPG,mimic
+CAM016905,https://zenodo.org/record/4153502/files/CAM016905_d.JPG,0,test-2,18974,plesseni,18974_CAM016905_d.JPG,mimic
+CAM041784,https://zenodo.org/record/4291095/files/CAM041784_d.JPG,0,test,40103,lativitta,40103_CAM041784_d.JPG,major
+CAM041013,https://zenodo.org/record/2714333/files/CAM041013_d.JPG,0,test-2,13665,malleti,13665_CAM041013_d.JPG,mimic
+CAM021053,https://zenodo.org/record/2702457/files/CAM021053_d.JPG,0,test,11538,erato,11538_CAM021053_d.JPG,minor
+CAM045227,https://zenodo.org/record/5526257/files/CAM045227_d.JPG,0,test,43471,cyrbia,43471_CAM045227_d.JPG,minor
+CAM016270,https://zenodo.org/record/3082688/files/CAM016270_d.JPG,1,test-2,3386,plesseni x malleti,3386_CAM016270_d.JPG,mimic
+CAM017246,https://zenodo.org/record/3082688/files/CAM017246_d.JPG,0,test,4809,notabilis,4809_CAM017246_d.JPG,major
+CAM017206,https://zenodo.org/record/3082688/files/CAM017206_d.JPG,1,test,4729,notabilis x lativitta,4729_CAM017206_d.JPG,major
+CAM041666,https://zenodo.org/record/4291095/files/CAM041666_d.JPG,0,test,39631,lativitta,39631_CAM041666_d.JPG,major
+CAM016009,https://zenodo.org/record/3082688/files/CAM016009_d.JPG,0,test-2,2927,plesseni,2927_CAM016009_d.JPG,mimic
+CAM017182,https://zenodo.org/record/3082688/files/CAM017182_d.JPG,0,test,4684,notabilis,4684_CAM017182_d.JPG,major
+19N1432,https://zenodo.org/record/4288311/files/19N1432_d.JPG,0,test-2,20363,malleti,20363_19N1432_d.JPG,mimic
+19N0073,https://zenodo.org/record/4288311/files/19N0073_d.JPG,0,test-2,19291,malleti,19291_19N0073_d.JPG,mimic
+19N0127,https://zenodo.org/record/4288311/files/19N0127_d.JPG,0,test-2,19399,malleti,19399_19N0127_d.JPG,mimic
+CS003541,https://zenodo.org/record/2553501/files/CS3541 dorsal.jpeg,0,test-2,25935,malleti,25935_CS3541 dorsal.jpeg,mimic
+CAM017003,https://zenodo.org/record/3082688/files/CAM017003_d.JPG,1,test,4365,notabilis x lativitta,4365_CAM017003_d.JPG,major
+19N0416,https://zenodo.org/record/4288311/files/19N0416_d.JPG,0,test-2,19811,malleti,19811_19N0416_d.JPG,mimic
+CAM040235,https://zenodo.org/record/2707828/files/CAM040235_d.JPG,0,test-2,12086,malleti,12086_CAM040235_d.JPG,mimic
+CAM009204,https://zenodo.org/record/2686762/files/CAM009204_d.JPG,0,test-2,10377,plesseni,10377_CAM009204_d.JPG,mimic
+CAM041814,https://zenodo.org/record/4291095/files/CAM041814_d.JPG,0,test,40223,lativitta,40223_CAM041814_d.JPG,major
+19N0172,https://zenodo.org/record/4288311/files/19N0172_d.JPG,0,test-2,19489,malleti,19489_19N0172_d.JPG,mimic
+CAM041456,https://zenodo.org/record/4291095/files/CAM041456_d.JPG,0,test-2,38796,malleti,38796_CAM041456_d.JPG,mimic


### PR DESCRIPTION
Adds the reference files used for the challenge (dev and final phases), which we had [internally, here](https://github.com/Imageomics/data-fwg/tree/main/HDR-anomaly-data-challenge/data). Also updates the description in the `reference_data/` README to explain the files.

Closes #53 